### PR TITLE
connect Pact logging to chainweb logger

### DIFF
--- a/chainweb.cabal
+++ b/chainweb.cabal
@@ -361,6 +361,7 @@ test-suite chainweb-tests
         , http-client >= 0.5
         , http-types >= 0.12
         , lens >= 4.16
+        , loglevel >= 0.1
         , massiv >= 0.2
         , mwc-random >= 0.13
         , neat-interpolation >= 0.3

--- a/src/Chainweb/Chainweb/ChainResources.hs
+++ b/src/Chainweb/Chainweb/ChainResources.hs
@@ -101,7 +101,8 @@ instance HasChainId (ChainResources logger) where
 -- Intializes all local Chain resources, but doesn't start any networking.
 --
 withChainResources
-    :: ChainwebVersion
+    :: Logger logger
+    => ChainwebVersion
     -> ChainId
     -> PeerResources logger
     -> (Maybe FilePath)
@@ -111,7 +112,7 @@ withChainResources
     -> IO a
 withChainResources v cid peer chainDbDir logger mempoolCfg inner =
     Mempool.withInMemoryMempool mempoolCfg $ \mempool ->
-    withPactService mempool $ \_requestQ -> do
+    withPactService (setComponent "pact" logger) mempool $ \_requestQ -> do
     withBlockHeaderDb v cid $ \cdb -> do
         chainDbDirPath <- traverse (makeAbsolute . fromFilePath) chainDbDir
         withPersistedDb cid chainDbDirPath cdb $

--- a/test/Chainweb/Test/Pact/PactInProcApi.hs
+++ b/test/Chainweb/Test/Pact/PactInProcApi.hs
@@ -15,16 +15,19 @@ import Control.Concurrent.MVar.Strict
 
 import qualified Data.Aeson as A (encode)
 import Data.String.Conv (toS)
+import qualified Data.Text.IO as T
 import Data.Vector (Vector, (!))
 import qualified Data.Vector as V
 
 import System.FilePath
+import System.LogLevel
 import System.IO.Extra
 
 import Test.Tasty
 import Test.Tasty.Golden
 
 import Chainweb.BlockHeader
+import Chainweb.Logger
 import Chainweb.Pact.Service.PactInProcApi
 import Chainweb.Pact.Types
 import Chainweb.Payload
@@ -36,9 +39,10 @@ tests = testGroup "Pact in-proc API tests" <$> pactApiTest
 
 pactApiTest :: IO [TestTree]
 pactApiTest = do
+    let logger = genericLogger Warn T.putStrLn
 
     -- Init for tests
-    withPactService' testMemPoolAccess $ \reqQ -> do
+    withPactService' logger testMemPoolAccess $ \reqQ -> do
         let headers = V.fromList $ getBlockHeaders 4
 
         -- newBlock test


### PR DESCRIPTION
Replaces `putStrLn` as Pact logging sink with the chainweb logger.