### PR TITLE
Add stack-nix-yaml

### DIFF
--- a/stack-nix.yaml
+++ b/stack-nix.yaml
@@ -1,0 +1,3 @@
+resolver: ghc-8.4.4
+system-ghc: true
+install-ghc: false


### PR DESCRIPTION
With this, stack users will be able to build with 

```
nix-shell --pure --run "stack --stack-yaml stack-nix.yaml build"
```

Which will defer to the dependencies brought into scope by `nix-shell`, allowing users to avoid global installs or the use of an LTS