### PR TITLE
Remove redundant log message

### DIFF
--- a/src/P2P/Node.hs
+++ b/src/P2P/Node.hs
@@ -395,7 +395,6 @@ newSession conf node = do
     logg node Debug $ "Selected new peer " <> encodeToText newPeer
     syncFromPeer node newPeerInfo >>= \case
         False -> do
-            logg node Warn $ "Failed to connect new peer " <> showInfo newPeerInfo
             threadDelay =<< R.randomRIO (400000, 500000)
                 -- FIXME there are better ways to prevent the node from spinning
                 -- if no suitable (non-failing node) is available.


### PR DESCRIPTION
The exact same information is already being logged in the syncFromPeer function.