### PR TITLE
[mempool] stability and telemetry fixes for mempool

### DIFF
--- a/src/Chainweb/Chainweb/ChainResources.hs
+++ b/src/Chainweb/Chainweb/ChainResources.hs
@@ -39,6 +39,7 @@ import Control.Lens hiding ((.=), (<.>))
 import Control.Monad
 import Control.Monad.Catch
 
+import Data.IORef
 import qualified Data.Text as T
 
 import Prelude hiding (log)
@@ -216,23 +217,24 @@ runMempoolSyncClient mgr chain = bracket create destroy go
     syncLogger = setComponent "mempool-sync" $ _chainResLogger chain
 
 mempoolSyncP2pSession :: ChainResources logger -> P2pSession
-mempoolSyncP2pSession chain logg0 env = go
+mempoolSyncP2pSession chain logg0 env = newIORef False >>= go
   where
-    go = flip catches [ Handler asyncHandler , Handler errorHandler ] $ do
+    go ref = flip catches [ Handler (asyncHandler ref) , Handler errorHandler ] $ do
              logg Debug "mempool sync session starting"
-             Mempool.syncMempools pool peerMempool
-             logg Debug "mempool sync session succeeded"
-             return False
+             Mempool.syncMempools' logg pool peerMempool (writeIORef ref True)
+             logg Debug "mempool sync session finished"
+             readIORef ref
 
     remote = T.pack $ Sv.showBaseUrl $ Sv.baseUrl env
     logg d m = logg0 d $ T.concat ["[mempool sync@", remote, "]:", m]
 
-    asyncHandler (_ :: SomeAsyncException) = do
+    asyncHandler ref (_ :: SomeAsyncException) = do
         logg Debug "mempool sync session cancelled"
-        return False
+        -- We return True (ok) iff the mempool successfully finished initial sync.
+        readIORef ref
 
     errorHandler (e :: SomeException) = do
-        logg Debug ("mempool sync session failed: " <> sshow e)
+        logg Warn ("mempool sync session failed: " <> sshow e)
         throwM e
 
     peerMempool = MPC.toMempool v cid txcfg gaslimit env

--- a/test/Chainweb/Test/Mempool/Sync.hs
+++ b/test/Chainweb/Test/Mempool/Sync.hs
@@ -111,7 +111,9 @@ propSync (txs, missing, later) localMempool =
                                                in (x', x'))
             when (c == 0) $ void act
 
-    syncThread remoteMempool = eatExceptions $ syncMempools localMempool remoteMempool
+    noLog = const $ const $ return ()
+    syncThread remoteMempool =
+        eatExceptions $ syncMempools noLog localMempool remoteMempool
 
     -- a thread that reads from a mempool subscription and calls a handler for
     -- each element that comes through the channel.


### PR DESCRIPTION
  - don't always return failure from mempool sync; instead return "success" iff
    mempool sync got past the initial active sync phase

  - turn off p2p timeouts for mempool

  - add additional logging to mempool sync