### PR TITLE
To Pact, Or Not To Pact

### DIFF
--- a/chainweb.cabal
+++ b/chainweb.cabal
@@ -725,9 +725,7 @@ executable ea
         , aeson-pretty >= 0.8
         , base
         , base-prelude >= 1.3
-        , bytes >= 0.15
         , bytestring >= 0.10
-        , containers >= 0.5
         , loglevel >= 0.1
         , optparse-generic >= 1.3
         , text >= 1.2

--- a/scripts/run-nodes.sh
+++ b/scripts/run-nodes.sh
@@ -42,10 +42,6 @@ N=$1 && shift
 
 LOG_DIR=$1 && shift
 
-# Disable Pact until pact integration passes all tests
-export CHAINWEB_DISABLE_PACT=${CHAINWEB_DISABLE_PACT:-0}
-[ "$CHAINWEB_DISABLE_PACT" -ne "0" ] && echo "pact is disabled"
-
 # ############################################################################ #
 # some sanity checks
 

--- a/src/Chainweb/BlockHeader/Genesis.hs
+++ b/src/Chainweb/BlockHeader/Genesis.hs
@@ -52,7 +52,7 @@ import Data.MerkleLog hiding (Actual, Expected, MerkleHash)
 import Chainweb.BlockHash
 import Chainweb.BlockHeader
 import Chainweb.BlockHeader.Genesis.Testnet00
-import Chainweb.BlockHeader.Genesis.Testnet00Payload (payloadBlock)
+import qualified Chainweb.BlockHeader.Genesis.Testnet00Payload as TN0
 import Chainweb.ChainId (ChainId, HasChainId(..), encodeChainId)
 import Chainweb.Crypto.MerkleLog
 import Chainweb.Difficulty (HashTarget, maxTarget)
@@ -99,6 +99,7 @@ genesisTime :: ChainwebVersion -> BlockCreationTime
 genesisTime Test{} = BlockCreationTime epoche
 genesisTime TestWithTime{} = BlockCreationTime epoche
 genesisTime TestWithPow{} = BlockCreationTime epoche
+genesisTime PactWithTime{} = BlockCreationTime epoche
 genesisTime Simulation{} = BlockCreationTime epoche
 -- Tuesday, 2019 February 26, 10:55 AM
 genesisTime Testnet00 = BlockCreationTime . Time $ TimeSpan 1551207336601038
@@ -107,6 +108,7 @@ genesisMiner :: HasChainId p => ChainwebVersion -> p -> ChainNodeId
 genesisMiner Test{} p = ChainNodeId (_chainId p) 0
 genesisMiner TestWithTime{} p = ChainNodeId (_chainId p) 0
 genesisMiner TestWithPow{} p = ChainNodeId (_chainId p) 0
+genesisMiner PactWithTime{} p = ChainNodeId (_chainId p) 0
 genesisMiner Simulation{} p = ChainNodeId (_chainId p) 0
 -- TODO: Base the `ChainNodeId` off a Pact public key that is significant to Kadena.
 -- In other words, 0 is a meaningless hard-coding.
@@ -121,11 +123,13 @@ genesisBlockPayloadHash v = _payloadWithOutputsPayloadHash . genesisBlockPayload
 -- in PayloadStore.
 genesisBlockPayload :: ChainwebVersion -> ChainId -> PayloadWithOutputs
 genesisBlockPayload Test{} _ = emptyPayload
-genesisBlockPayload TestWithTime{} _ = payloadBlock
+genesisBlockPayload TestWithTime{} _ = emptyPayload
 genesisBlockPayload TestWithPow{} _ = emptyPayload
+-- This requires a real Payload for Pact tests to be meaningful.
+genesisBlockPayload PactWithTime{} _ = TN0.payloadBlock
 genesisBlockPayload Simulation{} _ =
     error "genesisBlockPayload isn't yet defined for Simulation"
-genesisBlockPayload Testnet00 _ = payloadBlock
+genesisBlockPayload Testnet00 _ = TN0.payloadBlock
 
 emptyPayload :: PayloadWithOutputs
 emptyPayload = PayloadWithOutputs mempty miner coinbase h i o

--- a/src/Chainweb/BlockHeader/Genesis.hs
+++ b/src/Chainweb/BlockHeader/Genesis.hs
@@ -100,7 +100,6 @@ genesisTime Test{} = BlockCreationTime epoche
 genesisTime TestWithTime{} = BlockCreationTime epoche
 genesisTime TestWithPow{} = BlockCreationTime epoche
 genesisTime PactWithTime{} = BlockCreationTime epoche
-genesisTime Simulation{} = BlockCreationTime epoche
 -- Tuesday, 2019 February 26, 10:55 AM
 genesisTime Testnet00 = BlockCreationTime . Time $ TimeSpan 1551207336601038
 
@@ -109,7 +108,6 @@ genesisMiner Test{} p = ChainNodeId (_chainId p) 0
 genesisMiner TestWithTime{} p = ChainNodeId (_chainId p) 0
 genesisMiner TestWithPow{} p = ChainNodeId (_chainId p) 0
 genesisMiner PactWithTime{} p = ChainNodeId (_chainId p) 0
-genesisMiner Simulation{} p = ChainNodeId (_chainId p) 0
 -- TODO: Base the `ChainNodeId` off a Pact public key that is significant to Kadena.
 -- In other words, 0 is a meaningless hard-coding.
 genesisMiner Testnet00 p = ChainNodeId (_chainId p) 0
@@ -127,8 +125,6 @@ genesisBlockPayload TestWithTime{} _ = emptyPayload
 genesisBlockPayload TestWithPow{} _ = emptyPayload
 -- This requires a real Payload for Pact tests to be meaningful.
 genesisBlockPayload PactWithTime{} _ = TN0.payloadBlock
-genesisBlockPayload Simulation{} _ =
-    error "genesisBlockPayload isn't yet defined for Simulation"
 genesisBlockPayload Testnet00 _ = TN0.payloadBlock
 
 emptyPayload :: PayloadWithOutputs

--- a/src/Chainweb/Chainweb/MinerResources.hs
+++ b/src/Chainweb/Chainweb/MinerResources.hs
@@ -83,5 +83,6 @@ runMiner v m = (chooseMiner v)
     chooseMiner Test{} = testMiner
     chooseMiner TestWithTime{} = testMiner
     chooseMiner TestWithPow{} = powMiner
+    chooseMiner PactWithTime{} = testMiner
     chooseMiner Simulation{} = testMiner
     chooseMiner Testnet00 = powMiner

--- a/src/Chainweb/Chainweb/MinerResources.hs
+++ b/src/Chainweb/Chainweb/MinerResources.hs
@@ -84,5 +84,4 @@ runMiner v m = (chooseMiner v)
     chooseMiner TestWithTime{} = testMiner
     chooseMiner TestWithPow{} = powMiner
     chooseMiner PactWithTime{} = testMiner
-    chooseMiner Simulation{} = testMiner
     chooseMiner Testnet00 = powMiner

--- a/src/Chainweb/Cut.hs
+++ b/src/Chainweb/Cut.hs
@@ -74,7 +74,7 @@ module Chainweb.Cut
 
 , MineFailure(..)
 , testMine
-, testMineWithPayload
+, mineWithPayload
 , createNewCut
 , randomChainId
 , arbitraryChainGraphChainId
@@ -575,7 +575,7 @@ testMine n target t payloadHash nid i c =
     forM (createNewCut n target t payloadHash nid i c) $ \p@(T2 h _) ->
         p <$ insertWebBlockHeaderDb h
 
-testMineWithPayload
+mineWithPayload
     :: forall cas cid
     . HasChainId cid
     => PayloadCas cas
@@ -590,7 +590,7 @@ testMineWithPayload
     -> Cut
     -> PactExecutionService
     -> IO (Either MineFailure (T2 BlockHeader Cut))
-testMineWithPayload n target t payload nid i c pact =
+mineWithPayload n target t payload nid i c pact =
     forM (createNewCut n target t payloadHash nid i c) $ \p@(T2 h _) -> do
         tryValidatePayload (_chainwebVersion h) h payload
         addNewPayload (given @(PayloadDb cas)) payload
@@ -611,12 +611,13 @@ testMineWithPayload n target t payload nid i c pact =
     validatePayload h o = void $ _pactValidateBlock pact h $ toPayloadData o
 
     toPayloadData PayloadWithOutputs{..} = PayloadData
-              { _payloadDataTransactions = fst <$> _payloadWithOutputsTransactions
-              , _payloadDataMiner = _payloadWithOutputsMiner
-              , _payloadDataPayloadHash = _payloadWithOutputsPayloadHash
-              , _payloadDataTransactionsHash = _payloadWithOutputsTransactionsHash
-              , _payloadDataOutputsHash = _payloadWithOutputsOutputsHash
-              }
+        { _payloadDataTransactions = fst <$> _payloadWithOutputsTransactions
+        , _payloadDataMiner = _payloadWithOutputsMiner
+        , _payloadDataPayloadHash = _payloadWithOutputsPayloadHash
+        , _payloadDataTransactionsHash = _payloadWithOutputsTransactionsHash
+        , _payloadDataOutputsHash = _payloadWithOutputsOutputsHash
+        }
+
 -- | Create a new block. Only produces a new cut but doesn't insert it into the
 -- chain database.
 --

--- a/src/Chainweb/Difficulty.hs
+++ b/src/Chainweb/Difficulty.hs
@@ -315,7 +315,6 @@ blockRate Test{} = Nothing
 blockRate TestWithTime{} = Just $ BlockRate 4
 blockRate TestWithPow{} = Just $ BlockRate 10
 blockRate PactWithTime{} = Just $ BlockRate 4
-blockRate Simulation{} = Nothing
 -- 120 blocks per hour, 2,880 per day, 20,160 per week, 1,048,320 per year.
 blockRate Testnet00 = Just $ BlockRate 30
 
@@ -334,7 +333,6 @@ window TestWithTime{} = Nothing
 -- 5 blocks, should take 50 seconds.
 window TestWithPow{} = Just $ WindowWidth 5
 window PactWithTime{} = Nothing
-window Simulation{} = Nothing
 -- 120 blocks, should take 1 hour given a 30 second BlockRate.
 window Testnet00 = Just $ WindowWidth 120
 
@@ -352,7 +350,6 @@ maxAdjust Test{} = Nothing
 maxAdjust TestWithTime{} = Nothing
 maxAdjust TestWithPow{} = Just $ MaxAdjustment 3
 maxAdjust PactWithTime{} = Nothing
-maxAdjust Simulation{} = Nothing
 -- See `adjust` for motivation.
 maxAdjust Testnet00 = Just $ MaxAdjustment 3
 
@@ -366,7 +363,6 @@ prereduction Test{} = 0
 prereduction TestWithTime{} = 0
 prereduction TestWithPow{} = 7
 prereduction PactWithTime{} = 0
-prereduction Simulation{} = 0
 -- As alluded to in `maxTarget`, 11 bits has been shown experimentally to be
 -- high enough to keep mining slow during the initial conditions of a
 -- single-machine-10-chain-10-miner scenario, thereby avoiding (too many)

--- a/src/Chainweb/Difficulty.hs
+++ b/src/Chainweb/Difficulty.hs
@@ -314,6 +314,7 @@ blockRate :: ChainwebVersion -> Maybe BlockRate
 blockRate Test{} = Nothing
 blockRate TestWithTime{} = Just $ BlockRate 4
 blockRate TestWithPow{} = Just $ BlockRate 10
+blockRate PactWithTime{} = Just $ BlockRate 4
 blockRate Simulation{} = Nothing
 -- 120 blocks per hour, 2,880 per day, 20,160 per week, 1,048,320 per year.
 blockRate Testnet00 = Just $ BlockRate 30
@@ -332,6 +333,7 @@ window Test{} = Nothing
 window TestWithTime{} = Nothing
 -- 5 blocks, should take 50 seconds.
 window TestWithPow{} = Just $ WindowWidth 5
+window PactWithTime{} = Nothing
 window Simulation{} = Nothing
 -- 120 blocks, should take 1 hour given a 30 second BlockRate.
 window Testnet00 = Just $ WindowWidth 120
@@ -349,6 +351,7 @@ maxAdjust :: ChainwebVersion -> Maybe MaxAdjustment
 maxAdjust Test{} = Nothing
 maxAdjust TestWithTime{} = Nothing
 maxAdjust TestWithPow{} = Just $ MaxAdjustment 3
+maxAdjust PactWithTime{} = Nothing
 maxAdjust Simulation{} = Nothing
 -- See `adjust` for motivation.
 maxAdjust Testnet00 = Just $ MaxAdjustment 3
@@ -362,6 +365,7 @@ prereduction :: ChainwebVersion -> Int
 prereduction Test{} = 0
 prereduction TestWithTime{} = 0
 prereduction TestWithPow{} = 7
+prereduction PactWithTime{} = 0
 prereduction Simulation{} = 0
 -- As alluded to in `maxTarget`, 11 bits has been shown experimentally to be
 -- high enough to keep mining slow during the initial conditions of a

--- a/src/Chainweb/Miner/POW.hs
+++ b/src/Chainweb/Miner/POW.hs
@@ -19,11 +19,10 @@
 
 module Chainweb.Miner.POW ( powMiner ) where
 
-import Control.Lens (ix, (^?), (^?!), view)
+import Control.Lens (ix, view, (^?), (^?!))
 
 import qualified Data.HashMap.Strict as HM
 import Data.Reflection (Given, give)
-import qualified Data.Sequence as S
 import qualified Data.Text as T
 import Data.Tuple.Strict (T2(..), T3(..))
 
@@ -42,7 +41,6 @@ import Chainweb.CutDB
 import Chainweb.Difficulty
 import Chainweb.Miner.Config (MinerConfig(..))
 import Chainweb.NodeId (NodeId)
-import Chainweb.Payload
 import Chainweb.Payload.PayloadStore
 import Chainweb.Sync.WebBlockHeaderStore
 import Chainweb.Time (getCurrentTimeIntegral)
@@ -164,16 +162,8 @@ powMiner logFun conf nid cutDb = runForever logFun "POW Miner" $ do
 
         -- Loops (i.e. "mines") if a non-matching nonce was generated.
         --
-
-        let mokPact = False
         let pact = _webPactExecutionService $ _webBlockPayloadStorePact payloadStore
-        payload <- case mokPact of
-            False -> _pactNewBlock pact (_configMinerInfo conf) p
-            True -> return
-                $ newPayloadWithOutputs (MinerData "miner") (CoinbaseOutput "coinbase")
-                $ S.fromList
-                    [ (Transaction "testTransaction", TransactionOutput "testOutput")
-                    ]
+        payload <- _pactNewBlock pact (_configMinerInfo conf) p
 
         -- The new block's creation time.
         --

--- a/src/Chainweb/Miner/POW.hs
+++ b/src/Chainweb/Miner/POW.hs
@@ -49,7 +49,7 @@ import Chainweb.Utils
 import Chainweb.WebBlockHeaderDB
 import Chainweb.WebPactExecutionService
 
-import Data.LogMessage (LogFunction, JsonLog(..))
+import Data.LogMessage (JsonLog(..), LogFunction)
 
 -- DEBUGGING --
 -- import Chainweb.ChainId (testChainId)
@@ -169,7 +169,7 @@ powMiner logFun conf nid cutDb = runForever logFun "POW Miner" $ do
         --
         let loop n = do
                 ct <- getCurrentTimeIntegral
-                testMineWithPayload @cas nonce target ct payload nid cid c pact >>= \case
+                mineWithPayload @cas nonce target ct payload nid cid c pact >>= \case
                     Left BadNonce -> do
                         -- atomicModifyIORef' counter (\n -> (succ n, ()))
                         c' <- _cut cutDb

--- a/src/Chainweb/Miner/Test.hs
+++ b/src/Chainweb/Miner/Test.hs
@@ -206,7 +206,7 @@ testMiner logFun conf nid cutDb = runForever logFun "Test Miner" $ do
         -- POW is not used.
         --
         result <- give payloadDb $ give wcdb
-            $ testMineWithPayload @cas (Nonce nonce) target ct payload nid cid c pact
+            $ mineWithPayload @cas (Nonce nonce) target ct payload nid cid c pact
 
         case result of
             Left BadNonce -> do

--- a/src/Chainweb/Pact/PactService.hs
+++ b/src/Chainweb/Pact/PactService.hs
@@ -104,7 +104,6 @@ pactDbConfig Test{} = PactDbConfig Nothing "log-unused" [] (Just 0) (Just 0)
 pactDbConfig TestWithTime{} = PactDbConfig Nothing "log-unused" [] (Just 0) (Just 0)
 pactDbConfig TestWithPow{} = PactDbConfig Nothing "log-unused" [] (Just 0) (Just 0)
 pactDbConfig PactWithTime{} = PactDbConfig Nothing "log-unused" [] (Just 0) (Just 0)
-pactDbConfig Simulation{} = PactDbConfig Nothing "log-unused" [] (Just 0) (Just 0)
 pactDbConfig Testnet00 = PactDbConfig Nothing "log-unused" [] (Just 0) (Just 0)
 
 pactLogLevel :: String -> LogLevel
@@ -221,7 +220,6 @@ initialPayloadState Test{} _ = return ()
 initialPayloadState TestWithTime{} _ = return ()
 initialPayloadState TestWithPow{} _ = return ()
 initialPayloadState v@PactWithTime{} cid = createCoinContract v cid
-initialPayloadState Simulation{} _ = return ()
 initialPayloadState v@Testnet00 cid = createCoinContract v cid
 
 createCoinContract :: ChainwebVersion -> ChainId -> PactServiceM ()

--- a/src/Chainweb/Pact/PactService.hs
+++ b/src/Chainweb/Pact/PactService.hs
@@ -103,6 +103,7 @@ pactDbConfig :: ChainwebVersion -> PactDbConfig
 pactDbConfig Test{} = PactDbConfig Nothing "log-unused" [] (Just 0) (Just 0)
 pactDbConfig TestWithTime{} = PactDbConfig Nothing "log-unused" [] (Just 0) (Just 0)
 pactDbConfig TestWithPow{} = PactDbConfig Nothing "log-unused" [] (Just 0) (Just 0)
+pactDbConfig PactWithTime{} = PactDbConfig Nothing "log-unused" [] (Just 0) (Just 0)
 pactDbConfig Simulation{} = PactDbConfig Nothing "log-unused" [] (Just 0) (Just 0)
 pactDbConfig Testnet00 = PactDbConfig Nothing "log-unused" [] (Just 0) (Just 0)
 
@@ -217,8 +218,9 @@ pactSpvSupport mv = P.SPVSupport $ \s o -> do
 
 initialPayloadState :: ChainwebVersion -> ChainId -> PactServiceM ()
 initialPayloadState Test{} _ = return ()
-initialPayloadState v@TestWithTime{} cid = createCoinContract v cid
+initialPayloadState TestWithTime{} _ = return ()
 initialPayloadState TestWithPow{} _ = return ()
+initialPayloadState v@PactWithTime{} cid = createCoinContract v cid
 initialPayloadState Simulation{} _ = return ()
 initialPayloadState v@Testnet00 cid = createCoinContract v cid
 

--- a/src/Chainweb/Pact/PactService.hs
+++ b/src/Chainweb/Pact/PactService.hs
@@ -222,6 +222,8 @@ initialPayloadState TestWithPow{} _ = return ()
 initialPayloadState v@PactWithTime{} cid = createCoinContract v cid
 initialPayloadState v@Testnet00 cid = createCoinContract v cid
 
+-- FIXME: Actually might be incorrect. It probably shouldn't be pulling
+-- `payloadBlock` like this.
 createCoinContract :: ChainwebVersion -> ChainId -> PactServiceM ()
 createCoinContract v cid = do
     let PayloadWithOutputs{..} = payloadBlock

--- a/src/Chainweb/PowHash.hs
+++ b/src/Chainweb/PowHash.hs
@@ -140,7 +140,6 @@ powHash Test{} = cryptoHash @SHA512t_256
 powHash TestWithTime{} = cryptoHash @SHA512t_256
 powHash TestWithPow{} = cryptoHash @SHA512t_256
 powHash PactWithTime{} = cryptoHash @SHA512t_256
-powHash Simulation {}= cryptoHash @SHA512t_256
 powHash Testnet00 = cryptoHash @SHA512t_256
 
 cryptoHash :: forall a . HashAlgorithm a => B.ByteString -> PowHash

--- a/src/Chainweb/PowHash.hs
+++ b/src/Chainweb/PowHash.hs
@@ -139,6 +139,7 @@ powHash :: ChainwebVersion -> B.ByteString -> PowHash
 powHash Test{} = cryptoHash @SHA512t_256
 powHash TestWithTime{} = cryptoHash @SHA512t_256
 powHash TestWithPow{} = cryptoHash @SHA512t_256
+powHash PactWithTime{} = cryptoHash @SHA512t_256
 powHash Simulation {}= cryptoHash @SHA512t_256
 powHash Testnet00 = cryptoHash @SHA512t_256
 

--- a/src/Chainweb/RestAPI/Orphans.hs
+++ b/src/Chainweb/RestAPI/Orphans.hs
@@ -249,10 +249,10 @@ instance ToParamSchema ChainwebVersion where
     toParamSchema _ = mempty
         & type_ .~ SwaggerString
         & enum_ ?~ (toJSON <$>
-            [ Simulation petersonChainGraph
-            , Test petersonChainGraph
+            [ Test petersonChainGraph
             , TestWithTime petersonChainGraph
             , TestWithPow petersonChainGraph
+            , PactWithTime petersonChainGraph
             , Testnet00
             ])
 

--- a/src/Chainweb/Version.hs
+++ b/src/Chainweb/Version.hs
@@ -92,8 +92,9 @@ import Data.Singletons
 --
 data ChainwebVersion
     = Test ChainGraph
-        -- ^ Test instance with
+        -- ^ Test instance with:
         --
+        --   * /No/ Pact evaluation,
         --   * configurable graph,
         --   * genesis block time is epoch,
         --   * target is maxBound,
@@ -103,21 +104,34 @@ data ChainwebVersion
         --
 
     | TestWithTime ChainGraph
-        -- ^ Test instance with
+        -- ^ Test instance with:
         --
+        --   * /No/ Pact evaluation,
         --   * configurable graph,
-        --   * genesis block time current time
+        --   * genesis block time current time,
         --   * target is maxBound,
-        --   * nonce is constant
+        --   * nonce is constant,
         --   * creationTime of BlockHeaders is actual time, and
         --   * POW is simulated by poison process thread delay.
         --
 
     | TestWithPow ChainGraph
-        -- ^ Test instance with
+        -- ^ Test instance with:
         --
+        --   * /No/ Pact evaluation,
         --   * configurable graph,
-        --   * genesis block time current time
+        --   * genesis block time current time,
+        --   * target is maxBound,
+        --   * nonce is constant, and
+        --   * creationTime of BlockHeaders is actual time.
+        --
+
+    | PactWithTime ChainGraph
+        -- ^ Test instance with:
+        --
+        --   * Pact evaluation,
+        --   * configurable graph,
+        --   * genesis block time current time,
         --   * target is maxBound,
         --   * nonce is constant, and
         --   * creationTime of BlockHeaders is actual time.
@@ -125,6 +139,14 @@ data ChainwebVersion
 
     | Simulation ChainGraph
     | Testnet00
+        -- ^ Production instance with:
+        --
+        --   * Pact evaluation,
+        --   * fixed graph,
+        --   * fixed genesis block time,
+        --   * target is based on `Chainweb.Difficulty.prereduction`,
+        --   * nonce varies with hash attempts, and
+        --   * creationTime of BlockHeaders is actual time.
     deriving (Eq, Ord, Generic)
     deriving anyclass (Hashable, NFData)
 
@@ -140,7 +162,8 @@ chainwebVersionId :: ChainwebVersion -> Word32
 chainwebVersionId v@Test{} = toTestChainwebVersion v 0x80000000
 chainwebVersionId v@TestWithTime{} = toTestChainwebVersion v 0x80000001
 chainwebVersionId v@TestWithPow{} = toTestChainwebVersion v 0x80000002
-chainwebVersionId v@Simulation{} = toTestChainwebVersion v 0x80000003
+chainwebVersionId v@PactWithTime{} = toTestChainwebVersion v 0x80000003
+chainwebVersionId v@Simulation{} = toTestChainwebVersion v 0x80000004
 chainwebVersionId Testnet00 = 0x00000001
 {-# INLINABLE chainwebVersionId #-}
 
@@ -183,6 +206,7 @@ chainwebVersionToText Testnet00 = "testnet00"
 chainwebVersionToText v@Test{} = "test-" <> sshow (chainwebVersionId v)
 chainwebVersionToText v@TestWithTime{} = "testWithTime-" <> sshow (chainwebVersionId v)
 chainwebVersionToText v@TestWithPow{} = "testWithPow-" <> sshow (chainwebVersionId v)
+chainwebVersionToText v@PactWithTime{} = "pactWithTime-" <> sshow (chainwebVersionId v)
 chainwebVersionToText v@Simulation{} = "simulation-" <> sshow (chainwebVersionId v)
 {-# INLINABLE chainwebVersionToText #-}
 
@@ -286,6 +310,7 @@ chainwebVersionGraph :: ChainwebVersion -> ChainGraph
 chainwebVersionGraph (Test g) = g
 chainwebVersionGraph (TestWithTime g) = g
 chainwebVersionGraph (TestWithPow g) = g
+chainwebVersionGraph (PactWithTime g) = g
 chainwebVersionGraph (Simulation g) = g
 chainwebVersionGraph Testnet00 = petersonChainGraph
 

--- a/src/Chainweb/Version.hs
+++ b/src/Chainweb/Version.hs
@@ -137,7 +137,6 @@ data ChainwebVersion
         --   * creationTime of BlockHeaders is actual time.
         --
 
-    | Simulation ChainGraph
     | Testnet00
         -- ^ Production instance with:
         --
@@ -163,7 +162,6 @@ chainwebVersionId v@Test{} = toTestChainwebVersion v 0x80000000
 chainwebVersionId v@TestWithTime{} = toTestChainwebVersion v 0x80000001
 chainwebVersionId v@TestWithPow{} = toTestChainwebVersion v 0x80000002
 chainwebVersionId v@PactWithTime{} = toTestChainwebVersion v 0x80000003
-chainwebVersionId v@Simulation{} = toTestChainwebVersion v 0x80000004
 chainwebVersionId Testnet00 = 0x00000001
 {-# INLINABLE chainwebVersionId #-}
 
@@ -207,7 +205,6 @@ chainwebVersionToText v@Test{} = "test-" <> sshow (chainwebVersionId v)
 chainwebVersionToText v@TestWithTime{} = "testWithTime-" <> sshow (chainwebVersionId v)
 chainwebVersionToText v@TestWithPow{} = "testWithPow-" <> sshow (chainwebVersionId v)
 chainwebVersionToText v@PactWithTime{} = "pactWithTime-" <> sshow (chainwebVersionId v)
-chainwebVersionToText v@Simulation{} = "simulation-" <> sshow (chainwebVersionId v)
 {-# INLINABLE chainwebVersionToText #-}
 
 -- | Read textual representation of Chainweb Version
@@ -311,7 +308,6 @@ chainwebVersionGraph (Test g) = g
 chainwebVersionGraph (TestWithTime g) = g
 chainwebVersionGraph (TestWithPow g) = g
 chainwebVersionGraph (PactWithTime g) = g
-chainwebVersionGraph (Simulation g) = g
 chainwebVersionGraph Testnet00 = petersonChainGraph
 
 instance HasChainGraph ChainwebVersion where

--- a/src/P2P/Peer.hs
+++ b/src/P2P/Peer.hs
@@ -448,6 +448,7 @@ bootstrapPeerInfos :: ChainwebVersion -> [PeerInfo]
 bootstrapPeerInfos Test{} = [testBootstrapPeerInfos]
 bootstrapPeerInfos TestWithTime{} = [testBootstrapPeerInfos]
 bootstrapPeerInfos TestWithPow{} = [testBootstrapPeerInfos]
+bootstrapPeerInfos PactWithTime{} = [testBootstrapPeerInfos]
 bootstrapPeerInfos Simulation{} = error
     $ "bootstrap peer info isn't defined for chainweb version Simulation"
 bootstrapPeerInfos Testnet00 = testnet00BootstrapPeerInfo

--- a/src/P2P/Peer.hs
+++ b/src/P2P/Peer.hs
@@ -449,8 +449,6 @@ bootstrapPeerInfos Test{} = [testBootstrapPeerInfos]
 bootstrapPeerInfos TestWithTime{} = [testBootstrapPeerInfos]
 bootstrapPeerInfos TestWithPow{} = [testBootstrapPeerInfos]
 bootstrapPeerInfos PactWithTime{} = [testBootstrapPeerInfos]
-bootstrapPeerInfos Simulation{} = error
-    $ "bootstrap peer info isn't defined for chainweb version Simulation"
 bootstrapPeerInfos Testnet00 = testnet00BootstrapPeerInfo
 
 testBootstrapPeerInfos :: PeerInfo

--- a/test/Chainweb/Test/Orphans/Internal.hs
+++ b/test/Chainweb/Test/Orphans/Internal.hs
@@ -50,6 +50,7 @@ arbitraryBytesSized = sized $ \s -> choose (0, s) >>= arbitraryBytes
 -- -------------------------------------------------------------------------- --
 -- Basics
 
+-- FIXME: This does not detect when new ChainwebVersions are added!
 instance Arbitrary ChainwebVersion where
     arbitrary = elements
         [ Test singletonChainGraph
@@ -58,8 +59,8 @@ instance Arbitrary ChainwebVersion where
         , TestWithTime petersonChainGraph
         , TestWithPow singletonChainGraph
         , TestWithPow petersonChainGraph
-        , Simulation singletonChainGraph
-        , Simulation petersonChainGraph
+        , PactWithTime singletonChainGraph
+        , PactWithTime petersonChainGraph
         , Testnet00
         ]
 

--- a/test/Chainweb/Test/P2P/Peer/BootstrapConfig.hs
+++ b/test/Chainweb/Test/P2P/Peer/BootstrapConfig.hs
@@ -38,8 +38,6 @@ bootstrapPeerConfig v@Test{} = testBootstrapPeerConfig v
 bootstrapPeerConfig v@TestWithTime{} = testBootstrapPeerConfig v
 bootstrapPeerConfig v@TestWithPow{} = testBootstrapPeerConfig v
 bootstrapPeerConfig v@PactWithTime{} = testBootstrapPeerConfig v
-bootstrapPeerConfig Simulation{} = error
-    $ "bootstrap peer config isn't defined for chainweb version Simulation"
 bootstrapPeerConfig Testnet00 = error
     $ "bootstrap peer config isn't defined for chainweb version Testnet00"
 
@@ -67,8 +65,6 @@ bootstrapCertificate Test{} = testBootstrapCertificate
 bootstrapCertificate TestWithTime{} = testBootstrapCertificate
 bootstrapCertificate TestWithPow{} = testBootstrapCertificate
 bootstrapCertificate PactWithTime{} = testBootstrapCertificate
-bootstrapCertificate Simulation{} = error
-    $ "bootstrap certificate isn't defined for chainweb version Simulation"
 bootstrapCertificate Testnet00 = error
     $ "bootstrap certificate isn't defined for chainweb version Testnet00"
 
@@ -126,8 +122,6 @@ bootstrapKey Test{} = testBootstrapKey
 bootstrapKey TestWithTime{} = testBootstrapKey
 bootstrapKey TestWithPow{} = testBootstrapKey
 bootstrapKey PactWithTime{} = testBootstrapKey
-bootstrapKey Simulation{} = error
-    $ "bootstrap key isn't defined for chainweb version Simulation"
 bootstrapKey Testnet00 = error
     $ "bootstrap key isn't defined for chainweb version Testnet00"
 

--- a/test/Chainweb/Test/P2P/Peer/BootstrapConfig.hs
+++ b/test/Chainweb/Test/P2P/Peer/BootstrapConfig.hs
@@ -37,6 +37,7 @@ bootstrapPeerConfig :: ChainwebVersion -> [PeerConfig]
 bootstrapPeerConfig v@Test{} = testBootstrapPeerConfig v
 bootstrapPeerConfig v@TestWithTime{} = testBootstrapPeerConfig v
 bootstrapPeerConfig v@TestWithPow{} = testBootstrapPeerConfig v
+bootstrapPeerConfig v@PactWithTime{} = testBootstrapPeerConfig v
 bootstrapPeerConfig Simulation{} = error
     $ "bootstrap peer config isn't defined for chainweb version Simulation"
 bootstrapPeerConfig Testnet00 = error
@@ -65,9 +66,10 @@ bootstrapCertificate :: ChainwebVersion -> X509CertPem
 bootstrapCertificate Test{} = testBootstrapCertificate
 bootstrapCertificate TestWithTime{} = testBootstrapCertificate
 bootstrapCertificate TestWithPow{} = testBootstrapCertificate
+bootstrapCertificate PactWithTime{} = testBootstrapCertificate
 bootstrapCertificate Simulation{} = error
     $ "bootstrap certificate isn't defined for chainweb version Simulation"
-bootstrapCertificate Testnet00  = error
+bootstrapCertificate Testnet00 = error
     $ "bootstrap certificate isn't defined for chainweb version Testnet00"
 
 -- | The test certificate is also stored in the file
@@ -123,6 +125,7 @@ bootstrapKey :: ChainwebVersion -> X509KeyPem
 bootstrapKey Test{} = testBootstrapKey
 bootstrapKey TestWithTime{} = testBootstrapKey
 bootstrapKey TestWithPow{} = testBootstrapKey
+bootstrapKey PactWithTime{} = testBootstrapKey
 bootstrapKey Simulation{} = error
     $ "bootstrap key isn't defined for chainweb version Simulation"
 bootstrapKey Testnet00 = error


### PR DESCRIPTION
Have you read Hamlet?

This PR introduces a new `ChainwebVersion`, `PactWithTime`, which features simulated mining delay as well as proper Pact validation and execution. `TestWithTime` has been reverted to its previous meaning, which in turn restores the efficiency of `slow-tests`:

```
 Number of logs: 2136
 Expected BlockCount: 300
    {"_statMinHeight":252,"_statMaxHeight":253,"_statBlockCount":278,"_statAvgHeight":252.9,"_statMedHeight":253}
    {"avgEfficiency%":90.97122302158273,"medEfficiency%":91.00719424460432,"minEfficiency%":90.64748201438849,"maxEfficiency%":91.00719424460432}
```