### PR TITLE
Remove obsolete bootstrap nodes

### DIFF
--- a/src/P2P/Peer.hs
+++ b/src/P2P/Peer.hs
@@ -486,11 +486,7 @@ testnet00BootstrapPeerInfo = map f testnetBootstrapHosts
 -- | Official TestNet bootstrap nodes.
 --
 testnetBootstrapHosts :: [Hostname]
-testnetBootstrapHosts = map unsafeHostnameFromText
-    [ "us1.tn1.chainweb.com"
-    , "eu1.tn1.chainweb.com"
-    , "ap1.tn1.chainweb.com"
-    ]
+testnetBootstrapHosts = map unsafeHostnameFromText []
 
 -- -------------------------------------------------------------------------- --
 -- Arbitrary Instances


### PR DESCRIPTION
These DNS names are unused, so I remove them here to avoid confusion.

This also means we no longer need to have our running nodes ignore these non-existent bootstraps. <- @mightybyte 