### PR TITLE
Remove unsafe use of unsafeChainId

### DIFF
--- a/bench/Bench.hs
+++ b/bench/Bench.hs
@@ -22,13 +22,13 @@ import System.IO (hFlush, stdout)
 
 import Chainweb.BlockHeader (BlockHeader(..), testBlockHeaders)
 import Chainweb.BlockHeader.Genesis (genesisBlockHeader)
-import Chainweb.ChainId (ChainId, unsafeChainId)
+import Chainweb.ChainId (ChainId)
 import Chainweb.Graph (singletonChainGraph)
 import Chainweb.Store.Git
 import Chainweb.Store.Git.Internal (leaves', lockGitStore)
 import Chainweb.TreeDB
 import Chainweb.Utils (withTempDir)
-import Chainweb.Version (ChainwebVersion(..))
+import Chainweb.Version (ChainwebVersion(..), someChainId)
 
 ---
 
@@ -115,11 +115,12 @@ branches gs leaf =
 
 -- Borrowed from Chainweb.Test.Utils
 
+toyVersion :: ChainwebVersion
+toyVersion = Test singletonChainGraph
+
 genesis :: BlockHeader
-genesis = toyGenesis chainId0
+genesis = toyGenesis $ someChainId toyVersion
 
 toyGenesis :: ChainId -> BlockHeader
-toyGenesis cid = genesisBlockHeader (Test singletonChainGraph) cid
+toyGenesis cid = genesisBlockHeader toyVersion cid
 
-chainId0 :: ChainId
-chainId0 = unsafeChainId 0

--- a/chainweb.cabal
+++ b/chainweb.cabal
@@ -564,6 +564,7 @@ executable slow-tests
         , deepseq >= 1.4
         , directory >= 1.2
         , extra >= 1.6
+        , exceptions >= 0.8
         , filepath >= 1.4
         , extra >= 1.6
         , fgl >= 5.6

--- a/examples/BlockHeaderChainDb.hs
+++ b/examples/BlockHeaderChainDb.hs
@@ -46,16 +46,17 @@ import Chainweb.TreeDB
 import Chainweb.Utils
 import Chainweb.Version
 
-import Data.DiGraph
-
 -- -------------------------------------------------------------------------- --
 -- Main
 
-exampleChainId :: ChainId
-exampleChainId = unsafeChainId 0
-
 graph :: ChainGraph
-graph = toChainGraph (const exampleChainId) singleton
+graph = singletonChainGraph
+
+exampleVersion :: ChainwebVersion
+exampleVersion = Test graph
+
+exampleChainId :: ChainId
+exampleChainId = someChainId exampleVersion
 
 -- | Setup a logger and run the example
 --
@@ -72,7 +73,7 @@ main = withHandleBackend (_logConfigBackend config)
 example :: Logger T.Text -> IO ()
 example logger = do
     db <- DB.initBlockHeaderDb DB.Configuration
-        { DB._configRoot = genesisBlockHeader (Test graph) exampleChainId
+        { DB._configRoot = genesisBlockHeader exampleVersion exampleChainId
         }
     withAsync (observer logger db) $ \o -> do
         mapConcurrently_ (miner logger db) $ ChainNodeId exampleChainId <$> [0..5]

--- a/examples/P2pExample.hs
+++ b/examples/P2pExample.hs
@@ -83,7 +83,7 @@ defaultP2pExampleConfig = P2pExampleConfig
     , _maxPeerCount = 50
     , _sessionTimeoutSeconds = 20
     , _meanSessionSeconds = 10
-    , _exampleChainId = unsafeChainId 0
+    , _exampleChainId = someChainId version
     , _logConfig = defaultLogConfig
     }
 

--- a/examples/TransactionGenerator.hs
+++ b/examples/TransactionGenerator.hs
@@ -68,6 +68,7 @@ import Chainweb.Simulate.Contracts.HelloWorld
 import Chainweb.Simulate.Contracts.SimplePayments
 import Chainweb.Simulate.Utils
 import Chainweb.Pact.RestAPI
+import Chainweb.Version
 
 data TransactionCommand = NoOp | DeployContracts [FilePath] | RunStandardContracts | RunSimpleExpressions | PollRequestKeys [ByteString]
   deriving (Show, Eq, Read, Generic)
@@ -141,7 +142,7 @@ defaultTransactionConfig :: TransactionConfig
 defaultTransactionConfig =
   TransactionConfig
     { _scriptCommand      = DeployContracts []
-    , _nodeChainId        = unsafeChainId 0
+    , _nodeChainId        = someChainId Testnet00
     , _serverRootPrefix   = "https://us1.chainweb.com"
     , _isChainweb         = True
     , _chainwebNodePort   = ChainwebPort 443

--- a/src/Chainweb/BlockHeader/Genesis.hs
+++ b/src/Chainweb/BlockHeader/Genesis.hs
@@ -64,7 +64,7 @@ import Chainweb.Pact.Types (noCoinbase, noMiner, toCoinbaseOutput)
 import Chainweb.Payload
 import Chainweb.Time (Time(..), TimeSpan(..), epoche)
 import Chainweb.Utils
-import Chainweb.Version (ChainwebVersion(..), encodeChainwebVersion)
+import Chainweb.Version (ChainwebVersion(..), chainIds, encodeChainwebVersion)
 
 ---
 
@@ -188,9 +188,7 @@ genesisBlockHeaders
 genesisBlockHeaders v = HM.fromList
     . fmap (id &&& genesisBlockHeader v)
     . toList
-    . chainIds_
-    . _chainGraph
-    $ v
+    $ chainIds v
 
 -- -------------------------------------------------------------------------- --
 -- Testnet00

--- a/src/Chainweb/ChainId.hs
+++ b/src/Chainweb/ChainId.hs
@@ -17,7 +17,7 @@
 -- Maintainer: Lars Kuhtz <lars@kadena.io>
 -- Stability: experimental
 --
--- TODO
+-- The defininitions in this module are also exported via "Chainweb.Version".
 --
 module Chainweb.ChainId
 ( ChainIdException(..)

--- a/src/Chainweb/ChainId.hs
+++ b/src/Chainweb/ChainId.hs
@@ -89,18 +89,21 @@ instance Exception ChainIdException
 -- -------------------------------------------------------------------------- --
 -- ChainId
 
--- | ChainId /within a Chainweb/.
+-- | ChainId /within the context a Chainweb instance/.
 --
--- Generally a block chain is /globally/ uniquely identified by its genesis hash.
--- This type only uniquely identifies the chain /locally/ within the context of
--- a chainweb.
+-- The set of valid ChainIds is determined by the 'ChainwebVersion'. In almost
+-- all use cases there should be a context that is an instance of
+-- 'HasChainwebVersion' can be used get the set of chain ids.
 --
--- However, the chainweb context is globally uniquely identified by the
--- 'ChainwebVersion', which in turn is determined by the identities of the
--- chains in the chainweb. Since the chainweb topology is statically represented
--- on the type level, while the Chainweb version is a runtime value, we break
--- the cycle by using the Chainweb version as globally unique identifier and
--- include the 'ChainwebVersion' and the 'ChainId' into the genesis hash.
+-- In the context of a particular chain the respective 'ChainId' can be obtained
+-- via instances of 'HasChainId'.
+--
+-- /How to create values of type 'ChainId'/
+--
+-- * To fold or traverse over all chain ids, use 'chainIds'.
+-- * To deserialize a chain id, use 'mkChainId'.
+-- * For random chain id consider using 'randomChainId'.
+-- * For some arbitrary but fixed chain id consider using 'someChainId'.
 --
 newtype ChainId :: Type where
     ChainId :: Word32 -> ChainId
@@ -233,8 +236,8 @@ instance SingKind ChainIdT where
 -- -------------------------------------------------------------------------- --
 -- Testing
 
--- | Generally, the 'ChainId' is determined by the genesis block of a chain for
--- a given 'Chainweb.Version'. This constructor is only for testing.
+-- | This function should be be rarely needed. Please consult the documentation
+-- of 'ChainId' for alternative ways for obtain 'ChainId' values.
 --
 unsafeChainId :: Word32 -> ChainId
 unsafeChainId = ChainId
@@ -245,3 +248,4 @@ unsafeGetChainId (ChainId cid) = cid
 
 instance Arbitrary ChainId where
     arbitrary = unsafeChainId <$> arbitrary
+

--- a/src/Chainweb/ChainId.hs
+++ b/src/Chainweb/ChainId.hs
@@ -89,7 +89,7 @@ instance Exception ChainIdException
 -- -------------------------------------------------------------------------- --
 -- ChainId
 
--- | ChainId /within the context a Chainweb instance/.
+-- | ChainId /within the context of a Chainweb instance/.
 --
 -- The set of valid ChainIds is determined by the 'ChainwebVersion'. In almost
 -- all use cases there should be a context that is an instance of
@@ -102,7 +102,7 @@ instance Exception ChainIdException
 --
 -- * To fold or traverse over all chain ids, use 'chainIds'.
 -- * To deserialize a chain id, use 'mkChainId'.
--- * For random chain id consider using 'randomChainId'.
+-- * For a random chain id consider using 'randomChainId'.
 -- * For some arbitrary but fixed chain id consider using 'someChainId'.
 --
 newtype ChainId :: Type where
@@ -237,7 +237,7 @@ instance SingKind ChainIdT where
 -- Testing
 
 -- | This function should be be rarely needed. Please consult the documentation
--- of 'ChainId' for alternative ways for obtain 'ChainId' values.
+-- of 'ChainId' for alternative ways to obtain 'ChainId' values.
 --
 unsafeChainId :: Word32 -> ChainId
 unsafeChainId = ChainId

--- a/src/Chainweb/ChainId.hs
+++ b/src/Chainweb/ChainId.hs
@@ -46,7 +46,7 @@ module Chainweb.ChainId
 
 -- * Testing
 , unsafeChainId
-, unsafeGetChainId
+, chainIdInt
 ) where
 
 import Control.DeepSeq
@@ -234,7 +234,7 @@ instance SingKind ChainIdT where
         SomeChainIdT p -> SomeSing (singByProxy p)
 
 -- -------------------------------------------------------------------------- --
--- Testing
+-- Misc
 
 -- | This function should be be rarely needed. Please consult the documentation
 -- of 'ChainId' for alternative ways to obtain 'ChainId' values.
@@ -243,8 +243,9 @@ unsafeChainId :: Word32 -> ChainId
 unsafeChainId = ChainId
 {-# INLINE unsafeChainId #-}
 
-unsafeGetChainId :: ChainId -> Word32
-unsafeGetChainId (ChainId cid) = cid
+chainIdInt :: Integral i => ChainId -> i
+chainIdInt (ChainId cid) = int cid
+{-# INLINE chainIdInt #-}
 
 instance Arbitrary ChainId where
     arbitrary = unsafeChainId <$> arbitrary

--- a/src/Chainweb/Chainweb.hs
+++ b/src/Chainweb/Chainweb.hs
@@ -384,8 +384,7 @@ withChainwebInternal conf logger peer payloadDb inner = do
         | otherwise = m []
 
     v = _configChainwebVersion conf
-    graph = _chainGraph v
-    cids = chainIds_ graph
+    cids = chainIds v
     cwnid = _configNodeId conf
     chainDbDir = _configChainDbDirPath conf
 

--- a/src/Chainweb/Chainweb/PeerResources.hs
+++ b/src/Chainweb/Chainweb/PeerResources.hs
@@ -55,7 +55,6 @@ import System.LogLevel
 -- internal modules
 
 import Chainweb.Counter
-import Chainweb.Graph
 import Chainweb.HostAddress
 import Chainweb.Logger
 import Chainweb.RestAPI.NetworkID
@@ -152,7 +151,7 @@ startPeerDb_ :: ChainwebVersion -> P2pConfiguration -> IO PeerDb
 startPeerDb_ v conf = startPeerDb nids conf
   where
     nids = HS.map ChainNetwork cids `HS.union` HS.singleton CutNetwork
-    cids = chainIds_ $ _chainGraph v
+    cids = chainIds v
 
 withPeerDb_ :: ChainwebVersion -> P2pConfiguration -> (PeerDb -> IO a) -> IO a
 withPeerDb_ v conf = bracket (startPeerDb_ v conf) (stopPeerDb conf)

--- a/src/Chainweb/Cut.hs
+++ b/src/Chainweb/Cut.hs
@@ -166,7 +166,7 @@ lookupCutM
     -> m BlockHeader
 lookupCutM cid c = firstOf (ixg (_chainId cid)) c
     ??? ChainNotInChainGraphException
-        (Expected $ chainIds_ $ _chainGraph c)
+        (Expected $ chainIds c)
         (Actual (_chainId cid))
 
 _cutWeight :: Cut -> BlockWeight

--- a/src/Chainweb/Cut/Test.hs
+++ b/src/Chainweb/Cut/Test.hs
@@ -234,7 +234,7 @@ arbitraryCut v = T.sized $ \s -> do
   where
     genCut :: Cut -> T.Gen Cut
     genCut c = do
-        cids <- T.shuffle (toList $ chainIds_ $ _chainGraph v)
+        cids <- T.shuffle (toList $ chainIds v)
         S.each cids
             & S.mapMaybeM (mine c)
             & S.map (\(T2 _ x) -> x)
@@ -251,7 +251,7 @@ arbitraryCut v = T.sized $ \s -> do
     target = genesisBlockTarget v
 
 arbitraryChainGraphChainId :: Given ChainGraph => T.Gen ChainId
-arbitraryChainGraphChainId = T.elements (toList chainIds)
+arbitraryChainGraphChainId = T.elements (toList $ graphChainIds given)
 
 instance Given ChainwebVersion => T.Arbitrary Cut where
     arbitrary = arbitraryCut given
@@ -272,8 +272,7 @@ arbitraryWebChainCut initialCut = do
         cids <- T.pick
             $ T.shuffle
             $ toList
-            $ chainIds_
-            $ _chainGraph @WebBlockHeaderDb given
+            $ chainIds initialCut
         S.each cids
             & S.mapMaybeM (mine c)
             & S.map (\(T2 _ c') -> c')
@@ -304,8 +303,7 @@ arbitraryWebChainCut_ initialCut = do
         cids <- TT.liftGen
             $ T.shuffle
             $ toList
-            $ chainIds_
-            $ _chainGraph @WebBlockHeaderDb given
+            $ chainIds initialCut
         S.each cids
             & S.mapMaybeM (fmap hush . mine c)
             & S.map (\(T2 _ c') -> c')

--- a/src/Chainweb/Graph.hs
+++ b/src/Chainweb/Graph.hs
@@ -63,8 +63,7 @@ module Chainweb.Graph
 -- * Checks with a given chain graph
 
 , isWebChain
-, chainIds
-, chainIds_
+, graphChainIds
 , checkWebChainId
 , checkAdjacentChainIds
 
@@ -74,8 +73,6 @@ module Chainweb.Graph
 , pairChainGraph
 , petersonChainGraph
 
--- * Random ChainId
-, randomChainId
 ) where
 
 import Control.Arrow
@@ -85,18 +82,14 @@ import Control.Monad
 import Control.Monad.Catch
 
 import Data.Bits
-import Data.Foldable
 import Data.Function
 import Data.Hashable
 import qualified Data.HashSet as HS
 import Data.Kind
-import Data.Reflection hiding (int)
 
 import GHC.Generics hiding (to)
 
 import Numeric.Natural
-
-import System.Random
 
 -- internal imports
 
@@ -264,13 +257,9 @@ instance HasChainGraph ChainGraph where
 -- -------------------------------------------------------------------------- --
 -- Checks with a given Graphs
 
-chainIds :: Given ChainGraph => HS.HashSet ChainId
-chainIds = vertices (_chainGraphGraph given)
-{-# INLINE chainIds #-}
-
-chainIds_ :: ChainGraph -> HS.HashSet ChainId
-chainIds_ = vertices . _chainGraphGraph
-{-# INLINE chainIds_ #-}
+graphChainIds :: ChainGraph -> HS.HashSet ChainId
+graphChainIds = vertices . _chainGraphGraph
+{-# INLINE graphChainIds #-}
 
 -- | Given a 'ChainGraph' @g@, @checkWebChainId p@ checks that @p@ is a vertex
 -- in @g@.
@@ -317,14 +306,4 @@ pairChainGraph = toChainGraph (unsafeChainId . int) pair
 
 petersonChainGraph :: ChainGraph
 petersonChainGraph = toChainGraph (unsafeChainId . int) petersonGraph
-
--- -------------------------------------------------------------------------- --
--- Random ChainId
-
--- | Uniformily get a random ChainId from the chain graph
---
-randomChainId :: HasChainGraph g => g -> IO ChainId
-randomChainId g = (!!) (toList cs) <$> randomRIO (0, length cs - 1)
-  where
-    cs = give (_chainGraph g) chainIds
 

--- a/src/Chainweb/Miner/POW.hs
+++ b/src/Chainweb/Miner/POW.hs
@@ -65,7 +65,6 @@ import Chainweb.Cut
 import Chainweb.Cut.CutHashes
 import Chainweb.CutDB
 import Chainweb.Difficulty
-import Chainweb.Graph
 import Chainweb.Miner.Config (MinerConfig(..))
 import Chainweb.NodeId
 import Chainweb.NodeId (NodeId)

--- a/src/Chainweb/Pact/PactService.hs
+++ b/src/Chainweb/Pact/PactService.hs
@@ -74,7 +74,7 @@ import qualified Pact.Types.SQLite as P
 
 import Chainweb.BlockHash
 import Chainweb.BlockHeader (BlockHeader(..), BlockHeight(..), isGenesisBlockHeader)
-import Chainweb.ChainId (ChainId, unsafeGetChainId)
+import Chainweb.ChainId (ChainId, chainIdInt)
 import Chainweb.CutDB (CutDb)
 import Chainweb.Logger
 import Chainweb.Pact.Backend.InMemoryCheckpointer (initInMemoryCheckpointEnv)
@@ -172,7 +172,7 @@ initPactService' ver cid chainwebLogger spv act = do
             internalError' s
         Right _ -> return ()
 
-    let !pd = P.PublicData def (unsafeGetChainId cid) def def
+    let !pd = P.PublicData def (chainIdInt cid) def def
     let !pse = PactServiceEnv Nothing checkpointEnv spv pd
 
     evalStateT (runReaderT act pse) (PactServiceState theState Nothing)

--- a/src/Chainweb/Payload/PayloadStore.hs
+++ b/src/Chainweb/Payload/PayloadStore.hs
@@ -65,7 +65,6 @@ import qualified Data.Sequence as S
 -- internal modules
 
 import Chainweb.BlockHeader.Genesis (genesisBlockPayload)
-import Chainweb.Graph
 import Chainweb.Payload
 import Chainweb.Version
 
@@ -214,7 +213,7 @@ initializePayloadDb
     => ChainwebVersion
     -> PayloadDb cas
     -> IO ()
-initializePayloadDb v db = traverse_ initForChain $ chainIds_ $ _chainGraph v
+initializePayloadDb v db = traverse_ initForChain $ chainIds v
   where
     initForChain cid = do
         addNewPayload db $ genesisBlockPayload v cid

--- a/src/Chainweb/SPV/RestAPI/Server.hs
+++ b/src/Chainweb/SPV/RestAPI/Server.hs
@@ -42,7 +42,6 @@ import Servant
 import Chainweb.BlockHeader
 import Chainweb.ChainId
 import Chainweb.CutDB
-import Chainweb.Graph
 import Chainweb.Payload.PayloadStore
 import Chainweb.RestAPI.Utils
 import Chainweb.SPV
@@ -155,5 +154,5 @@ someSpvServers
 someSpvServers v db = mconcat $ flip fmap cids $ \(FromSing (SChainId :: Sing c)) ->
     someSpvServer @_ @c (someCutDbVal v db)
   where
-    cids = toList . chainIds_ $ _chainGraph db
+    cids = toList $ chainIds db
 

--- a/src/Chainweb/Version.hs
+++ b/src/Chainweb/Version.hs
@@ -380,11 +380,11 @@ mkChainId v i = cid
 
 -- | Sometimes, in particular for testing and examples, some fixed chain id is
 -- needed, but it doesn't matter which one. This function provides some valid
--- chain id.
+-- chain ids.
 --
 someChainId :: HasCallStack => HasChainwebVersion v => v -> ChainId
 someChainId = head . toList . chainIds
-    -- 'head' is guaranteed to succeed because the empty graph isn't valid chain
+    -- 'head' is guaranteed to succeed because the empty graph isn't a valid chain
     -- graph.
 {-# INLINE someChainId #-}
 

--- a/src/Chainweb/Version.hs
+++ b/src/Chainweb/Version.hs
@@ -9,6 +9,7 @@
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE MultiWayIf #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
@@ -51,6 +52,29 @@ module Chainweb.Version
 , someChainId
 , randomChainId
 
+-- * ChainId
+, module Chainweb.ChainId
+
+-- * Re-exports from Chainweb.ChainGraph
+
+-- ** Chain Graph
+, ChainGraph
+, HasChainGraph(..)
+, adjacentChainIds
+
+-- ** Graph Properties
+, order
+, diameter
+, degree
+, shortestPath
+
+-- ** Undirected Edges
+, AdjPair
+, _getAdjPair
+, pattern Adj
+, adjs
+, adjsOfVertex
+, checkAdjacentChainIds
 ) where
 
 import Control.Concurrent.STM.TVar

--- a/src/Chainweb/WebBlockHeaderDB.hs
+++ b/src/Chainweb/WebBlockHeaderDB.hs
@@ -121,10 +121,9 @@ initWebBlockHeaderDb
     :: ChainwebVersion
     -> IO WebBlockHeaderDb
 initWebBlockHeaderDb v = WebBlockHeaderDb
-    <$> itraverse (\cid _ -> initBlockHeaderDb (conf cid)) (HS.toMap $ chainIds_ g)
+    <$> itraverse (\cid _ -> initBlockHeaderDb (conf cid)) (HS.toMap $ chainIds v)
     <*> pure v
   where
-    g = _chainGraph v
     conf cid = Configuration (genesisBlockHeader v cid)
 
 -- | FIXME: this needs some consistency checks

--- a/test/Chainweb/Test/BlockHeader/Genesis.hs
+++ b/test/Chainweb/Test/BlockHeader/Genesis.hs
@@ -13,9 +13,10 @@ module Chainweb.Test.BlockHeader.Genesis
 
 import Control.Monad (zipWithM_)
 
+import Data.Foldable
 import Data.Function (on)
 import qualified Data.HashMap.Strict as HM
-import Data.List (sortBy)
+import Data.List (sort, sortBy)
 
 import Test.Tasty
 import Test.Tasty.HUnit
@@ -24,9 +25,8 @@ import Test.Tasty.HUnit
 
 import Chainweb.BlockHeader (BlockHeader(..), Nonce(..))
 import Chainweb.BlockHeader.Genesis
-import Chainweb.ChainId (unsafeChainId)
 import Chainweb.Miner.Genesis (mineGenesis)
-import Chainweb.Version (ChainwebVersion(..))
+import Chainweb.Version (ChainwebVersion(..), chainIds)
 
 ---
 
@@ -48,6 +48,7 @@ allBlocksParse = map _blockHeight testnet00Chains @?= replicate 10 0
 -- what was hardcoded?
 --
 regeneration :: ChainwebVersion -> [BlockHeader] -> Assertion
-regeneration v bs = zipWithM_ (\cid chain -> mine cid @?= chain) [0..] bs
+regeneration v bs = zipWithM_ (\cid chain -> mine cid @?= chain) cids bs
   where
-    mine c = mineGenesis v (unsafeChainId c) (genesisTime v) (Nonce 0)
+    cids = sort $ toList $ chainIds v
+    mine c = mineGenesis v c (genesisTime v) (Nonce 0)

--- a/test/Chainweb/Test/Mempool/RestAPI.hs
+++ b/test/Chainweb/Test/Mempool/RestAPI.hs
@@ -4,7 +4,6 @@ module Chainweb.Test.Mempool.RestAPI (tests) where
 import Control.Concurrent
 import Control.Concurrent.STM
 import Control.Exception
-import Data.Foldable
 import qualified Data.Pool as Pool
 import qualified Network.HTTP.Client as HTTP
 import Servant.Client (BaseUrl(..), Scheme(..), mkClientEnv)
@@ -58,7 +57,7 @@ newTestServer inMemCfg = mask_ $ do
     blocksizeLimit = InMem._inmemTxBlockSizeLimit inMemCfg
     txcfg = InMem._inmemTxCfg inMemCfg
     host = "127.0.0.1"
-    chain = head $ toList $ chainIds_ singletonChainGraph
+    chain = someChainId version
     mkApp mp = chainwebApplication version (serverMempools [(chain, mp)])
     mkEnv port = do
         mgrSettings <- certificateCacheManagerSettings TlsInsecure Nothing

--- a/test/Chainweb/Test/Pact/PactExec.hs
+++ b/test/Chainweb/Test/Pact/PactExec.hs
@@ -45,15 +45,16 @@ import Pact.Types.Logger
 import qualified Pact.Types.Runtime as P
 import Pact.Types.Server
 
-import Chainweb.Graph (petersonChainGraph)
 import Chainweb.Pact.Backend.InMemoryCheckpointer
 import Chainweb.Pact.Backend.SQLiteCheckpointer
 import Chainweb.Pact.PactService
 import Chainweb.Pact.Types
 import Chainweb.Test.Pact.Utils
-import Chainweb.Version (ChainwebVersion(..))
-import Chainweb.ChainId
+import Chainweb.Version (ChainwebVersion(..), someChainId)
 import Chainweb.BlockHash
+
+testVersion :: ChainwebVersion
+testVersion = Testnet00
 
 tests :: IO TestTree
 tests = do
@@ -65,7 +66,7 @@ pactTestSetup :: IO PactTestSetup
 pactTestSetup = do
     let loggers = alwaysLog
     let logger = newLogger loggers $ LogName "PactService"
-    let pactCfg = pactDbConfig (Test petersonChainGraph)
+    let pactCfg = pactDbConfig testVersion
     let cmdConfig = toCommandConfig pactCfg
     let gasLimit = fromMaybe 0 (_ccGasLimit cmdConfig)
     let gasRate = fromMaybe 0 (_ccGasRate cmdConfig)
@@ -91,7 +92,8 @@ pactTestSetup = do
 pactExecTests :: PactTestSetup -> IO [TestTree]
 pactExecTests (PactTestSetup env st) = do
     let pss = PactServiceState st Nothing
-    fst <$> runStateT (runReaderT (initialPayloadState Testnet00 (unsafeChainId 0) >> execTests) env) pss
+        cid = someChainId testVersion
+    fst <$> runStateT (runReaderT (initialPayloadState testVersion cid >> execTests) env) pss
 
 execTests :: PactServiceM [TestTree]
 execTests = do

--- a/test/Chainweb/Test/Pact/PactInProcApi.hs
+++ b/test/Chainweb/Test/Pact/PactInProcApi.hs
@@ -174,10 +174,9 @@ checkBlockTransactions filePrefix bTrans = do
     return $ testGroup "BlockTransactions" $ ttTrans : [ttTransHash]
 
 getBlockHeaders :: ChainId -> Int -> [BlockHeader]
-getBlockHeaders cid n = do
-    let gbh0 = genesisBlockHeader testVersion cid
-    let after0s = take (n - 1) $ testBlockHeaders gbh0
-    gbh0 : after0s
+getBlockHeaders cid n = gbh0 : take (n - 1) (testBlockHeaders gbh0)
+  where
+    gbh0 = genesisBlockHeader testVersion cid
 
 testMemPoolAccess :: MemPoolAccess
 testMemPoolAccess _bHeight _bHash = do

--- a/test/Chainweb/Test/Pact/SPV.hs
+++ b/test/Chainweb/Test/Pact/SPV.hs
@@ -82,7 +82,7 @@ testCaseStepsN name n t = testGroup name $ fmap steps [1..n]
 --
 targetChain :: Cut -> BlockHeader -> IO ChainId
 targetChain c srcBlock = do
-    cids <- generate (shuffle $ toList $ chainIds_ graph)
+    cids <- generate (shuffle $ toList $ chainIds c)
     go cids
   where
     graph = _chainGraph c
@@ -138,7 +138,7 @@ withPactSetup cdb f = do
         pure (cpe,st)
 
     initCC = runRST $
-      initialPayloadState Testnet00 (unsafeChainId 0)
+      initialPayloadState Testnet00 $ someChainId Testnet00
 
 createCoinCmd :: Transaction -> IO (ExecMsg ParsedCode)
 createCoinCmd tx = buildExecParsedCode spvData

--- a/test/Chainweb/Test/Pact/Utils.hs
+++ b/test/Chainweb/Test/Pact/Utils.hs
@@ -10,8 +10,6 @@
 module Chainweb.Test.Pact.Utils
 ( -- * test data
   someED25519Pair
-, genesis
-, chainId0
 , testPactFilesDir
 , testKeyPairs
   -- * helper functions
@@ -45,9 +43,6 @@ import Pact.Parse (ParsedDecimal(..),ParsedInteger(..))
 
 -- internal chainweb modules
 
-import Chainweb.BlockHeader (BlockHeader)
-import Chainweb.ChainId (ChainId, unsafeChainId)
-import Chainweb.Test.Utils (toyGenesis)
 import Chainweb.Transaction
 import Chainweb.Utils
 
@@ -70,12 +65,6 @@ someED25519Pair =
     , "368820f80c324bbc7c2b0610688a7da43e39f91d118732671cd9c7500ff43cca"
     , ED25519
     )
-
-genesis :: BlockHeader
-genesis = toyGenesis chainId0
-
-chainId0 :: ChainId
-chainId0 = unsafeChainId 0
 
 ------------------------------------------------------------------------------
 -- helper logic

--- a/test/Chainweb/Test/RestAPI.hs
+++ b/test/Chainweb/Test/RestAPI.hs
@@ -113,7 +113,7 @@ simpleSessionTests :: Bool -> ChainwebVersion -> TestTree
 simpleSessionTests tls version =
     withBlockHeaderDbsServer tls version (testBlockHeaderDbs version) (return noMempool)
     $ \env -> testGroup "client session tests"
-        $ simpleClientSession env <$> toList (chainIds_ $ _chainGraph version)
+        $ simpleClientSession env <$> toList (chainIds version)
 
 simpleClientSession :: IO TestClientEnv_ -> ChainId -> TestTree
 simpleClientSession envIO cid =
@@ -223,10 +223,14 @@ putExisting = simpleTest "put existing block header" isRight $ \h0 ->
 
 putOnWrongChain :: IO TestClientEnv_ -> TestTree
 putOnWrongChain = simpleTest "put on wrong chain fails" (isErrorCode 400)
-    $ \h0 -> headerPutClient (_chainwebVersion h0) (_chainId h0)
-        . head
-        . testBlockHeadersWithNonce (Nonce 2)
-        $ genesisBlockHeader (Test petersonChainGraph) (unsafeChainId 1)
+    $ \h0 -> do
+        cid <- mkChainId v (1 :: Int)
+        headerPutClient (_chainwebVersion h0) (_chainId h0)
+            . head
+            . testBlockHeadersWithNonce (Nonce 2)
+            $ genesisBlockHeader v cid
+  where
+    v = Test petersonChainGraph
 
 putMissingParent :: IO TestClientEnv_ -> TestTree
 putMissingParent = simpleTest "put missing parent" (isErrorCode 400) $ \h0 ->

--- a/test/Chainweb/Test/SPV.hs
+++ b/test/Chainweb/Test/SPV.hs
@@ -83,7 +83,7 @@ testCaseStepsN name n test = testGroup name $ flip map [1..n] $ \i ->
 --
 targetChain :: Cut -> BlockHeader -> IO ChainId
 targetChain c srcBlock = do
-    cids <- generate (shuffle $ toList $ chainIds_ graph)
+    cids <- generate (shuffle $ toList $ chainIds c)
     go cids
   where
     graph = _chainGraph c
@@ -189,9 +189,8 @@ apiTests tls v = withTestPayloadResource v 100 (\_ _ -> return ()) $ \dbsIO ->
             testCaseStepsN "spv api tests (with tls)" 10 (txApiTests env)
         ]
   where
-    cids = toList (chainIds_ graph)
+    cids = toList $ chainIds v
     payloadDbs db = (, db) <$> cids
-    graph = _chainGraph v
 
 txApiTests :: IO TestClientEnv_ -> Step -> IO ()
 txApiTests envIO step = do

--- a/test/Chainweb/Test/Store/Git.hs
+++ b/test/Chainweb/Test/Store/Git.hs
@@ -13,20 +13,16 @@ import Test.Tasty.HUnit
 -- internal modules
 
 import Chainweb.BlockHeader (BlockHeader(..), testBlockHeaders)
-import Chainweb.ChainId
 import Chainweb.Store.Git
 import Chainweb.Store.Git.Internal
 import Chainweb.Test.TreeDB
-import Chainweb.Test.Utils (toyGenesis)
+import Chainweb.Test.Utils (toyGenesis, toyChainId)
 import Chainweb.Utils (withTempDir)
 
 ---
 
-chainId0 :: ChainId
-chainId0 = unsafeChainId 0
-
 genesis :: BlockHeader
-genesis = toyGenesis chainId0
+genesis = toyGenesis toyChainId
 
 chainLen :: Int
 chainLen = 100

--- a/test/Chainweb/Test/TreeDB/Persistence.hs
+++ b/test/Chainweb/Test/TreeDB/Persistence.hs
@@ -28,15 +28,11 @@ import Test.Tasty.HUnit
 
 -- internal modules
 
-import Chainweb.ChainId (ChainId, unsafeChainId)
-import Chainweb.Test.Utils (insertN, withDB)
+import Chainweb.Test.Utils (insertN, withToyDB, toyChainId)
 import Chainweb.TreeDB
 import Chainweb.TreeDB.Persist (fileEntries, persist)
 
 ---
-
-chainId0 :: ChainId
-chainId0 = unsafeChainId 0
 
 tests :: TestTree
 tests = testGroup "Persistence"
@@ -50,7 +46,7 @@ tests = testGroup "Persistence"
 -- write its only block, the genesis block.
 --
 onlyGenesis :: Assertion
-onlyGenesis = withDB chainId0 $ \g db -> do
+onlyGenesis = withToyDB toyChainId $ \g db -> do
     persist p db
     g' <- runResourceT . S.head_ $ fileEntries @(ResourceT IO) p
     g' @?= Just g
@@ -66,7 +62,7 @@ onlyGenesis = withDB chainId0 $ \g db -> do
 --  * The first block streamed from both the DB and the file will be the genesis.
 --
 manyBlocksWritten :: Assertion
-manyBlocksWritten = withDB chainId0 $ \g db -> do
+manyBlocksWritten = withToyDB toyChainId $ \g db -> do
     void $ insertN len g db
     persist p db
     fromDB <- S.toList_ $ entries db Nothing Nothing Nothing Nothing

--- a/test/Chainweb/Test/Utils.hs
+++ b/test/Chainweb/Test/Utils.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MultiWayIf #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE PatternSynonyms #-}
@@ -21,8 +22,10 @@ module Chainweb.Test.Utils
 (
 -- * BlockHeaderDb Generation
   toyBlockHeaderDb
+, toyChainId
 , toyGenesis
-, withDB
+, genesisBlockHeaderForChain
+, withToyDB
 , insertN
 , prettyTree
 , normalizeTree
@@ -79,6 +82,7 @@ import Control.Concurrent
 import Control.Concurrent.Async
 import Control.Exception (SomeException, bracket, handle)
 import Control.Lens (deep, filtered, toListOf)
+import Control.Monad.Catch (MonadThrow)
 import Control.Monad.IO.Class
 
 import Data.Aeson (FromJSON, ToJSON)
@@ -131,7 +135,7 @@ import Chainweb.Test.P2P.Peer.BootstrapConfig
 import Chainweb.Time
 import Chainweb.TreeDB
 import Chainweb.Utils
-import Chainweb.Version (ChainwebVersion(..))
+import Chainweb.Version
 
 import Data.CAS.HashMap hiding (toList)
 
@@ -142,10 +146,16 @@ import Numeric.AffineSpace
 import qualified P2P.Node.PeerDB as P2P
 
 -- -------------------------------------------------------------------------- --
--- BlockHeaderDb Generation
+-- Toy Values
+--
+-- All toy values are based on `toyVersion`. Don't use these values with another
+-- chainweb version!
 
 toyVersion :: ChainwebVersion
 toyVersion = Test singletonChainGraph
+
+toyChainId :: ChainId
+toyChainId = someChainId toyVersion
 
 toyGenesis :: ChainId -> BlockHeader
 toyGenesis cid = genesisBlockHeader toyVersion cid
@@ -163,8 +173,21 @@ toyBlockHeaderDb cid = (g,) <$> initBlockHeaderDb (Configuration g)
 -- an initialized `BlockHeaderDb`, perform some action
 -- and cleanly close the DB.
 --
-withDB :: ChainId -> (BlockHeader -> BlockHeaderDb -> IO ()) -> IO ()
-withDB cid = bracket (toyBlockHeaderDb cid) (closeBlockHeaderDb . snd) . uncurry
+withToyDB :: ChainId -> (BlockHeader -> BlockHeaderDb -> IO ()) -> IO ()
+withToyDB cid = bracket (toyBlockHeaderDb cid) (closeBlockHeaderDb . snd) . uncurry
+
+-- -------------------------------------------------------------------------- --
+-- BlockHeaderDb Generation
+
+genesisBlockHeaderForChain
+    :: MonadThrow m
+    => HasChainwebVersion v
+    => Integral i
+    => v
+    -> i
+    -> m BlockHeader
+genesisBlockHeaderForChain v i
+    = genesisBlockHeader (_chainwebVersion v) <$> mkChainId v i
 
 -- | Populate a `TreeDb` with /n/ generated `BlockHeader`s.
 --
@@ -217,7 +240,7 @@ tree v g = do
 -- | Generate a sane, legal genesis block for 'Test' chainweb instance
 --
 genesis :: ChainwebVersion -> Gen BlockHeader
-genesis v = return $ genesisBlockHeader v (unsafeChainId 0)
+genesis v = either (error . sshow) return $ genesisBlockHeaderForChain v (0 :: Int)
 
 forest :: Growth -> BlockHeader -> Gen (Forest BlockHeader)
 forest Randomly h = randomTrunk h
@@ -278,7 +301,7 @@ singleton :: ChainGraph
 singleton = singletonChainGraph
 
 testBlockHeaderDbs :: ChainwebVersion -> IO [(ChainId, BlockHeaderDb)]
-testBlockHeaderDbs v = mapM toEntry $ toList $ chainIds_ (_chainGraph v)
+testBlockHeaderDbs v = mapM toEntry $ toList $ chainIds v
   where
     toEntry c = do
         d <- db c

--- a/test/config/new-block-expected-0-blockOuts-hash.txt
+++ b/test/config/new-block-expected-0-blockOuts-hash.txt
@@ -1,1 +1,1 @@
-"r2HmcC7mZTsdfVASUlfAWyKvagDm9Zlr6-Sh89qUv5Y"
+"gspth0GZybMBPFoIzMMMXKtSvsxA0q-s3iQu8bzuCPk"

--- a/test/config/new-block-expected-0-blockPayHash.txt
+++ b/test/config/new-block-expected-0-blockPayHash.txt
@@ -1,1 +1,1 @@
-"M_vdVsU9zXy3TD8jkVC_3VX2qqU4LVQGCqZWbIooa-g"
+"dq5rtV4Mrzfxnnqoj5rZ7VAvEdU2yRCqWNknTAlNdaM"

--- a/test/config/new-empty-expected-0-blockOuts-hash.txt
+++ b/test/config/new-empty-expected-0-blockOuts-hash.txt
@@ -1,1 +1,1 @@
-"Rd_GpU9zrb10o7B4j0YpM2V-NnDi_j4_TLUYkXXGMZ8"
+"pPveennOK5z6hvoZQCkYxGYnzX2_lHfIbkdgQEKL4qw"

--- a/test/config/new-empty-expected-0-blockPayHash.txt
+++ b/test/config/new-empty-expected-0-blockPayHash.txt
@@ -1,1 +1,1 @@
-"6b73iZJxEe2hYd5-RNHWeWq18ImopTb7qIMiBuj3eGo"
+"tFs7pKxBCkCDVoJr5xYGLShjHQ1oLm1hM5C3SGgAJes"

--- a/test/config/validateBlock-expected-0-blockOuts-hash.txt
+++ b/test/config/validateBlock-expected-0-blockOuts-hash.txt
@@ -1,1 +1,1 @@
-"r2HmcC7mZTsdfVASUlfAWyKvagDm9Zlr6-Sh89qUv5Y"
+"gspth0GZybMBPFoIzMMMXKtSvsxA0q-s3iQu8bzuCPk"

--- a/test/config/validateBlock-expected-0-blockPayHash.txt
+++ b/test/config/validateBlock-expected-0-blockPayHash.txt
@@ -1,1 +1,1 @@
-"M_vdVsU9zXy3TD8jkVC_3VX2qqU4LVQGCqZWbIooa-g"
+"dq5rtV4Mrzfxnnqoj5rZ7VAvEdU2yRCqWNknTAlNdaM"


### PR DESCRIPTION
This PR removes almost all uses of `unsafeChainId`. In most cases the unsafe use was not needed, because the context already supported safe creation of `ChainId` values. This indicates that from the code it was not obvious how to safely construct of `ChainId` values.

This PR addresses this in two ways: It make safe construction of `ChainId` values more convenient and it improves the documentation.

The following new functions are added:

* [x] `chainIds :: HasChainwebVersion v => v -> HS.HashSet ChainId`
* [x] `mkChainId :: MonadThrow m => HasChainwebVersion v => Integral i => v -> i -> m ChainId`
* [x] `someChainId :: HasCallStack => HasChainwebVersion v => v -> ChainId`

The type of the function `randomChainId` is changed to

* [x] `randomChainId :: HasChainwebVersion v => v -> IO ChainId`

All uses of `unsafeChainId` in tests and examples are replaced by above functions.

Updated documentation of `ChainId`:

```Haskell
-- | ChainId /within the context a Chainweb instance/.
--
-- The set of valid ChainIds is determined by the 'ChainwebVersion'. In almost
-- all use cases there should be a context that is an instance of
-- 'HasChainwebVersion' and `chainIds' can be used get the set of chain ids.
--
-- In the context of a particular chain the 'ChainId' can be obtained via
-- instances of 'HasChainId'.
--
-- /How to create values of type 'ChainId'/
--
-- * To fold or traverse over all chain ids use 'chainIds'
-- * To deserialize a chain id use 'mkChainId'.
-- * For random chain id consider using 'randomChainId'.
-- * For some arbitrary but fixed chain id consider using 'someChainId'.
```
