### PR TITLE
Statically-known Text representations for `ChainwebVersion`

### DIFF
--- a/src/Chainweb/BlockHeader/Genesis.hs
+++ b/src/Chainweb/BlockHeader/Genesis.hs
@@ -99,7 +99,6 @@ genesisTime :: ChainwebVersion -> BlockCreationTime
 genesisTime Test{} = BlockCreationTime epoche
 genesisTime TestWithTime{} = BlockCreationTime epoche
 genesisTime TestWithPow{} = BlockCreationTime epoche
-genesisTime Simulation{} = BlockCreationTime epoche
 -- Tuesday, 2019 February 26, 10:55 AM
 genesisTime Testnet00 = BlockCreationTime . Time $ TimeSpan 1551207336601038
 
@@ -107,7 +106,6 @@ genesisMiner :: HasChainId p => ChainwebVersion -> p -> ChainNodeId
 genesisMiner Test{} p = ChainNodeId (_chainId p) 0
 genesisMiner TestWithTime{} p = ChainNodeId (_chainId p) 0
 genesisMiner TestWithPow{} p = ChainNodeId (_chainId p) 0
-genesisMiner Simulation{} p = ChainNodeId (_chainId p) 0
 -- TODO: Base the `ChainNodeId` off a Pact public key that is significant to Kadena.
 -- In other words, 0 is a meaningless hard-coding.
 genesisMiner Testnet00 p = ChainNodeId (_chainId p) 0
@@ -123,8 +121,6 @@ genesisBlockPayload :: ChainwebVersion -> ChainId -> PayloadWithOutputs
 genesisBlockPayload Test{} _ = emptyPayload
 genesisBlockPayload TestWithTime{} _ = payloadBlock
 genesisBlockPayload TestWithPow{} _ = emptyPayload
-genesisBlockPayload Simulation{} _ =
-    error "genesisBlockPayload isn't yet defined for Simulation"
 genesisBlockPayload Testnet00 _ = payloadBlock
 
 emptyPayload :: PayloadWithOutputs

--- a/src/Chainweb/Chainweb/MinerResources.hs
+++ b/src/Chainweb/Chainweb/MinerResources.hs
@@ -83,5 +83,4 @@ runMiner v m = (chooseMiner v)
     chooseMiner Test{} = testMiner
     chooseMiner TestWithTime{} = testMiner
     chooseMiner TestWithPow{} = powMiner
-    chooseMiner Simulation{} = testMiner
     chooseMiner Testnet00 = powMiner

--- a/src/Chainweb/CutDB.hs
+++ b/src/Chainweb/CutDB.hs
@@ -130,7 +130,7 @@ defaultCutDbConfig :: ChainwebVersion -> CutDbConfig
 defaultCutDbConfig v = CutDbConfig
     { _cutDbConfigInitialCut = genesisCut v
     , _cutDbConfigInitialCutFile = Nothing
-    , _cutDbConfigBufferSize = (order g ^ 2) * diameter g
+    , _cutDbConfigBufferSize = (order g ^ (2 :: Int)) * diameter g
     , _cutDbConfigLogLevel = Warn
     , _cutDbConfigTelemetryLevel = Warn
     , _cutDbConfigUseOrigin = True

--- a/src/Chainweb/Difficulty.hs
+++ b/src/Chainweb/Difficulty.hs
@@ -314,7 +314,6 @@ blockRate :: ChainwebVersion -> Maybe BlockRate
 blockRate Test{} = Nothing
 blockRate TestWithTime{} = Just $ BlockRate 4
 blockRate TestWithPow{} = Just $ BlockRate 10
-blockRate Simulation{} = Nothing
 -- 120 blocks per hour, 2,880 per day, 20,160 per week, 1,048,320 per year.
 blockRate Testnet00 = Just $ BlockRate 30
 
@@ -332,7 +331,6 @@ window Test{} = Nothing
 window TestWithTime{} = Nothing
 -- 5 blocks, should take 50 seconds.
 window TestWithPow{} = Just $ WindowWidth 5
-window Simulation{} = Nothing
 -- 120 blocks, should take 1 hour given a 30 second BlockRate.
 window Testnet00 = Just $ WindowWidth 120
 
@@ -349,7 +347,6 @@ maxAdjust :: ChainwebVersion -> Maybe MaxAdjustment
 maxAdjust Test{} = Nothing
 maxAdjust TestWithTime{} = Nothing
 maxAdjust TestWithPow{} = Just $ MaxAdjustment 3
-maxAdjust Simulation{} = Nothing
 -- See `adjust` for motivation.
 maxAdjust Testnet00 = Just $ MaxAdjustment 3
 
@@ -362,7 +359,6 @@ prereduction :: ChainwebVersion -> Int
 prereduction Test{} = 0
 prereduction TestWithTime{} = 0
 prereduction TestWithPow{} = 7
-prereduction Simulation{} = 0
 -- As alluded to in `maxTarget`, 11 bits has been shown experimentally to be
 -- high enough to keep mining slow during the initial conditions of a
 -- single-machine-10-chain-10-miner scenario, thereby avoiding (too many)

--- a/src/Chainweb/Graph.hs
+++ b/src/Chainweb/Graph.hs
@@ -74,7 +74,6 @@ module Chainweb.Graph
 
 , KnownGraph(..)
 , knownGraph
-, graphCode
 , singletonChainGraph
 , pairChainGraph
 , triangleChainGraph
@@ -95,7 +94,6 @@ import Data.Function (on)
 import Data.Hashable (Hashable(..))
 import qualified Data.HashSet as HS
 import Data.Kind (Type)
-import Data.Word (Word32)
 
 import GHC.Generics hiding (to)
 
@@ -326,17 +324,6 @@ knownGraph Triangle = triangleChainGraph
 knownGraph Peterson = petersonChainGraph
 knownGraph Twenty = twentyChainGraph
 knownGraph HoffmanSingle = hoffmanSingletonGraph
-
--- | Useful for the binary encoding of a `ChainGraph` within a
--- `ChainwebVersion`.
---
-graphCode :: KnownGraph -> Word32
-graphCode Singleton = 0x00010000
-graphCode Pair = 0x00020000
-graphCode Triangle = 0x00030000
-graphCode Peterson = 0x00040000
-graphCode Twenty = 0x00050000
-graphCode HoffmanSingle = 0x00060000
 
 singletonChainGraph :: ChainGraph
 singletonChainGraph = toChainGraph (unsafeChainId . int) Singleton G.singleton

--- a/src/Chainweb/Miner/POW.hs
+++ b/src/Chainweb/Miner/POW.hs
@@ -291,7 +291,6 @@ usePowHash :: ChainwebVersion -> (forall a . HashAlgorithm a => Proxy a -> f) ->
 usePowHash Test{} f = f $ Proxy @SHA512t_256
 usePowHash TestWithTime{} f = f $ Proxy @SHA512t_256
 usePowHash TestWithPow{} f = f $ Proxy @SHA512t_256
-usePowHash Simulation{} f = f $ Proxy @SHA512t_256
 usePowHash Testnet00{} f = f $ Proxy @SHA512t_256
 
 -- | This Miner makes low-level assumptions about the chainweb protocol. It may

--- a/src/Chainweb/Pact/PactService.hs
+++ b/src/Chainweb/Pact/PactService.hs
@@ -73,7 +73,8 @@ import qualified Pact.Types.SQLite as P
 -- internal modules
 
 import Chainweb.BlockHash
-import Chainweb.BlockHeader (BlockHeader(..), BlockHeight(..), isGenesisBlockHeader)
+import Chainweb.BlockHeader
+    (BlockHeader(..), BlockHeight(..), isGenesisBlockHeader)
 import Chainweb.ChainId (ChainId, chainIdInt)
 import Chainweb.CutDB (CutDb)
 import Chainweb.Logger
@@ -103,7 +104,6 @@ pactDbConfig :: ChainwebVersion -> PactDbConfig
 pactDbConfig Test{} = PactDbConfig Nothing "log-unused" [] (Just 0) (Just 0)
 pactDbConfig TestWithTime{} = PactDbConfig Nothing "log-unused" [] (Just 0) (Just 0)
 pactDbConfig TestWithPow{} = PactDbConfig Nothing "log-unused" [] (Just 0) (Just 0)
-pactDbConfig Simulation{} = PactDbConfig Nothing "log-unused" [] (Just 0) (Just 0)
 pactDbConfig Testnet00 = PactDbConfig Nothing "log-unused" [] (Just 0) (Just 0)
 
 pactLogLevel :: String -> LogLevel
@@ -219,7 +219,6 @@ initialPayloadState :: ChainwebVersion -> ChainId -> PactServiceM ()
 initialPayloadState Test{} _ = return ()
 initialPayloadState v@TestWithTime{} cid = createCoinContract v cid
 initialPayloadState TestWithPow{} _ = return ()
-initialPayloadState Simulation{} _ = return ()
 initialPayloadState v@Testnet00 cid = createCoinContract v cid
 
 createCoinContract :: ChainwebVersion -> ChainId -> PactServiceM ()

--- a/src/Chainweb/PowHash.hs
+++ b/src/Chainweb/PowHash.hs
@@ -139,7 +139,6 @@ powHash :: ChainwebVersion -> B.ByteString -> PowHash
 powHash Test{} = cryptoHash @SHA512t_256
 powHash TestWithTime{} = cryptoHash @SHA512t_256
 powHash TestWithPow{} = cryptoHash @SHA512t_256
-powHash Simulation {}= cryptoHash @SHA512t_256
 powHash Testnet00 = cryptoHash @SHA512t_256
 
 cryptoHash :: forall a . HashAlgorithm a => B.ByteString -> PowHash

--- a/src/Chainweb/RestAPI/Orphans.hs
+++ b/src/Chainweb/RestAPI/Orphans.hs
@@ -249,8 +249,7 @@ instance ToParamSchema ChainwebVersion where
     toParamSchema _ = mempty
         & type_ .~ SwaggerString
         & enum_ ?~ (toJSON <$>
-            [ Simulation petersonChainGraph
-            , Test petersonChainGraph
+            [ Test petersonChainGraph
             , TestWithTime petersonChainGraph
             , TestWithPow petersonChainGraph
             , Testnet00

--- a/src/Chainweb/Version.hs
+++ b/src/Chainweb/Version.hs
@@ -217,46 +217,47 @@ chainwebVersionToText v@TestWithTime{} = "testWithTime-" <> sshow (chainwebVersi
 chainwebVersionToText v@TestWithPow{} = "testWithPow-" <> sshow (chainwebVersionId v)
 {-# INLINABLE chainwebVersionToText #-}
 
--- | Read textual representation of Chainweb Version
+-- | Read textual representation of a `ChainwebVersion`.
 --
 chainwebVersionFromText :: MonadThrow m => T.Text -> m ChainwebVersion
-
--- Production versions
---
-chainwebVersionFromText "testnet00" = return Testnet00
-
--- Well-known test version names.
---
--- These are only used for parsing textual representations. There is a very low
--- chance that a roundtrip test for the 'HasTextRepresentation' of
--- 'ChainwebVersion' will succeed due to these names.
---
-chainwebVersionFromText "test" = return $ Test petersonChainGraph
-chainwebVersionFromText "test-singleton" = return $ Test singletonChainGraph
-chainwebVersionFromText "test-peterson" = return $ Test petersonChainGraph
-
-chainwebVersionFromText "testWithTime" = return $ TestWithTime petersonChainGraph
-chainwebVersionFromText "testWithTime-singleton" = return $ TestWithTime singletonChainGraph
-chainwebVersionFromText "testWithTime-peterson" = return $ TestWithTime petersonChainGraph
-
-chainwebVersionFromText "testWithPow" = return $ TestWithPow petersonChainGraph
-chainwebVersionFromText "testWithPow-singleton" = return $ TestWithPow singletonChainGraph
-chainwebVersionFromText "testWithPow-peterson" = return $ TestWithPow petersonChainGraph
-
--- Generic test versions
---
-chainwebVersionFromText t = case T.breakOnEnd "-" t of
-    (_, i) -> case treadM i of
-        Left e -> throwM
-            $ TextFormatException $ "Unknown Chainweb version: \"" <> t <> "\": " <> sshow e
-        Right x -> return $ fromTestChainwebVersionId x
-{-# INLINABLE chainwebVersionFromText #-}
+chainwebVersionFromText t =
+    case HM.lookup t chainwebVersions of
+        Nothing -> throwM $ TextFormatException $ "Unknown Chainweb version: \"" <> t
+        Just v -> pure v
 
 instance HasTextRepresentation ChainwebVersion where
     toText = chainwebVersionToText
     {-# INLINE toText #-}
     fromText = chainwebVersionFromText
     {-# INLINE fromText #-}
+
+chainwebVersions :: HM.HashMap T.Text ChainwebVersion
+chainwebVersions = HM.fromList
+  [
+  -- Test
+    ("test-singleton", Test singletonChainGraph)
+  , ("test-pair", Test pairChainGraph)
+  , ("test-triangle", Test triangleChainGraph)
+  , ("test-peterson", Test petersonChainGraph)
+  , ("test-twenty", Test twentyChainGraph)
+  , ("test-hoffman-singleton", Test hoffmanSingletonGraph)
+  -- TestWithTime
+  , ("testWithTime-singleton", TestWithTime singletonChainGraph)
+  , ("testWithTime-pair", TestWithTime pairChainGraph)
+  , ("testWithTime-triangle", TestWithTime triangleChainGraph)
+  , ("testWithTime-peterson", TestWithTime petersonChainGraph)
+  , ("testWithTime-twenty", TestWithTime twentyChainGraph)
+  , ("testWithTime-hoffman-singleton", TestWithTime hoffmanSingletonGraph)
+  -- TestWithPow
+  , ("testWithPow-singleton", TestWithPow singletonChainGraph)
+  , ("testWithPow-pair", TestWithPow pairChainGraph)
+  , ("testWithPow-triangle", TestWithPow triangleChainGraph)
+  , ("testWithPow-peterson", TestWithPow petersonChainGraph)
+  , ("testWithPow-twenty", TestWithPow twentyChainGraph)
+  , ("testWithPow-hoffman-singleton", TestWithPow hoffmanSingletonGraph)
+  -- Testnet00
+  , ("testnet00", Testnet00)
+  ]
 
 -- -------------------------------------------------------------------------- --
 -- Test instances

--- a/src/Chainweb/Version.hs
+++ b/src/Chainweb/Version.hs
@@ -157,7 +157,6 @@ data ChainwebVersion
         --   * creationTime of BlockHeaders is actual time.
         --
 
-    | Simulation ChainGraph
     | Testnet00
     deriving (Eq, Ord, Generic)
     deriving anyclass (Hashable, NFData)
@@ -174,7 +173,6 @@ chainwebVersionId :: ChainwebVersion -> Word32
 chainwebVersionId v@Test{} = toTestChainwebVersion v 0x80000000
 chainwebVersionId v@TestWithTime{} = toTestChainwebVersion v 0x80000001
 chainwebVersionId v@TestWithPow{} = toTestChainwebVersion v 0x80000002
-chainwebVersionId v@Simulation{} = toTestChainwebVersion v 0x80000003
 chainwebVersionId Testnet00 = 0x00000001
 {-# INLINABLE chainwebVersionId #-}
 
@@ -217,7 +215,6 @@ chainwebVersionToText Testnet00 = "testnet00"
 chainwebVersionToText v@Test{} = "test-" <> sshow (chainwebVersionId v)
 chainwebVersionToText v@TestWithTime{} = "testWithTime-" <> sshow (chainwebVersionId v)
 chainwebVersionToText v@TestWithPow{} = "testWithPow-" <> sshow (chainwebVersionId v)
-chainwebVersionToText v@Simulation{} = "simulation-" <> sshow (chainwebVersionId v)
 {-# INLINABLE chainwebVersionToText #-}
 
 -- | Read textual representation of Chainweb Version
@@ -320,7 +317,6 @@ chainwebVersionGraph :: ChainwebVersion -> ChainGraph
 chainwebVersionGraph (Test g) = g
 chainwebVersionGraph (TestWithTime g) = g
 chainwebVersionGraph (TestWithPow g) = g
-chainwebVersionGraph (Simulation g) = g
 chainwebVersionGraph Testnet00 = petersonChainGraph
 
 instance HasChainGraph ChainwebVersion where
@@ -418,4 +414,3 @@ randomChainId :: HasChainwebVersion v => v -> IO ChainId
 randomChainId v = (!!) (toList cs) <$> randomRIO (0, length cs - 1)
   where
     cs = chainIds v
-

--- a/src/P2P/Peer.hs
+++ b/src/P2P/Peer.hs
@@ -448,8 +448,6 @@ bootstrapPeerInfos :: ChainwebVersion -> [PeerInfo]
 bootstrapPeerInfos Test{} = [testBootstrapPeerInfos]
 bootstrapPeerInfos TestWithTime{} = [testBootstrapPeerInfos]
 bootstrapPeerInfos TestWithPow{} = [testBootstrapPeerInfos]
-bootstrapPeerInfos Simulation{} = error
-    $ "bootstrap peer info isn't defined for chainweb version Simulation"
 bootstrapPeerInfos Testnet00 = testnet00BootstrapPeerInfo
 
 testBootstrapPeerInfos :: PeerInfo

--- a/test/Chainweb/Test/Orphans/Internal.hs
+++ b/test/Chainweb/Test/Orphans/Internal.hs
@@ -58,8 +58,6 @@ instance Arbitrary ChainwebVersion where
         , TestWithTime petersonChainGraph
         , TestWithPow singletonChainGraph
         , TestWithPow petersonChainGraph
-        , Simulation singletonChainGraph
-        , Simulation petersonChainGraph
         , Testnet00
         ]
 

--- a/test/Chainweb/Test/P2P/Peer/BootstrapConfig.hs
+++ b/test/Chainweb/Test/P2P/Peer/BootstrapConfig.hs
@@ -37,8 +37,6 @@ bootstrapPeerConfig :: ChainwebVersion -> [PeerConfig]
 bootstrapPeerConfig v@Test{} = testBootstrapPeerConfig v
 bootstrapPeerConfig v@TestWithTime{} = testBootstrapPeerConfig v
 bootstrapPeerConfig v@TestWithPow{} = testBootstrapPeerConfig v
-bootstrapPeerConfig Simulation{} = error
-    $ "bootstrap peer config isn't defined for chainweb version Simulation"
 bootstrapPeerConfig Testnet00 = error
     $ "bootstrap peer config isn't defined for chainweb version Testnet00"
 
@@ -65,9 +63,7 @@ bootstrapCertificate :: ChainwebVersion -> X509CertPem
 bootstrapCertificate Test{} = testBootstrapCertificate
 bootstrapCertificate TestWithTime{} = testBootstrapCertificate
 bootstrapCertificate TestWithPow{} = testBootstrapCertificate
-bootstrapCertificate Simulation{} = error
-    $ "bootstrap certificate isn't defined for chainweb version Simulation"
-bootstrapCertificate Testnet00  = error
+bootstrapCertificate Testnet00 = error
     $ "bootstrap certificate isn't defined for chainweb version Testnet00"
 
 -- | The test certificate is also stored in the file
@@ -123,8 +119,6 @@ bootstrapKey :: ChainwebVersion -> X509KeyPem
 bootstrapKey Test{} = testBootstrapKey
 bootstrapKey TestWithTime{} = testBootstrapKey
 bootstrapKey TestWithPow{} = testBootstrapKey
-bootstrapKey Simulation{} = error
-    $ "bootstrap key isn't defined for chainweb version Simulation"
 bootstrapKey Testnet00 = error
     $ "bootstrap key isn't defined for chainweb version Testnet00"
 


### PR DESCRIPTION
This PR allows the usage of `ChainwebVersion` text representations like `testWithTime-peterson` instead of `testWithTime-4075880449`. This applies to CLI flags, as well as JSON.

In turn, this fixes the "version `Map` priming" problem, which blocks further work elsewhere (#135).

The new accepted postfixes are:
- `-singleton`
- `-pair`
- `-triangle`
- `-peterson`
- `-twenty`
- `-hoffman-singleton`