### PR TITLE
Minimum Difficulty Adjustment Thresholds

### DIFF
--- a/src/Chainweb/TreeDB/Difficulty.hs
+++ b/src/Chainweb/TreeDB/Difficulty.hs
@@ -55,10 +55,9 @@ hashTarget db bh
                  & fmap fromJuste  -- Thanks to the two guard conditions above,
                                    -- this will (should) always succeed.
 
-        let
-            -- The time difference in microseconds between when the earliest and
-            -- latest blocks in the window were mined.
-            delta :: TimeSpan Int64
+        -- The time difference in microseconds between when the earliest and
+        -- latest blocks in the window were mined.
+        let delta :: TimeSpan Int64
             !delta = TimeSpan $ time bh' - time start
 
         pure . adjust ver delta $ _blockTarget bh'


### PR DESCRIPTION
From the Haddocks:

> Spikes in *HashRate* may occur as the mining network grows and shrinks. To ensure that adjustment does not occur too quickly or with too much granularity, we enforce a "minimum factor of change" (Z) for `adjust`. If `adjust` notices that the change for the given window is not large enough, then it will not occur. The overall pattern of difficulty then becomes less of a rippling pond, and more of a series of plateaus with distinct jumps. Analysis has been shown that Z should be greater than a factor of e=2.71828⋯ (source needed).

In particular, this change softens the effect of sudden addition / loss of mining power. For our current production `ChainwebVersion`s we set the minimum required change to be `3`. Therefore, on average (when we're already half way through a mining window), 4/5 of the miners would need to suddenly quit the network in order to decrease the difficulty at the next adjustment interval.