### PR TITLE
Pass --hide-successes to test suite

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -54,6 +54,7 @@ in
           doCheck = runTests;
           doHaddock = runTests;
           doCoverage = runCoverage;
+          testTarget = "--test-option=--hide-successes";
         }));
 
         configuration-tools = dontCheck (self.callHackage "configuration-tools" "0.4.0" {});


### PR DESCRIPTION
See this link for how this change looks in CI when there is a test failure:

https://gitlab.com/kadena-io/chainweb-node/-/jobs/208064271