### PR TITLE
[WIP] Mempool Experiments

### DIFF
--- a/chainweb.cabal
+++ b/chainweb.cabal
@@ -114,6 +114,7 @@ library
         , Chainweb.Logger
         , Chainweb.Mempool.InMem
         , Chainweb.Mempool.Mempool
+        , Chainweb.Mempool.P2pConfig
         , Chainweb.Mempool.RestAPI
         , Chainweb.Mempool.RestAPI.Client
         , Chainweb.Mempool.RestAPI.Server

--- a/src/Chainweb/Chainweb.hs
+++ b/src/Chainweb/Chainweb.hs
@@ -479,7 +479,7 @@ runChainweb cw = do
             clients = concat
                 [ miner
                 , cutNetworks mgr (_chainwebCutResources cw)
-                , map (runMempoolSyncClient mempoolMgr mempoolP2pConfig) chainVals
+                -- , map (runMempoolSyncClient mempoolMgr mempoolP2pConfig) chainVals
                 ]
 
         mapConcurrently_ id clients

--- a/src/Chainweb/Chainweb.hs
+++ b/src/Chainweb/Chainweb.hs
@@ -68,6 +68,7 @@ module Chainweb.Chainweb
 , chainwebPayloadDb
 , chainwebPactData
 , chainwebThrottler
+, chainwebConfig
 
 -- ** Mempool integration
 , ChainwebTransaction
@@ -122,6 +123,7 @@ import Chainweb.Graph
 import Chainweb.HostAddress
 import Chainweb.Logger
 import qualified Chainweb.Mempool.InMem as Mempool
+import Chainweb.Mempool.P2pConfig
 import Chainweb.Miner.Config
 import Chainweb.NodeId
 import qualified Chainweb.Pact.BloomCache as Bloom
@@ -172,6 +174,7 @@ data ChainwebConfiguration = ChainwebConfiguration
     , _configTransactionIndex :: !(EnableConfig TransactionIndexConfig)
     , _configIncludeOrigin :: !Bool
     , _configThrottleRate :: !Natural
+    , _configMempoolP2p :: !MempoolP2pConfig
     }
     deriving (Show, Eq, Generic)
 
@@ -194,6 +197,7 @@ defaultChainwebConfiguration v = ChainwebConfiguration
     , _configTransactionIndex = defaultEnableConfig defaultTransactionIndexConfig
     , _configIncludeOrigin = True
     , _configThrottleRate = 1000
+    , _configMempoolP2p = defaultMempoolP2pConfig
     }
 
 instance ToJSON ChainwebConfiguration where
@@ -205,6 +209,7 @@ instance ToJSON ChainwebConfiguration where
         , "transactionIndex" .= _configTransactionIndex o
         , "includeOrigin" .= _configIncludeOrigin o
         , "throttleRate" .= _configThrottleRate o
+        , "mempoolP2p" .= _configMempoolP2p o
         ]
 
 instance FromJSON (ChainwebConfiguration -> ChainwebConfiguration) where
@@ -216,6 +221,7 @@ instance FromJSON (ChainwebConfiguration -> ChainwebConfiguration) where
         <*< configTransactionIndex %.: "transactionIndex" % o
         <*< configIncludeOrigin ..: "includeOrigin" % o
         <*< configThrottleRate ..: "throttleRate" % o
+        <*< configMempoolP2p %.: "mempoolP2p" % o
 
 pChainwebConfiguration :: MParser ChainwebConfiguration
 pChainwebConfiguration = id
@@ -237,6 +243,7 @@ pChainwebConfiguration = id
     <*< configThrottleRate .:: option auto
         % long "throttle-rate"
         <> help "how many requests per second are accepted from another node before it is being throttled"
+    <*< configMempoolP2p %:: pMempoolP2pConfig
 
 -- -------------------------------------------------------------------------- --
 -- Chainweb Resources
@@ -253,6 +260,7 @@ data Chainweb logger cas = Chainweb
     , _chainwebManager :: !HTTP.Manager
     , _chainwebPactData :: [(ChainId, PactServerData logger cas)]
     , _chainwebThrottler :: !(Throttle Address)
+    , _chainwebConfig :: !ChainwebConfiguration
     }
 
 makeLenses ''Chainweb
@@ -294,6 +302,11 @@ withChainweb c logger rocksDb inner =
         | _p2pConfigIgnoreBootstrapNodes (_configP2p c) = c
         | otherwise = configP2p . p2pConfigKnownPeers <>~ bootstrapPeerInfos v $ c
 
+-- TODO: The type InMempoolConfig contains parameters that should be
+-- configurable as well as parameters that are determined by the chainweb
+-- version or the chainweb protocol. These should be separated in to two
+-- different types.
+--
 mempoolConfig :: Mempool.InMemConfig ChainwebTransaction
 mempoolConfig = Mempool.InMemConfig
     chainwebTransactionConfig
@@ -371,6 +384,7 @@ withChainwebInternal conf logger peer rocksDb inner = do
                     , _chainwebManager = mgr
                     , _chainwebPactData = pactData
                     , _chainwebThrottler = throttler
+                    , _chainwebConfig = conf
                     }
 
     withPactData cs cuts m
@@ -464,16 +478,12 @@ runChainweb cw = do
         let clients :: [IO ()]
             clients = concat
                 [ miner
-                    -- FIXME: should we start mining with some delay, so
-                    -- that the block header base is up to date?
                 , cutNetworks mgr (_chainwebCutResources cw)
-                -- , map (runChainSyncClient mgr) chainVals
-                    -- TODO: reenable once full payload and adjacent parent validation
-                    -- is implemented for ChainSyncClient
-                , map (runMempoolSyncClient mempoolMgr) chainVals
+                , map (runMempoolSyncClient mempoolMgr mempoolP2pConfig) chainVals
                 ]
 
         mapConcurrently_ id clients
         wait server
   where
     logg = logFunctionText $ _chainwebLogger cw
+    mempoolP2pConfig = _configMempoolP2p $ _chainwebConfig cw

--- a/src/Chainweb/Chainweb/ChainResources.hs
+++ b/src/Chainweb/Chainweb/ChainResources.hs
@@ -1,4 +1,6 @@
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
@@ -28,13 +30,13 @@ module Chainweb.Chainweb.ChainResources
 , runMempoolSyncClient
 ) where
 
+import Chainweb.Time
+
 import Control.Concurrent.MVar (MVar)
-import Control.Exception (SomeAsyncException)
 import Control.Lens hiding ((.=), (<.>))
 import Control.Monad
 import Control.Monad.Catch
 
-import Data.IORef
 import qualified Data.Text as T
 
 import GHC.Stack
@@ -59,6 +61,7 @@ import Chainweb.Logger
 import qualified Chainweb.Mempool.InMem as Mempool
 import Chainweb.Mempool.Mempool (MempoolBackend)
 import qualified Chainweb.Mempool.Mempool as Mempool
+import Chainweb.Mempool.P2pConfig
 import qualified Chainweb.Mempool.RestAPI.Client as MPC
 import Chainweb.Pact.Service.PactInProcApi
 import Chainweb.Payload
@@ -74,6 +77,7 @@ import Data.CAS
 import Data.CAS.RocksDB
 
 import P2P.Node
+import P2P.Node.Configuration
 import P2P.Session
 
 import qualified Servant.Client as Sv
@@ -175,15 +179,16 @@ runMempoolSyncClient
     :: Logger logger
     => HTTP.Manager
         -- ^ HTTP connection pool
+    -> MempoolP2pConfig
     -> ChainResources logger
         -- ^ chain resources
     -> IO ()
-runMempoolSyncClient mgr chain = bracket create destroy go
+runMempoolSyncClient mgr memP2pConfig chain = bracket create destroy go
   where
     create = do
         logg Debug "starting mempool p2p sync"
         p2pCreateNode v netId peer (logFunction syncLogger) peerDb mgr $
-            mempoolSyncP2pSession chain
+            mempoolSyncP2pSession chain (_mempoolP2pConfigPollInterval memP2pConfig)
     go n = do
         -- Run P2P client node
         logg Info "mempool sync p2p node initialized, starting session"
@@ -193,30 +198,27 @@ runMempoolSyncClient mgr chain = bracket create destroy go
 
     v = _chainwebVersion chain
     peer = _peerResPeer $ _chainResPeer chain
-    p2pConfig = _peerResConfig $ _chainResPeer chain
+    p2pConfig = _peerResConfig (_chainResPeer chain)
+        & set p2pConfigMaxSessionCount (_mempoolP2pConfigMaxSessionCount memP2pConfig)
+        & set p2pConfigSessionTimeout (_mempoolP2pConfigSessionTimeout memP2pConfig)
     peerDb = _peerResDb $ _chainResPeer chain
     netId = ChainNetwork $ _chainId chain
 
     logg = logFunctionText syncLogger
     syncLogger = setComponent "mempool-sync" $ _chainResLogger chain
 
-mempoolSyncP2pSession :: ChainResources logger -> P2pSession
-mempoolSyncP2pSession chain logg0 env _ = newIORef False >>= go
+mempoolSyncP2pSession :: ChainResources logger -> Seconds -> P2pSession
+mempoolSyncP2pSession chain pollInterval logg0 env _ =
+    flip catches [ Handler errorHandler ] $ do
+        logg Debug "mempool sync session starting"
+        Mempool.syncMempools' logg syncIntervalUs pool peerMempool
+        logg Debug "mempool sync session finished"
+        return True
   where
-    syncIntervalUs = 10000000
-    go ref = flip catches [ Handler (asyncHandler ref) , Handler errorHandler ] $ do
-             logg Debug "mempool sync session starting"
-             Mempool.syncMempools' logg syncIntervalUs pool peerMempool (writeIORef ref True)
-             logg Debug "mempool sync session finished"
-             readIORef ref
+    syncIntervalUs = int pollInterval * 1000000
 
     remote = T.pack $ Sv.showBaseUrl $ Sv.baseUrl env
     logg d m = logg0 d $ T.concat ["[mempool sync@", remote, "]:", m]
-
-    asyncHandler ref (_ :: SomeAsyncException) = do
-        logg Debug "mempool sync session cancelled"
-        -- We return True (ok) iff the mempool successfully finished initial sync.
-        readIORef ref
 
     errorHandler (e :: SomeException) = do
         logg Warn ("mempool sync session failed: " <> sshow e)

--- a/src/Chainweb/Mempool/InMem.hs
+++ b/src/Chainweb/Mempool/InMem.hs
@@ -343,8 +343,7 @@ reaperThread cfg dataLock restore = forever $ do
 
 ------------------------------------------------------------------------------
 toMempoolBackend :: InMemoryMempool t -> MempoolBackend t
-toMempoolBackend (InMemoryMempool cfg@(InMemConfig tcfg blockSizeLimit _)
-                                  lock broadcaster _) =
+toMempoolBackend (InMemoryMempool cfg lock broadcaster _) =
   MempoolBackend
     { mempoolTxConfig = tcfg
     , mempoolBlockGasLimit = blockSizeLimit
@@ -362,6 +361,7 @@ toMempoolBackend (InMemoryMempool cfg@(InMemConfig tcfg blockSizeLimit _)
     }
 
   where
+    InMemConfig tcfg blockSizeLimit _ = cfg
     member = memberInMem lock
     lookup = lookupInMem lock
     insert = insertInMem broadcaster cfg lock

--- a/src/Chainweb/Mempool/Mempool.hs
+++ b/src/Chainweb/Mempool/Mempool.hs
@@ -293,7 +293,7 @@ syncMempools' log0 us localMempool remoteMempool =
         (SyncState numMissingFromLocal missingChunks remoteHashes _) <- readIORef syncState
 
         deb $ T.concat
-            [ sshow (fromIntegral $ HashSet.size remoteHashes)
+            [ sshow (HashSet.size remoteHashes)
             , " hashes at remote ("
             , sshow numMissingFromLocal
             , " need to be fetched)"

--- a/src/Chainweb/Mempool/Mempool.hs
+++ b/src/Chainweb/Mempool/Mempool.hs
@@ -31,6 +31,7 @@ module Chainweb.Mempool.Mempool
   ) where
 ------------------------------------------------------------------------------
 import Control.Concurrent (threadDelay)
+import Control.Concurrent.Async (concurrently)
 import Control.Concurrent.STM.TBMChan (TBMChan)
 import Control.DeepSeq (NFData)
 import Control.Exception
@@ -46,7 +47,7 @@ import Data.ByteString.Char8 (ByteString)
 import qualified Data.ByteString.Char8 as B
 import Data.Decimal (Decimal)
 import Data.Decimal (DecimalRaw(..))
-import Data.Foldable (foldl', traverse_)
+import Data.Foldable (traverse_)
 import Data.Hashable (Hashable(hashWithSalt))
 import Data.HashSet (HashSet)
 import qualified Data.HashSet as HashSet
@@ -200,44 +201,69 @@ data SyncState = SyncState {
 --
 -- The sync procedure:
 --
---    1. begin subscription with remote's mempool
---    2. get the list of pending transaction hashes from remote.
---    3. lookup any hashes that are missing, and insert them into local
---    4. push any hashes remote is missing
---    5. block forever, waiting to be killed (subscription will still be active.)
+--    1. get the list of pending transaction hashes from remote,
+--    2. lookup any hashes that are missing, and insert them into local,
+--    3. push any hashes remote is missing,
+--    4. sleep the given number of microseconds.
 --
--- Blocks until killed, or until the underlying mempool connection throws an
+-- Loops until killed, or until the underlying mempool connection throws an
 -- exception.
-
+--
 syncMempools'
     :: Show t
     => LogFunctionText
-    -> Int                  -- ^ polling interval in microseconds
-    -> MempoolBackend t     -- ^ local mempool
-    -> MempoolBackend t     -- ^ remote mempool
-    -> IO ()                -- ^ on initial sync complete
+    -> Int
+        -- ^ polling interval in microseconds
+    -> MempoolBackend t
+        -- ^ local mempool
+    -> MempoolBackend t
+        -- ^ remote mempool
     -> IO ()
-syncMempools' log0 us localMempool remoteMempool onInitialSyncComplete =
+syncMempools' log0 us localMempool remoteMempool =
     runForever log0 "mempool-sync-session" $ sync >> threadDelay us
 
   where
-    maxCnt = 10000   -- don't pull more than this many new transactions from a
-                     -- single peer in a session.
+    maxCnt = 10000
+        -- don't pull more than this many new transactions from a single peer in
+        -- a session.
 
-    syncChunk missing hashes = do
-        (SyncState cnt chunks presentAtRemote tooMany) <- readIORef missing
-        res <- (`V.zip` hashes) <$> mempoolMember localMempool hashes
-        let !newMissing = V.map snd $ V.filter (not . fst) res
-        let !newMissingCnt = V.length newMissing
+    -- This function is called for each chunk of pending hashes in the the remote mempool.
+    --
+    -- The 'SyncState' collects
+    -- * the total count of hashes that are missing from the local pool,
+    -- * chunks of hashes that are missing from the local pool,
+    -- * the set of hashes that is available locally but missing from the remote pool, and
+    -- * whether there are @tooMany@ missing hashes.
+    --
+    -- When we already collected @tooMany@ missing hashes we stop updating the sync state
+    --
+    -- TODO: would it help if 'mempoolGetPendingTransactions' would provide an option for early
+    -- termination in case we got @tooMany@ missing hashes?
+    --
+    syncChunk syncState hashes = do
+        (SyncState cnt chunks remoteHashes tooMany) <- readIORef syncState
+
+        -- If there are too many missing hashes we stop collecting
+        --
         when (not tooMany) $ do
-            let !presentAtRemote' = V.foldl' (flip HashSet.insert) presentAtRemote hashes
+
+            -- Collect remote hashes that are missing from the local pool
+            res <- (`V.zip` hashes) <$> mempoolMember localMempool hashes
+            let !newMissing = V.map snd $ V.filter (not . fst) res
+            let !newMissingCnt = V.length newMissing
+
+            -- Collect set of all remote hashes
+            let !remoteHashes' = V.foldl' (flip HashSet.insert) remoteHashes hashes
+
+            -- Count number of missing hashes and decide if there @tooMany@
             let !newCnt = cnt + fromIntegral newMissingCnt
             let !tooMany' = (newCnt >= maxCnt)
 
-            writeIORef missing $!
+            -- Update the SyncState
+            writeIORef syncState $!
                 if tooMany'
-                    then SyncState cnt chunks presentAtRemote True
-                    else SyncState newCnt (newMissing : chunks) presentAtRemote' False
+                    then SyncState cnt chunks remoteHashes True
+                    else SyncState newCnt (newMissing : chunks) remoteHashes' False
 
     fromPending (Pending t) = t
     fromPending _ = error "impossible"
@@ -251,55 +277,53 @@ syncMempools' log0 us localMempool remoteMempool onInitialSyncComplete =
         mempoolInsert localMempool newTxs
 
     log :: Text -> IO ()
-    log = log0 Info             -- TODO: some of these messages should be
-                                -- "debug" but we're ok with overlogging for
-                                -- now.
+    log = log0 Info
+        -- TODO: some of these messages should be "debug" but we're ok with
+        -- overlogging for now.
+
     deb :: Text -> IO ()
     deb = log0 Debug
 
     sync = flip finally (log "sync finished") $ do
         deb "Get pending hashes from remote"
-        missing <- newIORef $! SyncState 0 [] HashSet.empty False
-        mempoolGetPendingTransactions remoteMempool $ syncChunk missing
-        (SyncState _ missingChunks presentHashes _) <- readIORef missing
 
-        let numMissingFromLocal = foldl' (+) 0 (map V.length missingChunks)
-        let numPresentAtRemote = HashSet.size presentHashes
+        -- Intialize and collect SyncState
+        syncState <- newIORef $! SyncState 0 [] HashSet.empty False
+        mempoolGetPendingTransactions remoteMempool $ syncChunk syncState
+        (SyncState numMissingFromLocal missingChunks remoteHashes _) <- readIORef syncState
 
-        deb $ T.concat [
-            sshow (numMissingFromLocal + numPresentAtRemote)
-          , " hashes at remote ("
-          , sshow numMissingFromLocal
-          , " need to be fetched)"
-          ]
+        deb $ T.concat
+            [ sshow (fromIntegral $ HashSet.size remoteHashes)
+            , " hashes at remote ("
+            , sshow numMissingFromLocal
+            , " need to be fetched)"
+            ]
 
-        -- Go fetch missing transactions from remote
-        traverse_ fetchMissing missingChunks
+        numPushed <- fmap snd $ concurrently
 
-        -- Push our missing txs to remote.
-        numPushed <- push presentHashes
-        deb $ T.concat [
-            "pushed "
-          , sshow numPushed
-          , " new transactions to remote."
-          ]
+            -- Go fetch missing transactions from remote
+            (traverse_ fetchMissing missingChunks)
 
-        -- We're done syncing. If we cut off the sync session because of too
-        -- many remote txs, we are free to go now, but otherwise we'll block
-        -- indefinitely waiting for the p2p session to kill us (and slurping
-        -- from the remote subscription queue).
-        onInitialSyncComplete
+            -- Push our missing txs to remote.
+            (push remoteHashes)
+
+        deb $ "pushed " <> sshow numPushed <> " new transactions to remote."
         log "sync complete, sleeping"
 
-    push presentHashes = do
+    -- Push transactions that are available locally but are missing from the
+    -- remote pool to the remote pool.
+    --
+    push remoteHashes = do
         ref <- newIORef 0
         mempoolGetPendingTransactions localMempool $ \chunk -> do
-            let chunk' = V.filter (not . flip HashSet.member presentHashes) chunk
+            let chunk' = V.filter (not . flip HashSet.member remoteHashes) chunk
             when (not $ V.null chunk') $ do
                 sendChunk chunk'
                 modifyIORef' ref (+ V.length chunk')
         readIORef ref
 
+    -- Send a chunk of tranactions to the remote pool.
+    --
     sendChunk chunk = do
         v <- (V.map fromPending . V.filter isPending) <$> mempoolLookup localMempool chunk
         when (not $ V.null v) $ mempoolInsert remoteMempool v
@@ -313,7 +337,7 @@ syncMempools
     -> MempoolBackend t     -- ^ remote mempool
     -> IO ()
 syncMempools log us localMempool remoteMempool =
-    syncMempools' log us localMempool remoteMempool (return ())
+    syncMempools' log us localMempool remoteMempool
 
 ------------------------------------------------------------------------------
 -- | Raw/unencoded transaction hashes.

--- a/src/Chainweb/Mempool/P2pConfig.hs
+++ b/src/Chainweb/Mempool/P2pConfig.hs
@@ -1,0 +1,87 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TemplateHaskell #-}
+
+-- |
+-- Module: Chainweb.Mempool.P2pConfig
+-- Copyright: Copyright © 2019 Kadena LLC.
+-- License: MIT
+-- Maintainer: Lars Kuhtz <lars@kadena.io>
+-- Stability: experimental
+--
+-- P2p Configuration for the Mempool.
+--
+module Chainweb.Mempool.P2pConfig
+( MempoolP2pConfig(..)
+, mempoolP2pConfigMaxSessionCount
+, mempoolP2pConfigSessionTimeout
+, mempoolP2pConfigPollInterval
+, defaultMempoolP2pConfig
+, pMempoolP2pConfig
+) where
+
+import Configuration.Utils
+
+import Control.Lens.TH
+
+import GHC.Generics
+
+import Numeric.Natural
+
+-- internal modules
+
+import Chainweb.Time
+import Chainweb.Utils
+
+data MempoolP2pConfig = MempoolP2pConfig
+    { _mempoolP2pConfigMaxSessionCount :: !Natural
+        -- ^ max session count
+    , _mempoolP2pConfigSessionTimeout :: !Seconds
+        -- ^ timeout in seconds
+    , _mempoolP2pConfigPollInterval :: !Seconds
+    }
+    deriving (Show, Eq, Ord, Generic)
+
+makeLenses ''MempoolP2pConfig
+
+defaultMempoolP2pConfig :: MempoolP2pConfig
+defaultMempoolP2pConfig = MempoolP2pConfig
+    { _mempoolP2pConfigMaxSessionCount = 6
+    , _mempoolP2pConfigSessionTimeout = 120
+    , _mempoolP2pConfigPollInterval = 30
+    }
+
+instance ToJSON MempoolP2pConfig where
+    toJSON o = object
+        [ "maxSessionCount" .= _mempoolP2pConfigMaxSessionCount o
+        , "sessionTimeout" .= _mempoolP2pConfigSessionTimeout o
+        , "pollInterval" .= _mempoolP2pConfigPollInterval o
+        ]
+
+instance FromJSON (MempoolP2pConfig -> MempoolP2pConfig) where
+    parseJSON = withObject "MempoolP2pConfig" $ \o -> id
+        <$< mempoolP2pConfigMaxSessionCount ..: "maxSessionCount" % o
+        <*< mempoolP2pConfigSessionTimeout ..: "sessionTimeout" % o
+        <*< mempoolP2pConfigPollInterval ..: "pollInterval" % o
+
+instance FromJSON MempoolP2pConfig where
+    parseJSON = withObject "P2pExampleConfig" $ \o -> MempoolP2pConfig
+        <$> o .: "maxSessionCount"
+        <*> o .: "sessionTimeout"
+        <*> o .: "pollInterval"
+
+pMempoolP2pConfig :: MParser MempoolP2pConfig
+pMempoolP2pConfig = id
+    <$< mempoolP2pConfigMaxSessionCount .:: option auto
+        % long "mempool-p2p-max-session-count"
+        <> help "maximum number of sessions that are active at any time"
+    <*< mempoolP2pConfigSessionTimeout .:: textOption
+        % long "mempool-p2p-session-timeout"
+        <> help "timeout for sessions in seconds"
+    <*< mempoolP2pConfigPollInterval .:: textOption
+        % long "mempool-p2p-poll-interval"
+        <> help "poll interval for synchronizing mempools in seconds"
+

--- a/src/Chainweb/Mempool/RestAPI/Client.hs
+++ b/src/Chainweb/Mempool/RestAPI/Client.hs
@@ -107,7 +107,9 @@ toMempool version chain txcfg blocksizeLimit env =
             let finalize = Async.uninterruptibleCancel t
             let sub = Subscription chan finalize
             r <- newIORef sub
-            void $ mkWeakIORef r finalize
+            void $ mkWeakIORef r $ do
+                putStrLn "{\"action\": \"finalize\", \"location\": \"Chainweb.Mempool.RestAPI.Client.toMempool\" }"
+                finalize
             return r
         -- make sure subscription is initialized before returning.
         takeMVar mv
@@ -293,7 +295,7 @@ asIoStream (ResultStream func) withFunc = func $ \popper -> do
 
 
 instance Show a => BuildFromStream a (Streams.InputStream a) where
-  buildFromStream rs = let out = unsafePerformIO go
+  buildFromStream rs = let out = unsafePerformIO go -- TODO cancel chanThead if stream is canceled?
                        in out `seq` out
     where
       createThread = do
@@ -301,7 +303,9 @@ instance Show a => BuildFromStream a (Streams.InputStream a) where
           t <- Async.asyncWithUnmask (chanThread chan)
           Async.link t
           ref <- newIORef (chan, t)
-          wk <- mkWeakIORef ref (Async.uninterruptibleCancel t)
+          wk <- mkWeakIORef ref $ do
+              putStrLn "{\"action\": \"finalize\", \"location\": \"Chainweb.Mempool.RestAPI.Client.BuildFromString\" }"
+              Async.uninterruptibleCancel t
           return $! (ref, wk)
 
       chanThread chan restore =

--- a/src/Chainweb/Mempool/RestAPI/Server.hs
+++ b/src/Chainweb/Mempool/RestAPI/Server.hs
@@ -84,7 +84,9 @@ getPendingHandler mempool = liftIO $ mask_ $ do
         Async.link t
         let d = GpData chan t
         !ref <- newIORef d
-        !wk <- mkWeakIORef ref (Async.uninterruptibleCancel t)
+        !wk <- mkWeakIORef ref $ do
+            putStrLn "{\"action\": \"finalize\", \"location\": \"Chainweb.Mempool.RestAPI.Server.getPendingHandler\" }"
+            Async.uninterruptibleCancel t
         return $! (ref, wk)
 
     chanThread chan restore =


### PR DESCRIPTION
DON'T MERGE INTO MASTER. This PR contains code for experimenting with the Mempool.

* Log invocation of finalizers of weak references to stdout.
* Disable subscriptions in sync sessions. Instead get pending tx from remote every 10 seconds.

The following logstash configuration can be used to forward the finalizer logs to Elasticsearch:

```yams
input {
    stdin {
        add_field => {
            "IP" => "${MY_IP}"
        }
        codec => "line"
        tags => []
    }
}

filter {
    json {
        source => "message"
    }
}

output {
    elasticsearch {
        hosts => [ "${ESHOST}:80" ]
        index => "connectionpool-%{+YYYY.MM.dd}"
    }
    # stdout {}
}
```

Assuming the environment variables `MY_IP`, `MY_PORT`, and `ESHOST` are set, it can be used like:

```sh
chainweb-node --chainweb-version testnet01 --log-handle=es:$ESHOST:80 --hostname=$MY_IP --port=$MY_PORT --telemetry-log-handle=es:$ESHOST:80 | logstash -f logstash.yaml
```