### PR TITLE
use HsOpenSSL for HTTPS

### DIFF
--- a/chainweb.cabal
+++ b/chainweb.cabal
@@ -320,6 +320,9 @@ library
         , yaml >= 0.11
         , yet-another-logger >= 0.3.1
 
+        , HsOpenSSL >= 0.11
+        , http-client-openssl
+
     if flag(tls13)
         cpp-options: -DWITH_TLS13=1
 


### PR DESCRIPTION
This PR has been tested on Testnet. What would be missing before it could be used in production is integration of certificate validation for chainweb-node self-signed certificates.