### PR TITLE
War on thunks

### DIFF
--- a/src/Chainweb/BlockHash.hs
+++ b/src/Chainweb/BlockHash.hs
@@ -128,7 +128,7 @@ encodeBlockHash (BlockHash bytes) = encodeMerkleLogHash bytes
 {-# INLINE encodeBlockHash #-}
 
 decodeBlockHash :: MonadGet m => m BlockHash
-decodeBlockHash = BlockHash <$> decodeMerkleLogHash
+decodeBlockHash = BlockHash <$!> decodeMerkleLogHash
 {-# INLINE decodeBlockHash #-}
 
 instance ToJSON BlockHash where
@@ -151,7 +151,7 @@ instance FromJSONKey BlockHash where
     {-# INLINE fromJSONKey #-}
 
 randomBlockHash :: MonadIO m => m BlockHash
-randomBlockHash = BlockHash <$> randomMerkleLogHash
+randomBlockHash = BlockHash <$!> randomMerkleLogHash
 {-# INLINE randomBlockHash #-}
 
 nullBlockHash :: BlockHash
@@ -204,7 +204,7 @@ encodeBlockHashRecord (BlockHashRecord r) = do
 decodeBlockHashWithChainId
     :: MonadGet m
     => m (ChainId, BlockHash)
-decodeBlockHashWithChainId = (,) <$> decodeChainId <*> decodeBlockHash
+decodeBlockHashWithChainId = (,) <$!> decodeChainId <*> decodeBlockHash
 
 decodeBlockHashRecord :: MonadGet m => m BlockHashRecord
 decodeBlockHashRecord = do
@@ -219,7 +219,7 @@ decodeBlockHashWithChainIdChecked
     => Expected p
     -> m (ChainId, BlockHash)
 decodeBlockHashWithChainIdChecked p = (,)
-    <$> decodeChainIdChecked p
+    <$!> decodeChainIdChecked p
     <*> decodeBlockHash
 
 -- to use this wrap the runGet into some MonadThrow.
@@ -231,9 +231,9 @@ decodeBlockHashRecordChecked
     => Expected [p]
     -> m BlockHashRecord
 decodeBlockHashRecordChecked ps = do
-    (l :: Natural) <- int <$> getWord16le
+    (l :: Natural) <- int <$!> getWord16le
     void $ check ItemCountDecodeException (int . length <$> ps) (Actual l)
-    hashes <- mapM decodeBlockHashWithChainIdChecked (Expected <$> getExpected ps)
+    hashes <- mapM decodeBlockHashWithChainIdChecked (Expected <$!> getExpected ps)
     return $ BlockHashRecord $ HM.fromList $ hashes
 
 blockHashRecordToSequence :: BlockHashRecord -> S.Seq BlockHash

--- a/src/Chainweb/BlockHash.hs
+++ b/src/Chainweb/BlockHash.hs
@@ -210,7 +210,7 @@ decodeBlockHashRecord :: MonadGet m => m BlockHashRecord
 decodeBlockHashRecord = do
     l <- getWord16le
     hashes <- mapM (const decodeBlockHashWithChainId) [1 .. l]
-    return $ BlockHashRecord $ HM.fromList $ hashes
+    return $! BlockHashRecord $! HM.fromList hashes
 
 decodeBlockHashWithChainIdChecked
     :: MonadGet m
@@ -234,7 +234,7 @@ decodeBlockHashRecordChecked ps = do
     (l :: Natural) <- int <$!> getWord16le
     void $ check ItemCountDecodeException (int . length <$> ps) (Actual l)
     hashes <- mapM decodeBlockHashWithChainIdChecked (Expected <$!> getExpected ps)
-    return $ BlockHashRecord $ HM.fromList $ hashes
+    return $! BlockHashRecord $! HM.fromList hashes
 
 blockHashRecordToSequence :: BlockHashRecord -> S.Seq BlockHash
 blockHashRecordToSequence = S.fromList . fmap snd . sort . HM.toList . _getBlockHashRecord

--- a/src/Chainweb/BlockHeader.hs
+++ b/src/Chainweb/BlockHeader.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DeriveGeneric #-}
@@ -508,7 +509,7 @@ decodeBlockHeaderChecked
     => MonadGet m
     => m BlockHeader
 decodeBlockHeaderChecked = do
-    bh <- decodeBlockHeader
+    !bh <- decodeBlockHeader
     _ <- checkAdjacentChainIds bh bh (Expected $ _blockAdjacentChainIds bh)
     return bh
 
@@ -525,7 +526,7 @@ decodeBlockHeaderCheckedChainId
     => Expected p
     -> m BlockHeader
 decodeBlockHeaderCheckedChainId p = do
-    bh <- decodeBlockHeaderChecked
+    !bh <- decodeBlockHeaderChecked
     _ <- checkChainId p (Actual (_chainId bh))
     return bh
 
@@ -547,7 +548,7 @@ decodeBlockHeaderWithoutHash = do
     a9 <- decodeChainwebVersion
     a10 <- decodeChainNodeId
     return
-        $ fromLog
+        $! fromLog
         $ newMerkleLog
         $ a0
         :+: a1
@@ -587,7 +588,7 @@ instance FromJSON BlockHeader where
     parseJSON = withText "BlockHeader" $ \t ->
         case runGet decodeBlockHeader =<< decodeB64UrlNoPaddingText t of
             Left (e :: SomeException) -> fail (sshow e)
-            Right x -> return x
+            (Right !x) -> return x
 
 _blockAdjacentChainIds :: BlockHeader -> HS.HashSet ChainId
 _blockAdjacentChainIds =

--- a/src/Chainweb/BlockHeader/Validation.hs
+++ b/src/Chainweb/BlockHeader/Validation.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
@@ -140,7 +141,7 @@ validateAdditionsM lookupParent as = traverse_ (validateEntryM lookupParent') as
   where
     lookupParent' h = case HM.lookup h as of
         Nothing -> lookupParent h
-        p -> return p
+        !p -> return p
 
 -- -------------------------------------------------------------------------- --
 -- Validate with Lookup Function
@@ -174,10 +175,10 @@ validateInductiveInternal
     -> BlockHeader
     -> m [ValidationFailureType]
 validateInductiveInternal lookupParent b
-    | isGenesisBlockHeader b = return (validateParent b b)
+    | isGenesisBlockHeader b = return $! validateParent b b
     | otherwise = lookupParent (_blockParent b) >>= \case
         Nothing -> return [MissingParent]
-        Just p -> return $ validateParent p b
+        (Just !p) -> return $! validateParent p b
 
 -- -------------------------------------------------------------------------- --
 -- Validate BlockHeaders

--- a/src/Chainweb/BlockHeaderDB.hs
+++ b/src/Chainweb/BlockHeaderDB.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
@@ -259,7 +260,7 @@ initBlockHeaderDb config = do
         (Codec (runPut . encodeBlockHash) (runGet decodeBlockHash))
         ["BlockHeader", cidNs, "rank"]
 
-    db = BlockHeaderDb cid
+    !db = BlockHeaderDb cid
         (_chainwebVersion rootEntry)
         (_configRocksDb config)
         headerTable
@@ -299,7 +300,7 @@ instance TreeDb BlockHeaderDb where
         -- lookup header
         rh <- MaybeT $ casLookup (_chainDbCas db) $ RankedBlockHash r h
 
-        return $ _getRankedBlockHeader rh
+        return $! _getRankedBlockHeader rh
     {-# INLINEABLE lookup #-}
 
     entries db k l mir mar f = withSeekTreeDb db k mir $ \it -> f $ do
@@ -322,7 +323,7 @@ instance TreeDb BlockHeaderDb where
     maxEntry db = withTableIter (_chainDbCas db) $ \it -> do
         tableIterLast it
         tableIterValue it >>= \case
-            Just (RankedBlockHeader r) -> return r
+            Just (RankedBlockHeader !r) -> return r
             Nothing -> throwM
                 $ InternalInvariantViolation "BlockHeaderDb.maxEntry: empty block header db"
     {-# INLINEABLE maxEntry #-}
@@ -330,7 +331,7 @@ instance TreeDb BlockHeaderDb where
     maxRank db = withTableIter (_chainDbCas db) $ \it -> do
         tableIterLast it
         tableIterKey it >>= \case
-            Just (RankedBlockHash r _) -> return (int r)
+            Just (RankedBlockHash !r _) -> return $! int r
             Nothing -> throwM
                 $ InternalInvariantViolation "BlockHeaderDb.maxRank: empty block header db"
     {-# INLINEABLE maxRank #-}
@@ -362,7 +363,7 @@ seekTreeDb
     -> Maybe MinRank
     -> IO (RocksDbTableIter RankedBlockHash RankedBlockHeader)
 seekTreeDb db k mir = do
-    it <- createTableIter (_chainDbCas db)
+    !it <- createTableIter (_chainDbCas db)
     case k of
         Nothing -> case mir of
             Nothing -> return ()
@@ -375,7 +376,7 @@ seekTreeDb db k mir = do
             let x = _getNextItem a
             r <- tableLookup (_chainDbRankTable db) x >>= \case
                 Nothing -> throwM $ TreeDbKeyNotFound @BlockHeaderDb x
-                Just b -> return b
+                (Just !b) -> return b
             tableIterSeek it (RankedBlockHash r x)
 
             -- if we don't find the cursor, throw exception

--- a/src/Chainweb/BlockHeaderDB.hs
+++ b/src/Chainweb/BlockHeaderDB.hs
@@ -107,7 +107,7 @@ encodeRankedBlockHeader = encodeBlockHeader . _getRankedBlockHeader
 {-# INLINE encodeRankedBlockHeader #-}
 
 decodeRankedBlockHeader :: MonadGet m => m RankedBlockHeader
-decodeRankedBlockHeader = RankedBlockHeader <$> decodeBlockHeader
+decodeRankedBlockHeader = RankedBlockHeader <$!> decodeBlockHeader
 {-# INLINE decodeRankedBlockHeader #-}
 
 -- -------------------------------------------------------------------------- --
@@ -128,7 +128,7 @@ encodeRankedBlockHash (RankedBlockHash r bh) = do
 
 decodeRankedBlockHash :: MonadGet m => m RankedBlockHash
 decodeRankedBlockHash = RankedBlockHash
-    <$> decodeBlockHeightBe
+    <$!> decodeBlockHeightBe
     <*> decodeBlockHash
 {-# INLINE decodeRankedBlockHash #-}
 
@@ -402,7 +402,7 @@ insertBlockHeaderDb :: BlockHeaderDb -> [E] -> IO ()
 insertBlockHeaderDb db es = do
 
     -- Validate set of additions
-    validateAdditionsDbM db $ HM.fromList $ (key &&& id) <$> es
+    validateAdditionsDbM db $ HM.fromList $ (key &&& id) <$!> es
 
     -- add set of additions to database
     mapM_ (dbAddChecked db) rankedAdditions

--- a/src/Chainweb/BlockHeaderDB/RestAPI/Server.hs
+++ b/src/Chainweb/BlockHeaderDB/RestAPI/Server.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
@@ -65,7 +66,7 @@ checkKey
     => db
     -> DbKey db
     -> m (DbKey db)
-checkKey db k = liftIO (lookup db k) >>= \case
+checkKey !db !k = liftIO (lookup db k) >>= \case
     Nothing -> throwError $ err404Msg $ object
         [ "reason" .= ("key not found" :: String)
         , "key" .= (sshow k :: String)

--- a/src/Chainweb/Chainweb/ChainResources.hs
+++ b/src/Chainweb/Chainweb/ChainResources.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
@@ -168,7 +169,7 @@ replayPact logger pact cdb pdb = do
   where
     payload h = casLookup pdb (_blockPayloadHash h) >>= \case
         Nothing -> error $ "Corrupted database: failed to load payload data for block header " <> sshow h
-        Just p -> return $ payloadWithOutputsToPayloadData p
+        (Just !p) -> return $! payloadWithOutputsToPayloadData p
 
     logg = logFunctionText (setComponent "pact-tx-replay" logger)
 

--- a/src/Chainweb/Chainweb/CutResources.hs
+++ b/src/Chainweb/Chainweb/CutResources.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
@@ -194,7 +195,7 @@ mkCutNetworkSync mgr cuts label cutSync = bracket create destroy $ \n ->
     s = _cutResSyncSession cutSync
 
     create = do
-        n <- p2pCreateNode v CutNetwork peer (logFunction logger) peerDb mgr s
+        !n <- p2pCreateNode v CutNetwork peer (logFunction logger) peerDb mgr s
         logFunctionText logger Info $ label <> ": initialized"
         return n
 

--- a/src/Chainweb/Chainweb/PeerResources.hs
+++ b/src/Chainweb/Chainweb/PeerResources.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE OverloadedStrings #-}
@@ -132,11 +133,11 @@ peerServerSettings peer
 
 allocateSocket :: P2pConfiguration -> IO (P2pConfiguration, Socket)
 allocateSocket conf = do
-    (p, sock) <- bindPortTcp
+    (!p, !sock) <- bindPortTcp
         (_peerConfigPort $ _p2pConfigPeer conf)
         (_peerConfigInterface $ _p2pConfigPeer conf)
-    let conf' = set (p2pConfigPeer . peerConfigPort) p conf
-    return (conf', sock)
+    let !conf' = set (p2pConfigPeer . peerConfigPort) p conf
+    return $! (conf', sock)
 
 deallocateSocket :: (P2pConfiguration, Socket) -> IO ()
 deallocateSocket (_, sock) = close sock
@@ -223,9 +224,9 @@ withConnectionManger logger certs key peerDb runInner = do
     certCacheLookup :: ServiceID -> IO (Maybe Fingerprint)
     certCacheLookup si = do
         ha <- serviceIdToHostAddress si
-        pe <- getOne . getEQ ha <$> peerDbSnapshot peerDb
-        return $ pe >>= fmap peerIdToFingerprint . _peerId . _peerEntryInfo
+        pe <- getOne . getEQ ha <$!> peerDbSnapshot peerDb
+        return $! pe >>= fmap peerIdToFingerprint . _peerId . _peerEntryInfo
 
     serviceIdToHostAddress (h, p) = HostAddress
-        <$> readHostnameBytes (B8.pack h)
+        <$!> readHostnameBytes (B8.pack h)
         <*> readPortBytes p

--- a/src/Chainweb/Cut/CutHashes.hs
+++ b/src/Chainweb/Cut/CutHashes.hs
@@ -47,7 +47,8 @@ module Chainweb.Cut.CutHashes
 import Control.Applicative
 import Control.Arrow
 import Control.DeepSeq
-import Control.Lens (Getter, to, view, makeLenses)
+import Control.Lens (Getter, makeLenses, to, view)
+import Control.Monad ((<$!>))
 import Control.Monad.Catch
 
 import qualified Crypto.Hash as C
@@ -114,7 +115,7 @@ cutIdBytes (CutId bytes) = bytes
 {-# INLINE cutIdBytes #-}
 
 decodeCutId :: MonadGet m => m CutId
-decodeCutId = CutId . SB.toShort <$> getBytes (int cutIdBytesCount)
+decodeCutId = CutId . SB.toShort <$!> getBytes (int cutIdBytesCount)
 {-# INLINE decodeCutId #-}
 
 instance Hashable CutId where

--- a/src/Chainweb/CutDB.hs
+++ b/src/Chainweb/CutDB.hs
@@ -179,7 +179,7 @@ cutHashesTable rdb = newCas rdb valueCodec keyCodec ["CutHashes"]
     keyCodec = Codec
         (\(a,b,c) -> runPut $ encodeBlockHeightBe a >> encodeBlockWeightBe b >> encodeCutId c)
         (runGet $ (,,) <$> decodeBlockHeightBe <*> decodeBlockWeightBe <*> decodeCutId)
-    valueCodec = Codec encodeToByteString decodeStrictOrThrow
+    valueCodec = Codec encodeToByteString decodeStrictOrThrow'
 
 -- -------------------------------------------------------------------------- --
 -- Cut DB

--- a/src/Chainweb/CutDB/RestAPI/Server.hs
+++ b/src/Chainweb/CutDB/RestAPI/Server.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE KindSignatures #-}
 {-# LANGUAGE LambdaCase #-}
@@ -59,9 +60,9 @@ import Chainweb.Version
 cutGetHandler :: CutDb cas -> Maybe MaxRank -> Handler CutHashes
 cutGetHandler db Nothing = liftIO $ cutToCutHashes Nothing <$> _cut db
 cutGetHandler db (Just (MaxRank (Max mar))) = liftIO $ do
-    c <- _cut db
-    c' <- limitCut (view cutDbWebBlockHeaderDb db) (int mar) c
-    return $ cutToCutHashes Nothing c'
+    !c <- _cut db
+    !c' <- limitCut (view cutDbWebBlockHeaderDb db) (int mar) c
+    return $! cutToCutHashes Nothing c'
 
 cutPutHandler :: CutDb cas -> CutHashes -> Handler NoContent
 cutPutHandler db c = NoContent <$ liftIO (addCutHashes db c)

--- a/src/Chainweb/Difficulty.hs
+++ b/src/Chainweb/Difficulty.hs
@@ -160,7 +160,7 @@ encodePowHashNat (PowHashNat n) = encodeWordLe n
 {-# INLINE encodePowHashNat #-}
 
 decodePowHashNat :: MonadGet m => m PowHashNat
-decodePowHashNat = PowHashNat <$> decodeWordLe
+decodePowHashNat = PowHashNat <$!> decodeWordLe
 {-# INLINE decodePowHashNat #-}
 
 encodePowHashNatBe :: MonadPut m => PowHashNat -> m ()
@@ -168,7 +168,7 @@ encodePowHashNatBe (PowHashNat n) = encodeWordBe n
 {-# INLINE encodePowHashNatBe #-}
 
 decodePowHashNatBe :: MonadGet m => m PowHashNat
-decodePowHashNatBe = PowHashNat <$> decodeWordBe
+decodePowHashNatBe = PowHashNat <$!> decodeWordBe
 {-# INLINE decodePowHashNatBe #-}
 
 instance ToJSON PowHashNat where
@@ -210,7 +210,7 @@ encodeHashDifficulty (HashDifficulty x) = encodePowHashNat x
 {-# INLINE encodeHashDifficulty #-}
 
 decodeHashDifficulty :: MonadGet m => m HashDifficulty
-decodeHashDifficulty = HashDifficulty <$> decodePowHashNat
+decodeHashDifficulty = HashDifficulty <$!> decodePowHashNat
 {-# INLINE decodeHashDifficulty #-}
 
 encodeHashDifficultyBe :: MonadPut m => HashDifficulty -> m ()
@@ -218,7 +218,7 @@ encodeHashDifficultyBe (HashDifficulty x) = encodePowHashNatBe x
 {-# INLINE encodeHashDifficultyBe #-}
 
 decodeHashDifficultyBe :: MonadGet m => m HashDifficulty
-decodeHashDifficultyBe = HashDifficulty <$> decodePowHashNatBe
+decodeHashDifficultyBe = HashDifficulty <$!> decodePowHashNatBe
 {-# INLINE decodeHashDifficultyBe #-}
 
 -- -------------------------------------------------------------------------- --
@@ -301,7 +301,7 @@ encodeHashTarget = encodePowHashNat . coerce
 {-# INLINE encodeHashTarget #-}
 
 decodeHashTarget :: MonadGet m => m HashTarget
-decodeHashTarget = HashTarget <$> decodePowHashNat
+decodeHashTarget = HashTarget <$!> decodePowHashNat
 {-# INLINE decodeHashTarget #-}
 
 -- -------------------------------------------------------------------------- --

--- a/src/Chainweb/Graph.hs
+++ b/src/Chainweb/Graph.hs
@@ -304,7 +304,7 @@ checkAdjacentChainIds g cid expectedAdj = do
     void $ check AdjacentChainMismatch
         (HS.map _chainId <$> expectedAdj)
         (Actual $ G.adjacents (_chainId cid) (_chainGraphGraph $ _chainGraph g))
-    return (getExpected expectedAdj)
+    return $! getExpected expectedAdj
 
 -- -------------------------------------------------------------------------- --
 -- Some Graphs

--- a/src/Chainweb/HostAddress.hs
+++ b/src/Chainweb/HostAddress.hs
@@ -210,7 +210,7 @@ ipV6Parser = p0
     h16 = Just <$> do
         h <- hexadecimal @Integer
         guard $ h < int (maxBound @Word16)
-        return (int h)
+        return $! (int h)
         <?> "h16"
 
     l0 = []
@@ -322,9 +322,9 @@ readHostnameBytes :: MonadThrow m => B8.ByteString -> m Hostname
 readHostnameBytes b = parseBytes "hostname" parser b
   where
     parser = hostParser <* endOfInput >>= \case
-        HostTypeName -> return $ HostnameName (CI.mk b)
-        HostTypeIPv4 -> return $ HostnameIPv4 (CI.mk b)
-        HostTypeIPv6 -> return $ HostnameIPv6 (CI.mk b)
+        HostTypeName -> return $! HostnameName (CI.mk b)
+        HostTypeIPv4 -> return $! HostnameIPv4 (CI.mk b)
+        HostTypeIPv6 -> return $! HostnameIPv6 (CI.mk b)
 {-# INLINE readHostnameBytes #-}
 
 localhost :: Hostname

--- a/src/Chainweb/Mempool/RestAPI/Client.hs
+++ b/src/Chainweb/Mempool/RestAPI/Client.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
@@ -109,7 +110,7 @@ toMempool version chain txcfg blocksizeLimit lastPar env =
 
     subscribe = do
         mv <- newEmptyMVar
-        ref <- mask_ $ do
+        !ref <- mask_ $ do
             chan <- atomically $ TBMChan.newTBMChan 8
             t <- Async.asyncWithUnmask $ subThread mv chan
             let finalize = Async.uninterruptibleCancel t

--- a/src/Chainweb/NodeId.hs
+++ b/src/Chainweb/NodeId.hs
@@ -45,6 +45,7 @@ module Chainweb.NodeId
 
 import Control.DeepSeq
 import Control.Lens
+import Control.Monad ((<$!>))
 import Control.Monad.Catch
 
 import Data.Aeson
@@ -94,7 +95,7 @@ encodeChainNodeId (ChainNodeId cid i) = encodeChainId cid >> putWord64le i
 {-# INLINE encodeChainNodeId #-}
 
 decodeChainNodeId :: MonadGet m => m ChainNodeId
-decodeChainNodeId = ChainNodeId <$> decodeChainId <*> getWord64le
+decodeChainNodeId = ChainNodeId <$!> decodeChainId <*> getWord64le
 {-# INLINE decodeChainNodeId #-}
 
 decodeChainNodeIdChecked
@@ -103,7 +104,7 @@ decodeChainNodeIdChecked
     => HasChainId p
     => Expected p
     -> m ChainNodeId
-decodeChainNodeIdChecked p = ChainNodeId <$> decodeChainIdChecked p <*> getWord64le
+decodeChainNodeIdChecked p = ChainNodeId <$!> decodeChainIdChecked p <*> getWord64le
 {-# INLINE decodeChainNodeIdChecked #-}
 
 chainNodeIdToText :: ChainNodeId -> T.Text
@@ -147,7 +148,7 @@ encodeNodeId (NodeId i) = putWord64le i
 {-# INLINE encodeNodeId #-}
 
 decodeNodeId :: MonadGet m => m NodeId
-decodeNodeId = NodeId <$> getWord64le
+decodeNodeId = NodeId <$!> getWord64le
 {-# INLINE decodeNodeId #-}
 
 nodeIdToText :: NodeId -> T.Text

--- a/src/Chainweb/Pact/Backend/InMemoryCheckpointer.hs
+++ b/src/Chainweb/Pact/Backend/InMemoryCheckpointer.hs
@@ -15,6 +15,7 @@ import Data.HashMap.Strict (HashMap)
 import qualified Data.HashMap.Strict as HMS
 
 import Control.Concurrent.MVar
+import Control.Exception (evaluate)
 
 import qualified Pact.Types.Logger as P
 import qualified Pact.Types.Runtime as P
@@ -65,7 +66,7 @@ saveInitial' lock p@PactDbState {..} = do
 
 save' :: MVar Store -> BlockHeight -> BlockHash -> PactDbState -> IO (Either String ())
 save' lock height hash p@PactDbState {..} = do
-     Right <$> modifyMVar_ lock (return . HMS.insert (height, hash) p)
+     Right <$> modifyMVar_ lock (evaluate . HMS.insert (height, hash) p)
 
 discard' :: MVar Store -> PactDbState -> IO (Either String ())
 discard' _ _ = return (Right ())

--- a/src/Chainweb/Pact/Backend/InMemoryCheckpointer.hs
+++ b/src/Chainweb/Pact/Backend/InMemoryCheckpointer.hs
@@ -27,7 +27,7 @@ import Chainweb.Pact.Backend.Types
 initInMemoryCheckpointEnv :: P.Logger -> P.GasEnv -> IO CheckpointEnv
 initInMemoryCheckpointEnv logger gasEnv = do
     inmem <- newMVar mempty
-    return $
+    return $!
         CheckpointEnv
             { _cpeCheckpointer =
                   Checkpointer
@@ -47,8 +47,8 @@ restore' :: MVar Store -> BlockHeight -> BlockHash -> IO (Either String PactDbSt
 restore' lock height hash = do
     withMVarMasked lock $ \store -> do
         case HMS.lookup (height, hash) store of
-            Just dbstate -> return (Right dbstate)
-            Nothing -> return $ Left $
+            Just dbstate -> return $! Right $! dbstate
+            Nothing -> return $! Left $!
               "InMemoryCheckpointer: Restore not found: height=" <> show height
               <> ", hash=" <> show hash
               <> ", known=" <> show (HMS.keys store)

--- a/src/Chainweb/Pact/BloomCache.hs
+++ b/src/Chainweb/Pact/BloomCache.hs
@@ -132,7 +132,7 @@ withCache cutDb bdbs = bracket (createCache cutDb bdbs) destroyCache
 
 member :: H.Hash -> (BlockHeight, BlockHash) -> TransactionBloomCache -> IO Bool
 member h k (TransactionBloomCache mv _) = do
-    mp <- readIORef mv
+    !mp <- readIORef mv
     -- N.B. return false positive on block missing
     fmap (fromMaybe True) $ runMaybeT $ do
         !bloom <- MaybeT $ return $! HashMap.lookup k mp

--- a/src/Chainweb/Pact/BloomCache.hs
+++ b/src/Chainweb/Pact/BloomCache.hs
@@ -223,7 +223,7 @@ updateChain' cutDb bdb minHeight blockHeader0 mp0 = go mp0 blockHeader0
             return $! HashMap.insert hkey bloom mp
 
     pdb = cutDb ^. CutDB.cutDbPayloadCas
-    fromTx (tx, _) = MaybeT (return (toPactTx tx))
+    fromTx (tx, _) = MaybeT (return $! toPactTx tx)
 
 bloomFalsePositiveRate :: Double
 bloomFalsePositiveRate = 0.08

--- a/src/Chainweb/Pact/BloomCache.hs
+++ b/src/Chainweb/Pact/BloomCache.hs
@@ -229,4 +229,4 @@ bloomFalsePositiveRate :: Double
 bloomFalsePositiveRate = 0.08
 
 toPactTx :: Transaction -> Maybe (Command Text)
-toPactTx (Transaction b) = decodeStrict b
+toPactTx (Transaction b) = decodeStrict' b

--- a/src/Chainweb/Pact/PactService.hs
+++ b/src/Chainweb/Pact/PactService.hs
@@ -312,7 +312,7 @@ execLocal cmd = do
 
   bh <- use psStateValidated >>= \v -> case v of
     Nothing -> throwM NoBlockValidatedYet
-    Just p -> return p
+    (Just !p) -> return p
 
   restoreCheckpointer $ Just (_blockHeight bh,_blockHash bh)
 

--- a/src/Chainweb/Pact/PactService.hs
+++ b/src/Chainweb/Pact/PactService.hs
@@ -67,7 +67,8 @@ import qualified Pact.Types.Runtime as P
 -- internal modules
 
 import Chainweb.BlockHash
-import Chainweb.BlockHeader (BlockHeader(..), BlockHeight(..), isGenesisBlockHeader)
+import Chainweb.BlockHeader
+    (BlockHeader(..), BlockHeight(..), isGenesisBlockHeader)
 import Chainweb.ChainId (ChainId)
 import Chainweb.CutDB (CutDb)
 import Chainweb.Logger
@@ -351,55 +352,49 @@ logDebug = logg "DEBUG"
 -- | Note: The BlockHeader here is the header of the block being validated
 execValidateBlock :: Bool -> BlockHeader -> PayloadData -> PactServiceM PayloadWithOutputs
 execValidateBlock loadingGenesis currHeader plData = do
+    !miner <- decodeStrictOrThrow' (_minerData $ _payloadDataMiner plData)
 
-    miner <- decodeStrictOrThrow (_minerData $ _payloadDataMiner plData)
-
-    let bHeight@(BlockHeight bh) = _blockHeight currHeader
-        bParent = _blockParent currHeader
-        bHash = _blockHash currHeader
-        isGenesisBlock = isGenesisBlockHeader currHeader
+    let bHeight@(BlockHeight !bh) = _blockHeight currHeader
+        !bParent = _blockParent currHeader
+        !bHash = _blockHash currHeader
+        !isGenesisBlock = isGenesisBlockHeader currHeader
 
     unless loadingGenesis $ logInfo $ "execValidateBlock: height=" ++ show bHeight ++
       ", parent=" ++ show bParent ++ ", hash=" ++ show bHash ++
       ", payloadHash=" ++ show (_blockPayloadHash currHeader)
 
     trans <- liftIO $ transactionsFromPayload plData
+    restoreCheckpointer $ if loadingGenesis then Nothing else Just $! (pred bHeight, bParent)
 
-    restoreCheckpointer $ if loadingGenesis then Nothing else Just (pred bHeight, bParent)
-
-    results <- locally (psPublicData . P.pdBlockHeight) (const bh) $
+    !results <- locally (psPublicData . P.pdBlockHeight) (const bh) $
       execTransactions (if isGenesisBlock then Nothing else Just bParent) miner trans
 
     finalizeCheckpointer $ \cp s -> save cp bHeight bHash s
-
     psStateValidated .= Just currHeader
-
     return $! toPayloadWithOutputs miner results
 
 
 execTransactions :: Maybe BlockHash -> MinerInfo -> Vector ChainwebTransaction ->
                     PactServiceM Transactions
 execTransactions nonGenesisParentHash miner ctxs = do
+    !currentState <- use psStateDb
 
-    currentState <- use psStateDb
+    let !isGenesis = isNothing nonGenesisParentHash
+        !dbEnvPersist' = _pdbsDbEnv $! currentState
 
-    let isGenesis = isNothing nonGenesisParentHash
-        dbEnvPersist' = _pdbsDbEnv $! currentState
+    !dbEnv' <- liftIO $ toEnv' dbEnvPersist'
 
-    dbEnv' <- liftIO $ toEnv' dbEnvPersist'
+    !coinOut <- runCoinbase nonGenesisParentHash dbEnv' miner
+    !txOuts <- applyPactCmds isGenesis dbEnv' ctxs miner
 
-    coinOut <- runCoinbase nonGenesisParentHash dbEnv' miner
-    txOuts <- applyPactCmds isGenesis dbEnv' ctxs miner
+    !newEnvPersist' <- liftIO $ toEnvPersist' dbEnv'
 
-    newEnvPersist' <- liftIO $! toEnvPersist' dbEnv'
-
-    let updatedState = PactDbState newEnvPersist'
-        cmdBSToTx = toTransactionBytes . fmap payloadBytes
-        paired = V.zipWith (curry $ first cmdBSToTx) ctxs txOuts
+    let !updatedState = PactDbState newEnvPersist'
+        !cmdBSToTx = toTransactionBytes . fmap payloadBytes
+        !paired = V.zipWith (curry $ first cmdBSToTx) ctxs txOuts
 
     psStateDb .= updatedState
-
-    return (Transactions paired coinOut)
+    return $! Transactions paired coinOut
 
 runCoinbase
     :: Maybe BlockHash
@@ -414,7 +409,7 @@ runCoinbase (Just _parentHash) (Env' dbEnv) mi@MinerInfo{..} = do
       pd = _psPublicData psEnv
       logger = _cpeLogger . _psCheckpointEnv $ psEnv
 
-  toHashCommandResult <$> liftIO (applyCoinbase logger dbEnv mi reward pd)
+  toHashCommandResult <$!> liftIO (applyCoinbase logger dbEnv mi reward pd)
 
 
 -- | Apply multiple Pact commands, incrementing the transaction Id for each
@@ -437,17 +432,16 @@ applyPactCmd
     -> PactServiceM HashCommandResult
 applyPactCmd isGenesis (Env' dbEnv) cmdIn miner = do
     psEnv <- ask
-    let logger   = _cpeLogger . _psCheckpointEnv $ psEnv
-        gasModel = P._geGasModel . _cpeGasEnv . _psCheckpointEnv $ psEnv
-        pd       = _psPublicData psEnv
-        spv      = _psSpvSupport psEnv
+    let !logger   = _cpeLogger . _psCheckpointEnv $ psEnv
+        !gasModel = P._geGasModel . _cpeGasEnv . _psCheckpointEnv $ psEnv
+        !pd       = _psPublicData psEnv
+        !spv      = _psSpvSupport psEnv
 
     -- cvt from Command PayloadWithTexts to Command ((Payload PublicMeta ParsedCode)
-    let cmd = payloadObj <$> cmdIn
-    result <- liftIO $! if isGenesis
+    let !cmd = payloadObj <$> cmdIn
+    result <- liftIO $ if isGenesis
         then applyGenesisCmd logger dbEnv pd spv cmd
         else applyCmd logger dbEnv miner gasModel pd spv cmd
-
     pure $! toHashCommandResult result
 
 toHashCommandResult :: P.CommandResult [P.TxLog A.Value] -> HashCommandResult
@@ -458,13 +452,13 @@ updateState = assign psStateDb
 
 transactionsFromPayload :: PayloadData -> IO (Vector ChainwebTransaction)
 transactionsFromPayload plData = do
-    let transSeq = _payloadDataTransactions plData
-    let transList = toList transSeq
-    let bytes = _transactionBytes <$> transList
-    let eithers = toCWTransaction <$> bytes
+    let !transSeq = _payloadDataTransactions plData
+    let !transList = toList transSeq
+    let !bytes = _transactionBytes <$!> transList
+    let !eithers = toCWTransaction <$!> bytes
     -- Note: if any transactions fail to convert, the final validation hash will fail to match
     -- the one computed during newBlock
-    let theRights  =  rights eithers
-    return $ V.fromList theRights
+    let theRights = rights eithers
+    return $! V.fromList theRights
   where
     toCWTransaction bs = codecDecode chainwebPayloadCodec bs

--- a/src/Chainweb/Pact/RestAPI/Server.hs
+++ b/src/Chainweb/Pact/RestAPI/Server.hs
@@ -168,7 +168,7 @@ listenHandler cutR cid chain bloomCache (ListenerRequest key) =
         go !prevCut = do
             m <- waitForNewCut prevCut
             case m of
-                Nothing -> return $ ListenTimeout defaultTimeout
+                Nothing -> return $! ListenTimeout defaultTimeout
                 (Just cut) -> poll cut
 
         poll cut = do
@@ -212,14 +212,14 @@ localHandler
     -> Handler (CommandResult Hash)
 localHandler _ _ cr cmd = do
   cmd' <- case validateCommand cmd of
-    Right c -> return c
+    (Right !c) -> return c
     Left err ->
       throwError $ err400 { errBody = "Validation failed: " <> BSL8.pack err }
   r <- liftIO $ _pactLocal (_chainResPact cr) cmd'
   case r of
     Left err ->
       throwError $ err400 { errBody = "Execution failed: " <> BSL8.pack (show err) }
-    Right r' -> return r'
+    (Right !r') -> return r'
 
 
 
@@ -326,5 +326,5 @@ validateCommand :: Command Text -> Either String ChainwebTransaction
 validateCommand cmdText = let
   cmdBS = encodeUtf8 <$> cmdText
   in case verifyCommand cmdBS of
-  ProcSucc cmd -> return $ (\bs -> PayloadWithText bs (_cmdPayload cmd)) <$> cmdBS
+  ProcSucc cmd -> return $! (\bs -> PayloadWithText bs (_cmdPayload cmd)) <$> cmdBS
   ProcFail err -> Left $ err

--- a/src/Chainweb/Pact/SPV.hs
+++ b/src/Chainweb/Pact/SPV.hs
@@ -89,7 +89,7 @@ pactSPV cdbv l = SPVSupport $ \s o -> readMVar cdbv >>= go s o
 
     extractOutputs :: TransactionOutput -> IO (Either Text (Object Name))
     extractOutputs (TransactionOutput t) =
-      case decodeStrict t :: Maybe HashCommandResult of
+      case decodeStrict' t :: Maybe HashCommandResult of
         Nothing -> internalError $
           "unable to decode spv transaction output"
         Just (CommandResult _ _ (PactResult (Right pv)) _ _ _ _) -> case fromPactValue pv of
@@ -138,7 +138,7 @@ getTxIdx bdb pdb bh th = do
           & return
   where
     toPactTx :: MonadThrow m => Transaction -> m (Command Text)
-    toPactTx (Transaction b) = decodeStrictOrThrow b
+    toPactTx (Transaction b) = decodeStrictOrThrow' b
 
     toTxHash :: MonadThrow m => Transaction -> m PactHash
     toTxHash = fmap _cmdHash . toPactTx

--- a/src/Chainweb/Pact/SPV.hs
+++ b/src/Chainweb/Pact/SPV.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
@@ -73,7 +74,7 @@ pactSPV cdbv l = SPVSupport $ \s o -> readMVar cdbv >>= go s o
     -- extract spv resources from pact object
     go s o cdb = case s of
       "TXOUT" -> case txOutputProofOf o of
-        Left u -> return $ Left u
+        (Left !u) -> return $! Left u
         Right t -> extractOutputs =<< verifyTransactionOutputProof cdb t
       "TXIN" -> return $ Left "TXIN is currently unsupported"
       x -> return . Left
@@ -93,8 +94,8 @@ pactSPV cdbv l = SPVSupport $ \s o -> readMVar cdbv >>= go s o
         Nothing -> internalError $
           "unable to decode spv transaction output"
         Just (CommandResult _ _ (PactResult (Right pv)) _ _ _ _) -> case fromPactValue pv of
-          (TObject o _) -> return $ Right o
-          o -> do
+          (TObject !o _) -> return $! Right o
+          !o -> do
             logLog l "ERROR" $ show o
             return . Left $ pack "type error in associated pact transaction, should be object"
         Just o -> do
@@ -122,8 +123,8 @@ getTxIdx bdb pdb bh th = do
         >>= pure . note "unable to find payload associated with transaction hash"
 
     case ph of
-      Left s -> return $ Left s
-      Right a -> do
+      (Left !s) -> return $! Left s
+      (Right !a) -> do
         -- get payload
         payload <- _payloadWithOutputsTransactions <$> casLookupM pdb a
 

--- a/src/Chainweb/Pact/Service/BlockValidation.hs
+++ b/src/Chainweb/Pact/Service/BlockValidation.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE BangPatterns #-}
+
 -- |
 -- Module      :  Chainweb.Pact.TransactionExec
 -- Copyright   :  Copyright © 2018 Kadena LLC.
@@ -31,8 +33,8 @@ import Chainweb.Transaction
 newBlock :: MinerInfo -> BlockHeader -> TQueue RequestMsg ->
             IO (MVar (Either PactException PayloadWithOutputs))
 newBlock mi bHeader reqQ = do
-    resultVar <- newEmptyMVar :: IO (MVar (Either PactException PayloadWithOutputs))
-    let msg = NewBlockMsg NewBlockReq
+    !resultVar <- newEmptyMVar :: IO (MVar (Either PactException PayloadWithOutputs))
+    let !msg = NewBlockMsg NewBlockReq
           { _newBlockHeader = bHeader
           , _newMiner = mi
           , _newResultVar = resultVar }
@@ -45,8 +47,8 @@ validateBlock
     -> TQueue RequestMsg
     -> IO (MVar (Either PactException PayloadWithOutputs))
 validateBlock bHeader plData reqQ = do
-    resultVar <- newEmptyMVar :: IO (MVar (Either PactException PayloadWithOutputs))
-    let msg = ValidateBlockMsg ValidateBlockReq
+    !resultVar <- newEmptyMVar :: IO (MVar (Either PactException PayloadWithOutputs))
+    let !msg = ValidateBlockMsg ValidateBlockReq
           { _valBlockHeader = bHeader
           , _valResultVar = resultVar
           , _valPayloadData = plData }
@@ -55,8 +57,8 @@ validateBlock bHeader plData reqQ = do
 
 local :: ChainwebTransaction -> TQueue RequestMsg -> IO (MVar (Either PactException HashCommandResult))
 local ct reqQ = do
-    resultVar <- newEmptyMVar
-    let msg = LocalMsg LocalReq
+    !resultVar <- newEmptyMVar
+    let !msg = LocalMsg LocalReq
           { _localRequest = ct
           , _localResultVar = resultVar }
     addRequest reqQ msg

--- a/src/Chainweb/Pact/Service/PactInProcApi.hs
+++ b/src/Chainweb/Pact/Service/PactInProcApi.hs
@@ -24,6 +24,7 @@ module Chainweb.Pact.Service.PactInProcApi
 import Control.Concurrent.Async
 import Control.Concurrent.MVar.Strict
 import Control.Concurrent.STM.TQueue
+import Control.Exception (evaluate)
 import Control.Monad.STM
 
 import Data.Int
@@ -69,7 +70,7 @@ withPactService' ver cid logger memPoolAccess cdbv action = do
     link a
     r <- action reqQ
     closeQueue reqQ
-    return r
+    evaluate r
 
 -- TODO: get from config
 maxBlockSize :: Int64

--- a/src/Chainweb/Pact/Types.hs
+++ b/src/Chainweb/Pact/Types.hs
@@ -61,9 +61,9 @@ import Data.Vector (Vector)
 import Pact.Parse (ParsedDecimal)
 import Pact.Types.ChainMeta (PublicData(..))
 import Pact.Types.Command
+import Pact.Types.Exp
 import qualified Pact.Types.Hash as H
 import Pact.Types.PactValue
-import Pact.Types.Exp
 import Pact.Types.Runtime (SPVSupport(..))
 import Pact.Types.Term (KeySet(..), Name(..))
 
@@ -79,17 +79,16 @@ import Chainweb.Utils
 type HashCommandResult = CommandResult H.Hash
 
 data Transactions = Transactions
-    { _transactionPairs :: Vector (Transaction, HashCommandResult)
-    , _transactionCoinbase :: HashCommandResult
-    } deriving (Eq,Show)
+    { _transactionPairs :: !(Vector (Transaction, HashCommandResult))
+    , _transactionCoinbase :: !HashCommandResult
+    } deriving (Eq, Show)
 
 type MinerKeys = KeySet
-
 type MinerId = Text
 
 data MinerInfo = MinerInfo
-  { _minerAccount :: MinerId
-  , _minerKeys :: MinerKeys
+  { _minerAccount :: !MinerId
+  , _minerKeys :: !MinerKeys
   } deriving (Show,Eq)
 
 instance ToJSON MinerInfo where
@@ -120,13 +119,13 @@ toMinerData :: MinerInfo -> MinerData
 toMinerData = MinerData . encodeToByteString
 
 fromMinerData :: MonadThrow m => MinerData -> m MinerInfo
-fromMinerData = decodeStrictOrThrow . _minerData
+fromMinerData = decodeStrictOrThrow' . _minerData
 
 toCoinbaseOutput :: HashCommandResult -> CoinbaseOutput
 toCoinbaseOutput = CoinbaseOutput . encodeToByteString
 
 fromCoinbaseOutput :: MonadThrow m => CoinbaseOutput -> m HashCommandResult
-fromCoinbaseOutput = decodeStrictOrThrow . _coinbaseOutput
+fromCoinbaseOutput = decodeStrictOrThrow' . _coinbaseOutput
 
 -- Keyset taken from cp examples in Pact
 -- The private key here was taken from `examples/cp` from the Pact repository
@@ -136,8 +135,8 @@ defaultMiner = MinerInfo "miner" $ KeySet
   (Name "keys-all" def)
 
 data PactDbStatePersist = PactDbStatePersist
-    { _pdbspRestoreFile :: Maybe FilePath
-    , _pdbspPactDbState :: PactDbState
+    { _pdbspRestoreFile :: !(Maybe FilePath)
+    , _pdbspPactDbState :: !PactDbState
     }
 
 -- | Indicates a computed gas charge (gas amount * gas price)
@@ -145,15 +144,15 @@ newtype GasSupply = GasSupply { _gasSupply :: ParsedDecimal }
    deriving (Eq,Show,Ord,Num,Real,Fractional,ToJSON,FromJSON)
 
 data PactServiceEnv = PactServiceEnv
-  { _psMempoolAccess :: Maybe MemPoolAccess
-  , _psCheckpointEnv :: CheckpointEnv
-  , _psSpvSupport :: SPVSupport
-  , _psPublicData :: PublicData
+  { _psMempoolAccess :: !(Maybe MemPoolAccess)
+  , _psCheckpointEnv :: !CheckpointEnv
+  , _psSpvSupport :: !SPVSupport
+  , _psPublicData :: !PublicData
   }
 
 data PactServiceState = PactServiceState
-  { _psStateDb :: PactDbState
-  , _psStateValidated :: Maybe BlockHeader
+  { _psStateDb :: !PactDbState
+  , _psStateValidated :: !(Maybe BlockHeader)
   }
 
 type PactServiceM = ReaderT PactServiceEnv (StateT PactServiceState IO)

--- a/src/Chainweb/Payload.hs
+++ b/src/Chainweb/Payload.hs
@@ -82,6 +82,7 @@ module Chainweb.Payload
 ) where
 
 import Control.DeepSeq
+import Control.Monad ((<$!>))
 import Control.Monad.Catch
 
 import Crypto.Hash.Algorithms
@@ -122,7 +123,7 @@ encodeBlockTransactionsHash :: MonadPut m => BlockTransactionsHash -> m ()
 encodeBlockTransactionsHash (BlockTransactionsHash w) = encodeMerkleLogHash w
 
 decodeBlockTransactionsHash :: MonadGet m => m BlockTransactionsHash
-decodeBlockTransactionsHash = BlockTransactionsHash <$> decodeMerkleLogHash
+decodeBlockTransactionsHash = BlockTransactionsHash <$!> decodeMerkleLogHash
 
 instance IsMerkleLogEntry ChainwebHashTag BlockTransactionsHash where
     type Tag BlockTransactionsHash = 'BlockTransactionsHashTag
@@ -144,7 +145,7 @@ encodeBlockOutputsHash :: MonadPut m => BlockOutputsHash -> m ()
 encodeBlockOutputsHash (BlockOutputsHash w) = encodeMerkleLogHash w
 
 decodeBlockOutputsHash :: MonadGet m => m BlockOutputsHash
-decodeBlockOutputsHash = BlockOutputsHash <$> decodeMerkleLogHash
+decodeBlockOutputsHash = BlockOutputsHash <$!> decodeMerkleLogHash
 
 instance IsMerkleLogEntry ChainwebHashTag BlockOutputsHash where
     type Tag BlockOutputsHash = 'BlockOutputsHashTag
@@ -166,7 +167,7 @@ encodeBlockPayloadHash :: MonadPut m => BlockPayloadHash -> m ()
 encodeBlockPayloadHash (BlockPayloadHash w) = encodeMerkleLogHash w
 
 decodeBlockPayloadHash :: MonadGet m => m BlockPayloadHash
-decodeBlockPayloadHash = BlockPayloadHash <$> decodeMerkleLogHash
+decodeBlockPayloadHash = BlockPayloadHash <$!> decodeMerkleLogHash
 
 instance IsMerkleLogEntry ChainwebHashTag BlockPayloadHash where
     type Tag BlockPayloadHash = 'BlockPayloadHashTag
@@ -212,7 +213,7 @@ transactionToText = encodeB64UrlNoPaddingText . _transactionBytes
 
 transactionFromText :: MonadThrow m => T.Text -> m Transaction
 transactionFromText t = either (throwM . TextFormatException . sshow) return
-    $ Transaction <$> decodeB64UrlNoPaddingText t
+    $ Transaction <$!> decodeB64UrlNoPaddingText t
 {-# INLINE transactionFromText #-}
 
 instance HasTextRepresentation Transaction where
@@ -254,7 +255,7 @@ transactionOutputToText = encodeB64UrlNoPaddingText . _transactionOutputBytes
 
 transactionOutputFromText :: MonadThrow m => T.Text -> m TransactionOutput
 transactionOutputFromText t = either (throwM . TextFormatException . sshow) return
-    $ TransactionOutput <$> decodeB64UrlNoPaddingText t
+    $ TransactionOutput <$!> decodeB64UrlNoPaddingText t
 {-# INLINE transactionOutputFromText #-}
 
 instance HasTextRepresentation TransactionOutput where
@@ -309,7 +310,7 @@ instance ToJSON BlockPayload where
 
 instance FromJSON BlockPayload where
     parseJSON = withObject "BlockPayload" $ \o -> BlockPayload
-        <$> o .: "payloadHash"
+        <$!> o .: "payloadHash"
         <*> o .: "transactionsHash"
         <*> o .: "outputsHash"
 
@@ -369,7 +370,7 @@ minerDataToText = encodeB64UrlNoPaddingText . _minerData
 
 minerDataFromText :: MonadThrow m => T.Text -> m MinerData
 minerDataFromText t = either (throwM . TextFormatException . sshow) return
-    $ MinerData <$> decodeB64UrlNoPaddingText t
+    $ MinerData <$!> decodeB64UrlNoPaddingText t
 {-# INLINE minerDataFromText #-}
 
 instance HasTextRepresentation MinerData where
@@ -407,7 +408,7 @@ instance ToJSON BlockTransactions where
 
 instance FromJSON BlockTransactions where
     parseJSON = withObject "BlockTransactions" $ \o -> BlockTransactions
-        <$> o .: "transactionHash"
+        <$!> o .: "transactionHash"
         <*> o .: "transaction"
         <*> o .: "minerData"
 
@@ -470,7 +471,7 @@ coinbaseOutputToText = encodeB64UrlNoPaddingText . _coinbaseOutput
 
 coinbaseOutputFromText :: MonadThrow m => T.Text -> m CoinbaseOutput
 coinbaseOutputFromText t = either (throwM . TextFormatException . sshow) return
-    $ CoinbaseOutput <$> decodeB64UrlNoPaddingText t
+    $ CoinbaseOutput <$!> decodeB64UrlNoPaddingText t
 {-# INLINE coinbaseOutputFromText #-}
 
 instance HasTextRepresentation CoinbaseOutput where
@@ -511,7 +512,7 @@ instance ToJSON BlockOutputs where
 
 instance FromJSON BlockOutputs where
     parseJSON = withObject "BlockOutputs" $ \o -> BlockOutputs
-        <$> o .: "outputsHash"
+        <$!> o .: "outputsHash"
         <*> o .: "outputs"
         <*> o .: "coinbaseOutput"
 
@@ -564,7 +565,7 @@ instance ToJSON TransactionTree where
 
 instance FromJSON TransactionTree where
     parseJSON = withObject "TransactionTree" $ \o -> TransactionTree
-        <$> o .: "hash"
+        <$!> o .: "hash"
         <*> (o .: "tree" >>= merkleTreeFromJson)
 
 merkleTreeToJson :: MerkleTree a -> Value
@@ -600,7 +601,7 @@ instance ToJSON OutputTree where
 
 instance FromJSON OutputTree where
     parseJSON = withObject "OutputTree" $ \o -> OutputTree
-        <$> o .: "hash"
+        <$!> o .: "hash"
         <*> (o .: "tree" >>= merkleTreeFromJson)
 
 -- -------------------------------------------------------------------------- --
@@ -694,8 +695,8 @@ newBlockPayload
     -> BlockPayload
 newBlockPayload mi co s = blockPayload txs outs
   where
-    (_, txs) = newBlockTransactions mi (fst <$> s)
-    (_, outs) = newBlockOutputs co (snd <$> s)
+    (_, txs) = newBlockTransactions mi (fst <$!> s)
+    (_, outs) = newBlockOutputs co (snd <$!> s)
 
 -- -------------------------------------------------------------------------- --
 -- Payload Data
@@ -721,7 +722,7 @@ instance ToJSON PayloadData where
 
 instance FromJSON PayloadData where
     parseJSON = withObject "PayloadData" $ \o -> PayloadData
-        <$> o .: "transactions"
+        <$!> o .: "transactions"
         <*> o .: "minerData"
         <*> o .: "payloadHash"
         <*> o .: "transactionsHash"
@@ -803,7 +804,7 @@ instance ToJSON PayloadWithOutputs where
 
 instance FromJSON PayloadWithOutputs where
     parseJSON = withObject "PayloadWithOutputs" $ \o -> PayloadWithOutputs
-        <$> o .: "transactions"
+        <$!> o .: "transactions"
         <*> o .: "minerData"
         <*> o .: "coinbase"
         <*> o .: "payloadHash"
@@ -820,7 +821,7 @@ payloadWithOutputsToBlockObjects PayloadWithOutputs {..} =
 
 payloadWithOutputsToPayloadData :: PayloadWithOutputs -> PayloadData
 payloadWithOutputsToPayloadData o = PayloadData
-    { _payloadDataTransactions = fst <$> _payloadWithOutputsTransactions o
+    { _payloadDataTransactions = fst <$!> _payloadWithOutputsTransactions o
     , _payloadDataMiner = _payloadWithOutputsMiner o
     , _payloadDataPayloadHash = _payloadWithOutputsPayloadHash o
     , _payloadDataTransactionsHash = _payloadWithOutputsTransactionsHash o

--- a/src/Chainweb/Payload/RestAPI.hs
+++ b/src/Chainweb/Payload/RestAPI.hs
@@ -63,7 +63,7 @@ somePayloadDbVal :: forall cas . ChainwebVersion -> ChainId -> PayloadDb cas -> 
 somePayloadDbVal v cid db = runIdentity $ do
     SomeChainwebVersionT (Proxy :: Proxy vt) <- return $ someChainwebVersionVal v
     SomeChainIdT (Proxy :: Proxy cidt) <- return $ someChainIdVal cid
-    return $ SomePayloadDb (PayloadDb_ @cas @vt @cidt db)
+    return $! SomePayloadDb (PayloadDb_ @cas @vt @cidt db)
 
 -- -------------------------------------------------------------------------- --
 -- Payload GET API
@@ -100,7 +100,7 @@ somePayloadApi :: ChainwebVersion -> ChainId -> SomeApi
 somePayloadApi v c = runIdentity $ do
     SomeChainwebVersionT (_ :: Proxy v') <- return $ someChainwebVersionVal v
     SomeChainIdT (_ :: Proxy c') <- return $ someChainIdVal c
-    return $ SomeApi (payloadApi @v' @c')
+    return $! SomeApi (payloadApi @v' @c')
 
 somePayloadApis :: ChainwebVersion -> [ChainId] -> SomeApi
 somePayloadApis v = mconcat . fmap (somePayloadApi v)

--- a/src/Chainweb/Time.hs
+++ b/src/Chainweb/Time.hs
@@ -174,7 +174,7 @@ getCurrentTimeIntegral :: Integral a => IO (Time a)
 getCurrentTimeIntegral = do
     -- returns POSIX seconds with picosecond precision
     t <- getPOSIXTime
-    return $ Time $ TimeSpan (round $ t * 1000000)
+    return $! Time $! TimeSpan $! round $ t * 1000000
 
 encodeTime :: MonadPut m => Time Int64 -> m ()
 encodeTime (Time a) = encodeTimeSpan a

--- a/src/Chainweb/Time.hs
+++ b/src/Chainweb/Time.hs
@@ -68,6 +68,7 @@ module Chainweb.Time
 ) where
 
 import Control.DeepSeq
+import Control.Monad ((<$!>))
 import Control.Monad.Catch
 
 import Data.Aeson (FromJSON, ToJSON)
@@ -118,7 +119,7 @@ encodeTimeSpanToWord64 (TimeSpan a) = BA.unLE . BA.toLE $ unsigned a
 {-# INLINE encodeTimeSpanToWord64 #-}
 
 decodeTimeSpan :: MonadGet m => m (TimeSpan Int64)
-decodeTimeSpan = TimeSpan . signed <$> getWord64le
+decodeTimeSpan = TimeSpan . signed <$!> getWord64le
 {-# INLINE decodeTimeSpan #-}
 
 castTimeSpan :: NumCast a b => TimeSpan a -> TimeSpan b
@@ -126,7 +127,7 @@ castTimeSpan (TimeSpan a) = TimeSpan $ numCast a
 {-# INLINE castTimeSpan #-}
 
 maybeCastTimeSpan :: MaybeNumCast a b => TimeSpan a -> Maybe (TimeSpan b)
-maybeCastTimeSpan (TimeSpan a) = TimeSpan <$> maybeNumCast a
+maybeCastTimeSpan (TimeSpan a) = TimeSpan <$!> maybeNumCast a
 {-# INLINE maybeCastTimeSpan #-}
 
 ceilingTimeSpan :: RealFrac a => Integral b => TimeSpan a -> TimeSpan b
@@ -184,7 +185,7 @@ encodeTimeToWord64 (Time a) = encodeTimeSpanToWord64 a
 {-# INLINE encodeTimeToWord64 #-}
 
 decodeTime :: MonadGet m => m (Time Int64)
-decodeTime  = Time <$> decodeTimeSpan
+decodeTime  = Time <$!> decodeTimeSpan
 {-# INLINE decodeTime #-}
 
 castTime :: NumCast a b => Time a -> Time b
@@ -192,7 +193,7 @@ castTime (Time a) = Time $ castTimeSpan a
 {-# INLINE castTime #-}
 
 maybeCastTime :: MaybeNumCast a b => Time a -> Maybe (Time b)
-maybeCastTime (Time a) = Time <$> maybeCastTimeSpan a
+maybeCastTime (Time a) = Time <$!> maybeCastTimeSpan a
 {-# INLINE maybeCastTime #-}
 
 ceilingTime :: RealFrac a => Integral b => Time a -> Time b

--- a/src/Chainweb/Transaction.hs
+++ b/src/Chainweb/Transaction.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
@@ -50,7 +51,7 @@ instance FromJSON PayloadWithText where
     parseJSON = Aeson.withText "PayloadWithText" $ \text -> let bs = T.encodeUtf8 text in
         case traverse parsePact =<< Aeson.eitherDecodeStrict' bs of
           Left err -> fail err
-          Right payload -> pure $ PayloadWithText bs payload
+          (Right !payload) -> pure $! PayloadWithText bs payload
       where
         parsePact :: Text -> Either String ParsedCode
         parsePact code = ParsedCode code <$> parseExprs code

--- a/src/Chainweb/TreeDB.hs
+++ b/src/Chainweb/TreeDB.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DeriveGeneric #-}
@@ -505,7 +506,7 @@ limitStream
     -> S.Stream (Of a) m (Natural, Eos)
 limitStream Nothing s = do
     limit' <- s & S.copy & S.length_
-    return (int limit', Eos True)
+    return $! (int limit', Eos True)
 limitStream (Just limit) s = do
     (limit' :> tailStream) <- s
         & S.splitAt (int limit)
@@ -514,8 +515,8 @@ limitStream (Just limit) s = do
     -- FIXME this can be expensive for infinite/blocking streams. Skip this if
     -- the underlying stream is known to be infinite.
     --
-    eos <- lift (atEos tailStream)
-    return (int limit', eos)
+    !eos <- lift (atEos tailStream)
+    return $! (int limit', eos)
 
 seekStream
     :: Monad m
@@ -574,7 +575,7 @@ lookupM
     -> IO (DbEntry db)
 lookupM db k = lookup db k >>= \case
     Nothing -> throwM $ TreeDbKeyNotFound @db k
-    Just x -> return x
+    (Just !x) -> return x
 
 -- | Lookup all entries in a stream of database keys and return the stream
 -- of entries. Throws if an entry is missing.
@@ -621,7 +622,7 @@ lookupParentM g db e = case parent e of
             $ InternalInvariantViolation "Chainweb.TreeDB.lookupParentM: Called getParentEntry on genesis block"
     Just p -> lookup db p >>= \case
         Nothing -> throwM $ TreeDbParentMissing @db e
-        Just x -> return x
+        (Just !x) -> return x
 
 -- | Replace all entries in the stream by their parent entries.
 -- If the genesis block is part of the stream it is replaced by itself.
@@ -641,7 +642,7 @@ lookupParentStreamM g db = S.mapMaybeM $ \e -> case parent e of
             $ InternalInvariantViolation "Chainweb.TreeDB.lookupParentStreamM: Called getParentEntry on genesis block"
     Just p -> lookup db p >>= \case
         Nothing -> throwM $ TreeDbParentMissing @db e
-        Just x -> return $ Just x
+        (Just !x) -> return $! Just x
 
 -- | Create a `Stream` from a `Foldable` value.
 --

--- a/src/Chainweb/TreeDB/RemoteDB.hs
+++ b/src/Chainweb/TreeDB/RemoteDB.hs
@@ -146,4 +146,4 @@ remoteDb
     -> IO RemoteDb
 remoteDb db logg env = do
     h <- root db
-    pure $ RemoteDb env (ALogFunction logg) (_blockChainwebVersion h) (_blockChainId h)
+    pure $! RemoteDb env (ALogFunction logg) (_blockChainwebVersion h) (_blockChainId h)

--- a/src/Chainweb/Utils.hs
+++ b/src/Chainweb/Utils.hs
@@ -522,7 +522,7 @@ parseJsonFromText
     => String
     -> Value
     -> Aeson.Parser a
-parseJsonFromText l = withText l $ either fail return . eitherFromText
+parseJsonFromText l = withText l $! either fail return . eitherFromText
 
 -- -------------------------------------------------------------------------- --
 -- Option Parsing
@@ -568,7 +568,7 @@ check
     -> m a
 check e a b = do
     unless (a ==? b) $ throwM (e a b)
-    return (getActual b)
+    return $! getActual b
 
 fromMaybeM :: MonadThrow m => Exception e => e -> Maybe a -> m a
 fromMaybeM e = maybe (throwM e) return
@@ -716,7 +716,7 @@ timeoutStream msecs = go
   where
     go s = lift (timeout msecs (S.next s)) >>= \case
         Nothing -> return Nothing
-        Just (Left r) -> return (Just r)
+        Just (Left r) -> return $! Just r
         Just (Right (a, s')) -> S.yield a >> go s'
 
 nub :: Monad m => Eq a => S.Stream (Of a) m r -> S.Stream (Of a) m r
@@ -780,7 +780,7 @@ withTempDir tag f = bracket create delete f
     create = do
         tmp <- getTemporaryDirectory
         suff <- randomIO @Word64
-        pure $ tmp </> fragment (printf "chainweb-%s-%d" tag suff)
+        pure $! tmp </> fragment (printf "chainweb-%s-%d" tag suff)
 
     delete :: Path Absolute -> IO ()
     delete = toAbsoluteFilePath >=> removeDirectoryRecursive

--- a/src/Chainweb/WebBlockHeaderDB.hs
+++ b/src/Chainweb/WebBlockHeaderDB.hs
@@ -104,7 +104,7 @@ initWebBlockHeaderDb
     -> ChainwebVersion
     -> IO WebBlockHeaderDb
 initWebBlockHeaderDb db v = WebBlockHeaderDb
-    <$> itraverse (\cid _ -> initBlockHeaderDb (conf cid db)) (HS.toMap $ chainIds v)
+    <$!> itraverse (\cid _ -> initBlockHeaderDb (conf cid db)) (HS.toMap $ chainIds v)
     <*> pure v
   where
     conf cid = Configuration (genesisBlockHeader v cid)
@@ -134,7 +134,7 @@ getWebBlockHeaderDb
     -> m BlockHeaderDb
 getWebBlockHeaderDb p = do
     checkWebChainId (given @WebBlockHeaderDb) p
-    return $ _webBlockHeaderDb given HM.! _chainId p
+    return $! _webBlockHeaderDb given HM.! _chainId p
 
 lookupWebBlockHeaderDb
     :: Given WebBlockHeaderDb

--- a/src/Chainweb/WebPactExecutionService.hs
+++ b/src/Chainweb/WebPactExecutionService.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE BangPatterns #-}
 
 module Chainweb.WebPactExecutionService
   ( WebPactExecutionService(..)
@@ -100,8 +101,8 @@ markAllValidated mempool payload height hash = mempoolMarkValidated mempool vali
     decodeTx = codecDecode $ txCodec txcfg
     decodedTxs = Either.rights $ fmap (decodeTx . _transactionBytes . fst)
                    $ toList $ _payloadWithOutputsTransactions payload
-    validatedTxs = V.fromList $ map ( \t -> ValidatedTransaction
-                                        { validatedHeight = height
-                                        , validatedHash = hash
-                                        , validatedTransaction = t }
-                                    ) decodedTxs
+    !validatedTxs = V.fromList $ map ( \t -> ValidatedTransaction
+                                         { validatedHeight = height
+                                         , validatedHash = hash
+                                         , validatedTransaction = t }
+                                     ) decodedTxs

--- a/src/Chainweb/WebPactExecutionService.hs
+++ b/src/Chainweb/WebPactExecutionService.hs
@@ -66,13 +66,14 @@ mkPactExecutionService mempool q = PactExecutionService
       mv <- validateBlock h pd q
       r <- takeMVar mv
       case r of
-        Right pdo -> markAllValidated mempool pdo (_blockHeight h) (_blockHash h) >> return pdo
+        (Right !pdo) -> markAllValidated mempool pdo (_blockHeight h) (_blockHash h)
+                          >> return pdo
         Left e -> throwM e
   , _pactNewBlock = \m h -> do
       mv <- newBlock m h q
       r <- takeMVar mv
       case r of
-        Right pdo -> return pdo
+        (Right !pdo) -> return pdo
         Left e -> throwM e
   , _pactLocal = \ct -> do
       mv <- local ct q

--- a/src/Control/Concurrent/FixedThreadPool.hs
+++ b/src/Control/Concurrent/FixedThreadPool.hs
@@ -101,7 +101,7 @@ doneGroup (Group sema gerr done) mberr = mask_ $ do
   where
     handleErr = writeIORef gerr mberr
     dec !k = let !k' = k - 1
-             in return (k', k' == 0)
+             in return $! (k', k' == 0)
 
 
 waitGroup :: Group -> IO (Maybe SomeException)

--- a/src/Data/CAS.hs
+++ b/src/Data/CAS.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE ConstraintKinds #-}
@@ -69,7 +70,7 @@ casLookupM
 casLookupM cas k = casLookup cas k >>= \case
     Nothing -> throwM . CasException $
       "casLookupM: lookup failed for cas key"
-    Just x -> return x
+    (Just !x) -> return x
 
 newtype CasException = CasException Text
     deriving (Eq, Show, Generic)

--- a/src/Data/CAS/RocksDB.hs
+++ b/src/Data/CAS/RocksDB.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
@@ -213,7 +214,7 @@ data RocksDbTableIter k v = RocksDbTableIter
 
 createTableIter :: RocksDbTable k v -> IO (RocksDbTableIter k v)
 createTableIter db = do
-    tit <- RocksDbTableIter
+    !tit <- RocksDbTableIter
         (_rocksDbTableValueCodec db)
         (_rocksDbTableKeyCodec db)
         (_rocksDbTableName db)
@@ -233,7 +234,7 @@ withTableIter db = bracket (createTableIter db) releaseTableIter
 tableIterValid :: MonadIO m => RocksDbTableIter k v -> m Bool
 tableIterValid it = I.iterKey (_rocksDbTableIter it) >>= \case
     Nothing -> return False
-    Just x -> return (checkIterKey it x)
+    (Just !x) -> return $! checkIterKey it x
 {-# INLINE tableIterValid #-}
 
 tableIterSeek :: MonadIO m => RocksDbTableIter k v -> k -> m ()
@@ -269,9 +270,9 @@ tableIterEntry it = I.iterEntry (_rocksDbTableIter it) >>= \case
     Just (k, v) -> do
         tryDecIterKey it k >>= \case
             Nothing -> return Nothing
-            Just k' -> do
-                v' <- decIterVal it v
-                return $ Just (k', v')
+            (Just !k') -> do
+                !v' <- decIterVal it v
+                return $! Just $! (k', v')
 {-# INLINE tableIterEntry #-}
 
 tableIterValue

--- a/src/Data/PQueue.hs
+++ b/src/Data/PQueue.hs
@@ -60,10 +60,10 @@ pQueueInsertLimit (PQueue s q) l t = modifyMVarMasked_ q $ \h -> do
         else h'
 
 pQueueIsEmpty :: PQueue a -> IO Bool
-pQueueIsEmpty (PQueue _ q) = H.null <$> readMVar q
+pQueueIsEmpty (PQueue _ q) = H.null <$!> readMVar q
 
 pQueueSize :: PQueue a -> IO Natural
-pQueueSize (PQueue _ q) = fromIntegral . H.size <$> readMVar q
+pQueueSize (PQueue _ q) = fromIntegral . H.size <$!> readMVar q
 
 -- | It the queue is empty it blocks and races for new items
 --

--- a/src/Data/PQueue.hs
+++ b/src/Data/PQueue.hs
@@ -55,7 +55,7 @@ pQueueInsertLimit :: Ord a => PQueue a -> Natural -> a -> IO ()
 pQueueInsertLimit (PQueue s q) l t = modifyMVarMasked_ q $ \h -> do
     h' <- evaluate $ H.insert t h
     void $ tryPutMVar s ()
-    return $ if H.size h > 2 * fromIntegral l
+    return $! if H.size h > 2 * fromIntegral l
         then H.take (fromIntegral l) h'
         else h'
 
@@ -72,12 +72,12 @@ pQueueRemove (PQueue s q) = run
   where
     run = do
         r <- modifyMVarMasked q $ \h -> case H.uncons h of
-            Nothing -> return (h, Nothing)
+            Nothing -> return $! (h, Nothing)
             Just (!a, !b) -> do
                 when (H.null b) $ void $ tryTakeMVar s
-                return (b, Just a)
+                return $! (b, Just a)
         case r of
             Nothing -> takeMVar s >> run
-            Just x -> return x
+            (Just !x) -> return x
 
 

--- a/src/Data/TaskMap.hs
+++ b/src/Data/TaskMap.hs
@@ -54,7 +54,7 @@ delete :: Eq k => Hashable k => TaskMap k v -> k -> IO ()
 delete (TaskMap var) k = modifyMVar_ var $ evaluate . HM.delete k
 
 lookup :: Eq k => Hashable k => TaskMap k v -> k -> IO (Maybe (Async v))
-lookup (TaskMap var) k = HM.lookup k <$> readMVar var
+lookup (TaskMap var) k = HM.lookup k <$!> readMVar var
 
 -- | If the key is in the map this blocks and awaits the results, otherwise
 -- it returns 'Nothing' immediately.
@@ -63,10 +63,10 @@ await :: Eq k => Hashable k => TaskMap k v -> k -> IO (Maybe v)
 await t = traverse wait <=< lookup t
 
 size :: TaskMap k v -> IO Int
-size (TaskMap var) = HM.size <$> readMVar var
+size (TaskMap var) = HM.size <$!> readMVar var
 
 null :: TaskMap k v -> IO Bool
-null (TaskMap var) = HM.null <$> readMVar var
+null (TaskMap var) = HM.null <$!> readMVar var
 
 memo
     :: Eq k

--- a/src/Data/TaskMap.hs
+++ b/src/Data/TaskMap.hs
@@ -48,7 +48,7 @@ insert :: Eq k => Hashable k => TaskMap k v -> k -> IO v -> IO (Async v)
 insert tm@(TaskMap var) k t = modifyMVarMasked var $ \m -> do
     !a <- asyncWithUnmask $ \umask -> umask t `finally` delete tm k
     m' <- evaluate $ HM.insert k a m
-    return (m', a)
+    return $! (m', a)
 
 delete :: Eq k => Hashable k => TaskMap k v -> k -> IO ()
 delete (TaskMap var) k = modifyMVar_ var $ evaluate . HM.delete k
@@ -84,6 +84,6 @@ memo tm@(TaskMap var) k task = do
         Nothing -> do
             !a <- asyncWithUnmask $ \umask -> umask (task k) `finally` delete tm k
             m' <- evaluate $ HM.insert k a m
-            return (m', a)
-        Just a -> return (m, a)
+            return $! (m', a)
+        (Just !a) -> return $! (m, a)
     wait a

--- a/src/Data/Word/Encoding.hs
+++ b/src/Data/Word/Encoding.hs
@@ -16,6 +16,7 @@ module Data.Word.Encoding
 , properties
 ) where
 
+import Control.Monad ((<$!>))
 import Data.Bits
 import Data.Bytes.Get
 import Data.Bytes.Put
@@ -74,9 +75,9 @@ instance WordEncoding Word64 where
 
 instance WordEncoding Word128 where
     encodeWordLe (Word128 a b) = encodeWordLe b *> encodeWordLe a
-    decodeWordLe = flip Word128 <$> decodeWordLe <*> decodeWordLe
+    decodeWordLe = flip Word128 <$!> decodeWordLe <*> decodeWordLe
     encodeWordBe (Word128 a b) = encodeWordBe a *> encodeWordBe b
-    decodeWordBe = Word128 <$> decodeWordBe <*> decodeWordBe
+    decodeWordBe = Word128 <$!> decodeWordBe <*> decodeWordBe
     {-# INLINE encodeWordLe #-}
     {-# INLINE decodeWordLe #-}
     {-# INLINE encodeWordBe #-}
@@ -84,9 +85,9 @@ instance WordEncoding Word128 where
 
 instance WordEncoding Word256 where
     encodeWordLe (Word256 a b) = encodeWordLe b *> encodeWordLe a
-    decodeWordLe = flip Word256 <$> decodeWordLe <*> decodeWordLe
+    decodeWordLe = flip Word256 <$!> decodeWordLe <*> decodeWordLe
     encodeWordBe (Word256 a b) = encodeWordBe a *> encodeWordBe b
-    decodeWordBe = Word256 <$> decodeWordBe <*> decodeWordBe
+    decodeWordBe = Word256 <$!> decodeWordBe <*> decodeWordBe
     {-# INLINE encodeWordLe #-}
     {-# INLINE decodeWordLe #-}
     {-# INLINE encodeWordBe #-}

--- a/src/P2P/Node.hs
+++ b/src/P2P/Node.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DeriveGeneric #-}
@@ -309,7 +310,7 @@ syncFromPeer node info = runClientM sync env >>= \case
     v = _p2pNodeChainwebVersion node
     nid = _p2pNodeNetworkId node
     sync = do
-        p <- peerGetClient v nid Nothing Nothing
+        !p <- peerGetClient v nid Nothing Nothing
         liftIO $ logg node Debug $ "got " <> sshow (_pageLimit p) <> " peers " <> showInfo info
         void $ peerPutClient v nid (_p2pNodePeerInfo node)
         liftIO $ logg node Debug $ "put own peer info to " <> showInfo info
@@ -351,7 +352,7 @@ findNextPeer conf node = do
     -- sessions:
 
     let checkPeer (n :: PeerEntry) = do
-            let pid = _peerId $ _peerEntryInfo n
+            let !pid = _peerId $ _peerEntryInfo n
             -- can this check be moved out of the fold?
             check (int sessionCount < _p2pConfigMaxSessionCount conf)
             check (M.notMember (_peerEntryInfo n) sessions)
@@ -367,7 +368,7 @@ findNextPeer conf node = do
 
         shiftR s = do
             i <- randomR node (0, size s - 1)
-            return $ shift i s
+            return $! shift i s
 
     -- Classify the peers by priority
     --
@@ -416,11 +417,11 @@ newSession conf node = do
                     ( round (0.9 * timeoutMs)
                     , round (1.1 * timeoutMs)
                     )
-                newSes <- async $ restore $ timeout t
+                !newSes <- async $ restore $ timeout t
                     $ _p2pNodeClientSession node (loggFun node) env newPeerInfo
                 incrementActiveSessionCount peerDb newPeerInfo
-                info <- atomically $ addSession node newPeerInfo newSes now
-                return (info, newSes)
+                !info <- atomically $ addSession node newPeerInfo newSes now
+                return $! (info, newSes)
             logg node Debug $ "Started peer session " <> showSessionId newPeerInfo newSes
             loggFun node Info $ JsonLog info
   where
@@ -432,14 +433,14 @@ newSession conf node = do
 awaitSessions :: P2pNode -> IO ()
 awaitSessions node = do
     (pId, info, ses, result) <- atomically $ do
-        (p, i, a, r) <- waitAnySession node
+        (!p, !i, !a, r) <- waitAnySession node
         removeSession node p
-        result <- case r of
+        !result <- case r of
             Right Nothing -> P2pSessionTimeout <$ countTimeout node
             Right (Just True) -> P2pSessionResultSuccess <$ countSuccess node
             Right (Just False) -> P2pSessionResultFailure <$ countFailure node
             Left e -> P2pSessionException (sshow e) <$ countException node
-        return (p, i, a, result)
+        return $! (p, i, a, result)
 
     -- update peer db entry
     --
@@ -509,7 +510,7 @@ startPeerDb
     -> P2pConfiguration
     -> IO PeerDb
 startPeerDb nids conf = do
-    peerDb <- newEmptyPeerDb
+    !peerDb <- newEmptyPeerDb
     forM_ nids $ \nid ->
         peerDbInsertPeerInfoList nid (_p2pConfigKnownPeers conf) peerDb
     case _p2pConfigPeerDbFilePath conf of
@@ -551,7 +552,7 @@ p2pCreateNode cv nid peer logfun db mgr session = do
     statsVar <- newTVarIO emptyP2pNodeStats
     rngVar <- newTVarIO =<< R.newStdGen
     activeVar <- newTVarIO True
-    let s = P2pNode
+    let !s = P2pNode
                 { _p2pNodeNetworkId = nid
                 , _p2pNodeChainwebVersion = cv
                 , _p2pNodePeerInfo = myInfo

--- a/src/P2P/Node/PeerDB.hs
+++ b/src/P2P/Node/PeerDB.hs
@@ -77,6 +77,7 @@ module P2P.Node.PeerDB
 import Control.Concurrent.MVar
 import Control.Concurrent.STM.TVar
 import Control.Lens hiding (Indexable)
+import Control.Monad ((<$!>))
 import Control.Monad.STM
 
 import Data.Aeson
@@ -272,11 +273,11 @@ peerDbSnapshotSTM (PeerDb _ var) = readTVar var
 {-# INLINE peerDbSnapshotSTM #-}
 
 peerDbSize :: PeerDb -> IO Natural
-peerDbSize (PeerDb _ var) = int . size <$> readTVarIO var
+peerDbSize (PeerDb _ var) = int . size <$!> readTVarIO var
 {-# INLINE peerDbSize #-}
 
 peerDbSizeSTM :: PeerDb -> STM Natural
-peerDbSizeSTM (PeerDb _ var) = int . size <$> readTVar var
+peerDbSizeSTM (PeerDb _ var) = int . size <$!> readTVar var
 {-# INLINE peerDbSizeSTM #-}
 
 -- | Adds new 'PeerInfo' values for a given chain id.
@@ -306,7 +307,7 @@ peerDbInsertList peers (PeerDb lock var) =
     withMVar lock
         . const
         . atomically
-        . modifyTVar var
+        . modifyTVar' var
         $ insertPeerEntryList peers
 
 peerDbInsertPeerInfoList :: NetworkId -> [PeerInfo] -> PeerDb -> IO ()

--- a/src/P2P/Node/RestAPI/Server.hs
+++ b/src/P2P/Node/RestAPI/Server.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
@@ -81,14 +82,14 @@ peerGetHandler
     -> Maybe (NextItem Int)
     -> Handler (Page (NextItem Int) PeerInfo)
 peerGetHandler db nid limit next = do
-    sn <- liftIO $ peerDbSnapshot db
-    page <- seekFiniteStreamToPage fst next effectiveLimit
+    !sn <- liftIO $ peerDbSnapshot db
+    !page <- seekFiniteStreamToPage fst next effectiveLimit
         . SP.map (second _peerEntryInfo)
         . SP.zip (SP.each [0..])
         . SP.each
         . toList
         $ getEQ nid sn
-    return $ over pageItems (fmap snd) page
+    return $! over pageItems (fmap snd) page
   where
     effectiveLimit = limit <|> Just defaultPeerInfoLimit
 

--- a/src/P2P/Peer.hs
+++ b/src/P2P/Peer.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DeriveGeneric #-}
@@ -122,13 +123,13 @@ shortPeerId = T.take 6 . toText
 
 peerIdFromText :: MonadThrow m => T.Text -> m PeerId
 peerIdFromText t = do
-    bytes <- decodeB64UrlNoPaddingText t
+    !bytes <- decodeB64UrlNoPaddingText t
     unless (B.length bytes == int fingerprintByteCount) $ throwM
         $ TextFormatException
         $ "wrong peer-id length: expected "
         <> sshow fingerprintByteCount <> " bytes, got "
         <> sshow (B.length bytes) <> " bytes."
-    return $ PeerId bytes
+    return $! PeerId bytes
 {-# INLINE peerIdFromText #-}
 
 unsafePeerIdFromText :: HasCallStack => String -> PeerId

--- a/src/P2P/Peer.hs
+++ b/src/P2P/Peer.hs
@@ -76,6 +76,7 @@ import Control.DeepSeq
 import Control.Lens hiding ((.=))
 import Control.Monad
 import Control.Monad.Catch
+import Control.Exception (evaluate)
 
 import qualified Data.Attoparsec.Text as A
 import qualified Data.ByteString as B
@@ -387,30 +388,30 @@ getPeerCertificate conf = do
         Nothing -> do
             bytes <- traverse T.readFile $ _peerConfigCertificateChainFile conf
             traverse x509CertChainPemFromText bytes
-        x -> return x
+        x -> evaluate x
 
     maybeKey <- case _peerConfigKey conf of
         Nothing -> do
             bytes <- traverse T.readFile $ _peerConfigKeyFile conf
             traverse x509KeyPemFromText bytes
-        x -> return x
+        x -> evaluate x
 
     case (maybeChain, maybeKey) of
         (Nothing, _) -> do
-            (fp, c, k) <- generateSelfSignedCertificate @DefCertType 365 dn Nothing
-            return (fp, X509CertChainPem c [], k)
-        (Just c@(X509CertChainPem a _), Just k) ->
-            return (unsafeFingerprintPem a, c, k)
+            (!fp, !c, !k) <- generateSelfSignedCertificate @DefCertType 365 dn Nothing
+            return $! (fp, X509CertChainPem c [], k)
+        (Just !c@(X509CertChainPem !a _), (Just !k)) ->
+            return $! (unsafeFingerprintPem a, c, k)
         _ -> throwM $ ConfigurationException "missing certificate key in peer config"
   where
     dn = name . B8.unpack . hostnameBytes . _hostAddressHost . _peerConfigAddr $ conf
 
 unsafeCreatePeer :: PeerConfig -> IO Peer
 unsafeCreatePeer conf = do
-    (fp, certs, key) <- getPeerCertificate conf
-    return $ Peer
+    (!fp, !certs, !key) <- getPeerCertificate conf
+    return $! Peer
         { _peerInfo = PeerInfo
-            { _peerId = Just $ peerIdFromFingerprint fp
+            { _peerId = Just $! peerIdFromFingerprint fp
             , _peerAddr = _peerConfigAddr conf
             }
         , _peerInterface = _peerConfigInterface conf

--- a/src/P2P/TaskQueue.hs
+++ b/src/P2P/TaskQueue.hs
@@ -112,7 +112,7 @@ makeLensesFor
 newTask :: TaskId -> Priority -> TaskAction env a -> IO (Task env a)
 newTask tid prio act = do
     var <- newIVar
-    return $ Task
+    return $! Task
         { _taskId = tid
         , _taskAction = act
         , _taskPriority = prio

--- a/src/Utils/Logging.hs
+++ b/src/Utils/Logging.hs
@@ -221,8 +221,8 @@ maybeLogHandle
     -> GenericBackend b
     -> GenericBackend b
 maybeLogHandle f = genericLogHandle $ \case
-    Left msg -> Just . Left <$> return msg
-    Right msg -> fmap Right <$> f msg
+    (Left !msg) -> Just . Left <$!> return msg
+    (Right !msg) -> fmap Right <$!> f msg
 {-# INLINEABLE maybeLogHandle #-}
 
 -- | This is most the powerful handle function that allows to implement generic
@@ -236,9 +236,9 @@ genericLogHandle
     -> GenericBackend b
 genericLogHandle f b msg = case fromBackendLogMessage msg of
     Nothing -> b msg
-    Just amsg -> f amsg >>= \case
+    (Just !amsg) -> f amsg >>= \case
         Nothing -> return mempty
-        Just msg' -> b msg'
+        (Just !msg') -> b msg'
 {-# INLINEABLE genericLogHandle #-}
 
 -- -------------------------------------------------------------------------- --
@@ -259,8 +259,8 @@ maybeLogHandler
     => (L.LogMessage a -> IO (Maybe (L.LogMessage SomeLogMessage)))
     -> LogHandler
 maybeLogHandler b = LogHandler $ \case
-    Left msg -> Just . Left <$> return msg
-    Right msg -> fmap Right <$> b msg
+    (Left !msg) -> Just . Left <$!> return msg
+    (Right !msg) -> fmap Right <$!> b msg
 {-# INLINEABLE maybeLogHandler #-}
 
 logHandles :: Monoid b => Foldable f => f LogHandler -> GenericBackend b -> GenericBackend b
@@ -492,7 +492,7 @@ withElasticsearchBackend mgr esServer ixName inner = do
   where
     curIxName = do
         d <- T.pack . formatTime defaultTimeLocale "%Y.%m.%d" <$> getCurrentTime
-        return $ ixName <> "-" <> d
+        return $! ixName <> "-" <> d
 
     errorLogFun Error msg = T.hPutStrLn stderr msg
     errorLogFun _ _ = return ()
@@ -517,14 +517,14 @@ withElasticsearchBackend mgr esServer ixName inner = do
         errorLogFun Info $ "send " <> sshow (elasticSearchBatchSize - remaining) <> " messages"
         void $ HTTP.httpLbs (putBulgLog batch) mgr
       where
-        go _ 0 !batch _ = return (0, batch)
+        go _ 0 !batch _ = return $! (0, batch)
         go i !remaining !batch !timer = isTimeout `orElse` fill
           where
             isTimeout = do
                 check =<< readTVar timer
-                return (remaining, batch)
+                return $! (remaining, batch)
             fill = tryReadTBQueue queue >>= \case
-                Nothing -> return (remaining, batch)
+                Nothing -> return $! (remaining, batch)
                 Just x -> do
                     go i (pred remaining) (batch <> indexAction i x) timer
 


### PR DESCRIPTION
General audit of the source code for:

  - forcing arguments passed to monadic `return` (this avoids thunk creation and helps compiler w/ strictness analysis)
  - making sure we use strict versions of mutref modifying functions like `modifyIORef'` and `modifyTVar'`
  - aeson: use versions of the decode functions that do not defer numeric conversion