### PR TITLE
-Widentities

### DIFF
--- a/chainweb.cabal
+++ b/chainweb.cabal
@@ -64,6 +64,7 @@ common warning-flags
         -Werror
         -Wincomplete-record-updates
         -Wincomplete-uni-patterns
+        -Widentities
 
 custom-setup
     setup-depends:

--- a/src/Chainweb/Chainweb/ChainResources.hs
+++ b/src/Chainweb/Chainweb/ChainResources.hs
@@ -210,13 +210,15 @@ runMempoolSyncClient mgr memP2pConfig chain = bracket create destroy go
     syncLogger = setComponent "mempool-sync" $ _chainResLogger chain
 
 mempoolSyncP2pSession :: ChainResources logger -> Seconds -> P2pSession
-mempoolSyncP2pSession chain pollInterval logg0 env _ =
+mempoolSyncP2pSession chain (Seconds pollInterval) logg0 env _ =
     flip catches [ Handler errorHandler ] $ do
         logg Debug "mempool sync session starting"
         Mempool.syncMempools' logg syncIntervalUs pool peerMempool
         logg Debug "mempool sync session finished"
         return True
   where
+    -- FIXME Potentially dangerous down-cast.
+    syncIntervalUs :: Int
     syncIntervalUs = int pollInterval * 1000000
 
     remote = T.pack $ Sv.showBaseUrl $ Sv.baseUrl env

--- a/src/Chainweb/Crypto/MerkleLog.hs
+++ b/src/Chainweb/Crypto/MerkleLog.hs
@@ -470,7 +470,8 @@ toMerkleNodeTagged b = case toMerkleNode @u @b b of
         $ fromWordBE @Word16 tag <> bytes
     TreeNode r -> TreeNode @(HashAlg u) r
   where
-    tag = fromIntegral $ tagVal @u @(Tag b)
+    tag :: Word16
+    tag = tagVal @u @(Tag b)
 
 -- | /Internal:/ Decode Merkle nodes that are tagged with the respedtive type
 -- from the Merkle universe.
@@ -826,4 +827,3 @@ instance
     fromMerkleNode (TreeNode _) = throwM expectedInputNodeException
     {-# INLINE toMerkleNode #-}
     {-# INLINE fromMerkleNode #-}
-

--- a/src/Chainweb/Difficulty.hs
+++ b/src/Chainweb/Difficulty.hs
@@ -105,7 +105,7 @@ import Text.Printf (printf)
 import Chainweb.Crypto.MerkleLog
 import Chainweb.MerkleUniverse
 import Chainweb.PowHash
-import Chainweb.Time (Seconds, TimeSpan(..))
+import Chainweb.Time (Seconds(..), TimeSpan(..))
 import Chainweb.Utils
 import Chainweb.Version (ChainwebVersion(..))
 
@@ -518,7 +518,7 @@ adjust ver (WindowWidth ww) (TimeSpan delta) oldTarget
   where
     br :: Natural
     br = case blockRate ver of
-        Just (BlockRate n) -> int n
+        Just (BlockRate (Seconds n)) -> int n
         Nothing -> error $ "adjust: Difficulty adjustment attempted on non-POW chainweb: " <> show ver
 
     minAdj :: PowHashNat

--- a/src/Chainweb/Mempool/Mempool.hs
+++ b/src/Chainweb/Mempool/Mempool.hs
@@ -494,7 +494,7 @@ putDecimal (Decimal places mantissa) = do
 
 getDecimal :: MonadGet m => m Decimal
 getDecimal = do
-    !places <- fromIntegral <$> getWord8
+    !places <- getWord8
     !negative <- getWord8
     numWords <- fromIntegral <$> getWord16le
     mantissaWords <- replicateM numWords getWord64le

--- a/src/Chainweb/Miner/Test.hs
+++ b/src/Chainweb/Miner/Test.hs
@@ -53,7 +53,7 @@ import Chainweb.NodeId (NodeId)
 import Chainweb.Payload
 import Chainweb.Payload.PayloadStore
 import Chainweb.Sync.WebBlockHeaderStore
-import Chainweb.Time (getCurrentTimeIntegral)
+import Chainweb.Time (Seconds(..), getCurrentTimeIntegral)
 import Chainweb.Utils
 import Chainweb.Version
 import Chainweb.WebPactExecutionService
@@ -173,7 +173,7 @@ testMiner logFun conf nid cutDb = runForever logFun "Test Miner" $ do
       where
         meanBlockTime :: Double
         meanBlockTime = case blockRate ver of
-            Just (BlockRate n) -> int n
+            Just (BlockRate (Seconds n)) -> int n
             Nothing -> error $ "No BlockRate available for given ChainwebVersion: " <> show ver
 
     -- | Assemble the new block.

--- a/src/Chainweb/Time.hs
+++ b/src/Chainweb/Time.hs
@@ -61,7 +61,7 @@ module Chainweb.Time
 , day
 
 -- * Seconds
-, Seconds
+, Seconds(..)
 , secondsToTimeSpan
 , secondsToText
 , secondsFromText
@@ -71,13 +71,13 @@ import Control.DeepSeq
 import Control.Monad.Catch
 
 import Data.Aeson (FromJSON, ToJSON)
-import qualified Data.Memory.Endian as BA
 import Data.Bytes.Get
 import Data.Bytes.Put
 import Data.Bytes.Signed
 import Data.Hashable (Hashable)
 import Data.Int
 import Data.Kind
+import qualified Data.Memory.Endian as BA
 import qualified Data.Text as T
 import Data.Time.Clock.POSIX
 import Data.Word
@@ -245,7 +245,7 @@ newtype Seconds = Seconds Integer
     deriving (Show, Eq, Ord, Generic)
     deriving anyclass (Hashable, NFData)
     deriving newtype (FromJSON, ToJSON)
-    deriving newtype (Num, Enum, Real, Integral)
+    deriving newtype (Num, Enum, Real)
 
 secondsToTimeSpan :: Num a => Seconds -> TimeSpan a
 secondsToTimeSpan (Seconds s) = scaleTimeSpan s second

--- a/test/Chainweb/Test/MultiNode.hs
+++ b/test/Chainweb/Test/MultiNode.hs
@@ -86,7 +86,7 @@ import Chainweb.Miner.Config
 import Chainweb.NodeId
 import Chainweb.Test.P2P.Peer.BootstrapConfig
 import Chainweb.Test.Utils
-import Chainweb.Time (Seconds)
+import Chainweb.Time (Seconds(..))
 import Chainweb.Utils
 import Chainweb.Version
 import Chainweb.WebBlockHeaderDB
@@ -275,7 +275,7 @@ runNodesForSeconds
     -> (T.Text -> IO ())
         -- ^ logging backend callback
     -> IO (Maybe Stats)
-runNodesForSeconds loglevel v n seconds write = do
+runNodesForSeconds loglevel v n (Seconds seconds) write = do
     stateVar <- newMVar $ emptyConsensusState v
     void $ timeout (int seconds * 1000000)
         $ runNodes loglevel write stateVar v n
@@ -414,18 +414,18 @@ consensusStateSummary s
     medHeight = median $ HM.elems cutHeights
 
 expectedBlockCount :: ChainwebVersion -> Seconds -> Natural
-expectedBlockCount v seconds = round ebc
+expectedBlockCount v (Seconds seconds) = round ebc
   where
     ebc :: Double
     ebc = int seconds * int (order $ _chainGraph v) / int br
 
     br :: Natural
     br = case blockRate v of
-        Just (BlockRate n) -> int n
+        Just (BlockRate (Seconds n)) -> int n
         Nothing -> error $ "expectedBlockCount: ChainwebVersion with no BlockRate given: " <> show v
 
 lowerStats :: ChainwebVersion -> Seconds -> Stats
-lowerStats v seconds = Stats
+lowerStats v (Seconds seconds) = Stats
     { _statBlockCount = round $ ebc * 0.3 -- temporarily, was 0.8
     , _statMaxHeight = round $ ebc * 0.3 -- temporarily, was 0.7
     , _statMinHeight = round $ ebc * 0.09 -- temporarily, was 0.3
@@ -438,11 +438,11 @@ lowerStats v seconds = Stats
 
     br :: Natural
     br = case blockRate v of
-        Just (BlockRate n) -> int n
+        Just (BlockRate (Seconds n)) -> int n
         Nothing -> error $ "lowerStats: ChainwebVersion with no BlockRate given: " <> show v
 
 upperStats :: ChainwebVersion -> Seconds -> Stats
-upperStats v seconds = Stats
+upperStats v (Seconds seconds) = Stats
     { _statBlockCount = round $ ebc * 1.2
     , _statMaxHeight = round $ ebc * 1.2
     , _statMinHeight = round $ ebc * 1.2
@@ -455,5 +455,5 @@ upperStats v seconds = Stats
 
     br :: Natural
     br = case blockRate v of
-        Just (BlockRate n) -> int n
+        Just (BlockRate (Seconds n)) -> int n
         Nothing -> error $ "upperStats: ChainwebVersion with no BlockRate given: " <> show v


### PR DESCRIPTION
This PR adds `-Widentities` to our warnings, and fixes the issues it highlights.

From the GHC User's Guide:

> Causes the compiler to emit a warning when a Prelude numeric conversion converts a type T to the same type T; such calls are probably no-ops and can be omitted. The functions checked for are: toInteger, toRational, fromIntegral, and realToFrac.