### PR TITLE
-Wcompat and -Wpartial-fields

### DIFF
--- a/chainweb.cabal
+++ b/chainweb.cabal
@@ -62,6 +62,8 @@ common warning-flags
     ghc-options:
         -Wall
         -Werror
+        -Wcompat
+        -Wpartial-fields
         -Wincomplete-record-updates
         -Wincomplete-uni-patterns
         -Widentities

--- a/tools/txg/TXG.hs
+++ b/tools/txg/TXG.hs
@@ -96,8 +96,8 @@ generateDelay = do
   distribution <- asks confTimingDist
   gen <- gets gsGen
   case distribution of
-    Just (Gaussian gmean gvar) -> liftIO (truncate <$> normal gmean gvar gen)
-    Just (Uniform ulow uhigh) -> liftIO (truncate <$> uniformR (ulow, uhigh) gen)
+    Just (GaussianTD (Gaussian gmean gvar)) -> liftIO (truncate <$> normal gmean gvar gen)
+    Just (UniformTD (Uniform ulow uhigh)) -> liftIO (truncate <$> uniformR (ulow, uhigh) gen)
     Nothing -> error "generateDelay: impossible"
 
 generateSimpleTransactions

--- a/tools/txg/TXG/Types.hs
+++ b/tools/txg/TXG/Types.hs
@@ -22,6 +22,7 @@ module TXG.Types
     TXCmd(..)
     -- * Timing
   , TimingDistribution(..)
+  , Gaussian(..), Uniform(..)
     -- * Args
   , Args(..)
   , defaultArgs
@@ -66,14 +67,20 @@ import qualified Utils.Logging.Config as U
 
 ---
 
-data TimingDistribution
-  = Gaussian { mean  :: !Double, var   :: !Double }
-  | Uniform  { low   :: !Double, high  :: !Double }
+data TimingDistribution = GaussianTD Gaussian | UniformTD Uniform
+  deriving (Eq, Show, Generic)
+  deriving anyclass (FromJSON, ToJSON)
+
+data Gaussian = Gaussian { mean :: !Double, var :: !Double }
+  deriving (Eq, Show, Generic)
+  deriving anyclass (FromJSON, ToJSON)
+
+data Uniform = Uniform { low :: !Double, high :: !Double }
   deriving (Eq, Show, Generic)
   deriving anyclass (FromJSON, ToJSON)
 
 defaultTimingDist :: TimingDistribution
-defaultTimingDist = Gaussian 1000000 (1000000 / 16)
+defaultTimingDist = GaussianTD $ Gaussian 1000000 (1000000 / 16)
 
 data TXCmd
   = DeployContracts [Sim.ContractName]


### PR DESCRIPTION
In the spirit of #223 , this PR adds two more warning flags. 

From the GHC User Guide:

> The option `-Wpartial-fields` warns about record fields that could fail when accessed via a lacking constructor. 

> `-Wcompat` turns on warnings that will be enabled by default in the future, but remain off in normal compilations for the time being. This allows library authors eager to make their code future compatible to adapt to new features before they even generate warnings.