### PR TITLE
TXG: Single Transactions

### DIFF
--- a/tools/txg/TXG.hs
+++ b/tools/txg/TXG.hs
@@ -30,10 +30,12 @@ import Configuration.Utils hiding (Error, Lens', (<.>))
 
 import Control.Concurrent.Async (mapConcurrently_)
 import Control.Concurrent.STM.TVar (modifyTVar')
+import Control.Error.Util (hushT, nothing)
 import Control.Lens hiding (op, (.=), (|>))
 import Control.Monad.Except
 import Control.Monad.Reader hiding (local)
 import Control.Monad.State.Strict
+import Control.Monad.Trans.Maybe (MaybeT(..))
 
 import Data.Generics.Product.Fields (field)
 import qualified Data.HashSet as HS
@@ -190,13 +192,12 @@ generateTransactions = do
         _ -> error "SimplePayments.CreateAccount code generation not supported"
 
 sendTransactions
-  :: MonadIO m
-  => ChainId
+  :: TXGConfig
+  -> ChainId
   -> [Command Text]
-  -> TXG m (Either ClientError RequestKeys)
-sendTransactions cid cmds = do
-  TXGConfig _ _ cenv v _ <- ask
-  liftIO $ runClientM (send v cid $ SubmitBatch cmds) cenv
+  -> IO (Either ClientError RequestKeys)
+sendTransactions (TXGConfig _ _ cenv v _) cid cmds =
+  runClientM (send v cid $ SubmitBatch cmds) cenv
 
 loop
   :: (MonadIO m, MonadLog SomeLogMessage m)
@@ -204,7 +205,8 @@ loop
   -> TXG m ()
 loop f = do
   (cid, transactions) <- f
-  requestKeys <- sendTransactions cid transactions
+  config <- ask
+  requestKeys <- liftIO $ sendTransactions config cid transactions
 
   case requestKeys of
     Left servantError ->
@@ -333,6 +335,26 @@ listenerRequestKey config host listenerRequest = do
     cid :: ChainId
     cid = fromMaybe (unsafeChainId 0) . listToMaybe $ nodeChainIds config
 
+-- | Send a single transaction to the network, and immediately listen for its result.
+singleTransaction :: Args -> HostAddress -> SingleTX -> IO ()
+singleTransaction args host (SingleTX c cid) = do
+  cfg <- mkTXGConfig Nothing args host
+  kps <- testSomeKeyPairs
+  cmd <- mkExec (T.unpack c) (datum kps) (Sim.makeMeta cid) kps Nothing
+  runMaybeT (f cfg cmd) >>= \case
+    Nothing -> putStrLn "Single Transaction: failed" >> exitWith (ExitFailure 1)
+    Just res -> pPrintNoColor res
+  where
+    datum :: [SomeKeyPair] -> Value
+    datum kps = object ["test-admin-keyset" .= fmap formatB16PubKey kps]
+
+    -- TODO Make `ExceptT` once `RequestKeys` is a `NonEmpty`.
+    f :: TXGConfig -> Command Text -> MaybeT IO ListenResponse
+    f cfg@(TXGConfig _ _ ce v _) cmd =
+      hushT (ExceptT $ sendTransactions cfg cid [cmd]) >>= \case
+        RequestKeys [] -> nothing
+        RequestKeys (rk:_) -> hushT . ExceptT $ runClientM (listen v cid $ ListenerRequest rk) ce
+
 work :: Args -> IO ()
 work cfg = do
   mgr <- newManager defaultManagerSettings
@@ -368,6 +390,8 @@ work cfg = do
           pollRequestKeys cfg host . RequestKey $ H.Hash rk
         ListenerRequestKey rk -> liftIO $
           listenerRequestKey cfg host . ListenerRequest . RequestKey $ H.Hash rk
+        SingleTransaction stx -> liftIO $
+          singleTransaction cfg host stx
 
 main :: IO ()
 main = runWithConfiguration mainInfo $ \config -> do

--- a/tools/txg/TXG/Simulate/Contracts/Common.hs
+++ b/tools/txg/TXG/Simulate/Contracts/Common.hs
@@ -113,7 +113,7 @@ parens s = "(" ++ s ++ ")"
 makeMeta :: ChainId -> CM.PublicMeta
 makeMeta cid = CM.PublicMeta (CM.ChainId $ toText cid) "sender00" 100 0.0001
 
-newtype ContractName = ContractName { getContractName :: String}
+newtype ContractName = ContractName { getContractName :: String }
   deriving (Eq, Ord, Show, Generic)
   deriving newtype Read
 

--- a/tools/txg/TXG/Types.hs
+++ b/tools/txg/TXG/Types.hs
@@ -20,6 +20,7 @@
 module TXG.Types
   ( -- * TXCmd
     TXCmd(..)
+  , SingleTX(..)
     -- * Timing
   , TimingDistribution(..)
   , Gaussian(..), Uniform(..)
@@ -88,7 +89,12 @@ data TXCmd
   | RunSimpleExpressions TimingDistribution
   | PollRequestKeys ByteString
   | ListenerRequestKey ByteString
+  | SingleTransaction SingleTX
   deriving (Show, Eq, Generic)
+  deriving anyclass (FromJSON, ToJSON)
+
+data SingleTX = SingleTX { _stxCmd :: Text, _stxChainId :: ChainId }
+  deriving (Eq, Show, Generic)
   deriving anyclass (FromJSON, ToJSON)
 
 transactionCommandToText :: TXCmd -> Text


### PR DESCRIPTION
This PR allows one to send a single TX and immediately wait for the result (via an internal `listen/` call).

Sample output, having sent `(+ 1 2)`:
```
ListenResponse 
    ( CommandResult 
        { _crReqKey = "O4pvMdZB9IzsvjrD4PfCsqZhOxa50ha98EFuONABvyo"
        , _crTxId = Just 120
        , _crResult = PactResult ( Right ( PLiteral ( LDecimal { _lDecimal = 3 } ) ) )
        , _crGas = Gas 1
        , _crLogs = Just "1sG131AkRe4pR0oMjpcvhYIfMP_VhYk5wTZ6sVoxhNI"
        , _crContinuation = Nothing
        , _crMetaData = Nothing
        } 
    )
```