### PR TITLE
Rework mempool sync logic.

### DIFF
--- a/src/Chainweb/Chainweb.hs
+++ b/src/Chainweb/Chainweb.hs
@@ -313,9 +313,11 @@ mempoolConfig = Mempool.InMemConfig
     Mempool.chainwebTransactionConfig
     blockGasLimit
     mempoolReapInterval
+    maxRecentLog
   where
-    blockGasLimit = 1000000                 -- TODO: policy decision
+    blockGasLimit = 1000000               -- TODO: policy decision
     mempoolReapInterval = 60 * 20 * 1000000   -- 20 mins
+    maxRecentLog = 2048                   -- store 2k recent transaction hashes
 
 -- Intializes all local chainweb components but doesn't start any networking.
 --

--- a/src/Chainweb/Mempool/InMem.hs
+++ b/src/Chainweb/Mempool/InMem.hs
@@ -11,48 +11,40 @@ module Chainweb.Mempool.InMem
   (
    -- * Initialization functions
     withInMemoryMempool
-  , withTxBroadcaster
-
     -- * Low-level create/destroy functions
   , makeSelfFinalizingInMemPool
+
+    -- * Low-level create/destroy functions
   , makeInMemPool
   , newInMemMempoolData
-  , createTxBroadcaster
-  , destroyTxBroadcaster
   ) where
 
 ------------------------------------------------------------------------------
 import Control.Applicative (pure, (<|>))
-import Control.Concurrent (forkIOWithUnmask, killThread, threadDelay, withMVar)
+import Control.Concurrent (forkIOWithUnmask, killThread, threadDelay)
 import Control.Concurrent.MVar
-    (MVar, modifyMVarMasked_, newEmptyMVar, newMVar, putMVar, readMVar,
-    takeMVar, withMVarMasked)
-import Control.Concurrent.STM
-import qualified Control.Concurrent.STM.TBMChan as TBMChan
-import Control.Exception
-    (AsyncException(ThreadKilled), SomeException, bracket, bracketOnError,
-    evaluate, finally, handle, mask_, throwIO)
-import Control.Monad (forever, join, void, (<$!>), (>=>))
+    (MVar, newMVar, readMVar, withMVar, withMVarMasked)
+import Control.Exception (bracket, bracketOnError, mask_)
+import Control.Monad (forever, void, (<$!>))
 
-import Data.Foldable (foldl', foldlM, traverse_)
+import Data.Foldable (foldl', foldlM)
 import qualified Data.HashMap.Strict as HashMap
 import qualified Data.HashPSQ as PSQ
 import qualified Data.HashSet as HashSet
 import Data.Int (Int64)
 import Data.IORef
-    (IORef, atomicModifyIORef', mkWeakIORef, modifyIORef', newIORef, readIORef,
-    writeIORef)
-import Data.Maybe (isJust)
+    (IORef, mkWeakIORef, modifyIORef', newIORef, readIORef, writeIORef)
 import Data.Ord (Down(..))
 import Data.Vector (Vector)
 import qualified Data.Vector as V
+import Data.Word (Word64)
+import Foreign.ForeignPtr
+import Foreign.Storable
+import GHC.ForeignPtr
 
 import Pact.Types.Gas (GasPrice(..))
 
 import Prelude hiding (init, lookup)
-
-import qualified System.Mem.Weak as Weak
-import System.Timeout (timeout)
 
 -- internal imports
 
@@ -68,147 +60,16 @@ toPriority r s = (Down r, s)
 
 
 ------------------------------------------------------------------------------
--- | Runs a user computation with a newly-created transaction broadcaster. The
--- broadcaster is destroyed after the user function runs.
-withTxBroadcaster :: (TxBroadcaster t -> IO a) -> IO a
-withTxBroadcaster = bracket createTxBroadcaster destroyTxBroadcaster
-
-
-------------------------------------------------------------------------------
--- | Creates a 'TxBroadcaster' object. Normally 'withTxBroadcaster' should be
--- used instead. Care should be taken in 'bracket'-style initialization
--- functions to get the exception handling right; if 'destroyTxBroadcaster' is
--- not called the broadcaster thread will leak.
-createTxBroadcaster :: IO (TxBroadcaster t)
-createTxBroadcaster = mask_ $ do
-    idgen <- newIORef 0
-    threadMV <- newEmptyMVar
-    doneMV <- newEmptyMVar
-    q <- atomically $ TBMChan.newTBMChan _defaultTxQueueLen
-    let !tx = TxBroadcaster idgen threadMV q doneMV
-    forkIOWithUnmask (broadcasterThread tx) >>= putMVar threadMV
-    return tx
-
-
-------------------------------------------------------------------------------
--- | Destroys a 'TxBroadcaster' object.
-destroyTxBroadcaster :: TxBroadcaster t -> IO ()
-destroyTxBroadcaster (TxBroadcaster _ _ q doneMV) = do
-    atomically $ TBMChan.writeTBMChan q Close
-    readMVar doneMV
-
-
-------------------------------------------------------------------------------
-broadcastTxs :: Vector t -> TxBroadcaster t -> IO ()
-broadcastTxs txs (TxBroadcaster _ _ q _) =
-    -- TODO: timeout here?
-    atomically $ void $ TBMChan.writeTBMChan q (Transactions txs)
-
--- FIXME: read this from config
-tout :: TxBroadcaster t -> IO a -> IO (Maybe a)
-tout _ m = timeout 2000000 m
-
-
-------------------------------------------------------------------------------
--- | Subscribe to a 'TxBroadcaster'.
-subscribeInMem :: TxBroadcaster t -> IO (IORef (Subscription t))
-subscribeInMem broadcaster = do
-    let q = _txbQueue broadcaster
-    subQ <- atomically $ TBMChan.newTBMChan defaultQueueLen
-    subId <- nextTxId $! _txbSubIdgen broadcaster
-    let final = atomically $ TBMChan.writeTBMChan q (Unsubscribe subId)
-    let !sub = Subscription subQ final
-    done <- newEmptyMVar
-    let !item = Subscribe subId sub done
-    -- TODO: timeout here
-    atomically $ TBMChan.writeTBMChan q item
-    takeMVar done
-  where
-    defaultQueueLen = 64
-
-
-------------------------------------------------------------------------------
--- | The transcription broadcaster thread reads commands from its channel and
--- dispatches them. Once a 'Close' command comes through, the broadcaster
--- thread closes up shop and returns.
-broadcasterThread :: TxBroadcaster t -> (forall a . IO a -> IO a) -> IO ()
-broadcasterThread broadcaster@(TxBroadcaster _ _ q doneMV) restore =
-    eatExceptions (restore $ bracket init cleanup go)
-      `finally` putMVar doneMV ()
-  where
-    -- Initially we start with no subscribers.
-    init :: IO (MVar (TxSubscriberMap t))
-    init = newMVar HashMap.empty
-
-    -- Our cleanup action is to traverse the subscriber map and call
-    -- TBMChan.closeTBMChan on any valid subscriber references. Subscribers
-    -- should then be notified that the broadcaster is finished.
-    cleanup mapMV = do
-        readMVar mapMV >>= traverse_ closeWeakChan
-
-    -- The main loop. Reads a command from the channel and dispatches it,
-    -- forever.
-    go !mapMV = forever . void $ do
-        cmd <- atomically $ TBMChan.readTBMChan q
-        maybe goodbyeCruelWorld (processCmd mapMV) cmd
-
-    processCmd mv x = modifyMVarMasked_ mv $ flip processCmd' x
-
-    -- new subscriber: add it to the map
-    processCmd' hm (Subscribe sid s done) = do
-        ref <- newIORef s
-        w <- mkWeakIORef ref (mempoolSubFinal s)
-        putMVar done ref
-        return $! HashMap.insert sid w hm
-    -- unsubscribe: call finalizer and delete from subscriber map
-    processCmd' hm (Unsubscribe sid) = do
-        (join <$> mapM Weak.deRefWeak (HashMap.lookup sid hm)) >>=
-            mapM_ (readIORef >=> closeChan)
-        return $! HashMap.delete sid hm
-    -- throw 'ThreadKilled' on receiving 'Close' -- cleanup will be called
-    processCmd' hm Close = do
-        goodbyeCruelWorld >> return hm
-    processCmd' hm (Transactions v) = broadcast v hm
-
-    -- ignore any exceptions received
-    eatExceptions = handle $ \(e :: SomeException) -> void $ evaluate e
-
-    closeWeakChan w = Weak.deRefWeak w >>=
-                      maybe (return ()) (readIORef >=> closeChan)
-    closeChan m = do
-        atomically . TBMChan.closeTBMChan $ mempoolSubChan m
-
-    -- TODO: write to subscribers in parallel
-    broadcast txV hm = do
-        let subs = HashMap.toList hm
-        foldlM (write txV) hm subs
-
-    write txV hm (sid, w) = do
-        ms <- Weak.deRefWeak w >>= mapM readIORef
-        case ms of
-          -- delete mapping if weak ref expires
-          Nothing -> do
-              return $! HashMap.delete sid hm
-          (Just s) -> do
-              m <- tout broadcaster $ atomically $ void $
-                   TBMChan.writeTBMChan (mempoolSubChan s) txV
-              -- close chan and delete mapping on timeout.
-              maybe (do atomically $ TBMChan.closeTBMChan (mempoolSubChan s)
-                        return $! HashMap.delete sid hm)
-                    (const $ return hm)
-                    m
-
-    goodbyeCruelWorld = throwIO ThreadKilled
-
-
-------------------------------------------------------------------------------
 makeInMemPool :: InMemConfig t
-              -> TxBroadcaster t
               -> IO (InMemoryMempool t)
-makeInMemPool cfg txB = mask_ $ do
+makeInMemPool cfg = mask_ $ do
     dataLock <- newInMemMempoolData >>= newMVar
     tid <- forkIOWithUnmask (reaperThread cfg dataLock)
-    return $! InMemoryMempool cfg dataLock txB tid
+    return $! InMemoryMempool cfg dataLock tid
+
+destroyInMemPool :: InMemoryMempool t -> IO ()
+destroyInMemPool = mask_ . killThread . _inmemReaper
+
 
 ------------------------------------------------------------------------------
 newInMemMempoolData :: IO (InMemoryMempoolData t)
@@ -216,15 +77,22 @@ newInMemMempoolData = InMemoryMempoolData <$!> newIORef PSQ.empty
                            <*> newIORef HashMap.empty
                            <*> newIORef HashSet.empty
                            <*> newIORef Nothing
+                           <*> newZeroCounter
+  where
+    newZeroCounter = do
+        let !val = 0 :: Word64
+        fp <- mallocPlainForeignPtrAlignedBytes 8 (alignment val)
+        withForeignPtr fp (flip poke val)
+        return fp
+
 
 ------------------------------------------------------------------------------
 makeSelfFinalizingInMemPool :: InMemConfig t
                             -> IO (MempoolBackend t)
 makeSelfFinalizingInMemPool cfg =
-    mask_ $ bracketOnError createTxBroadcaster destroyTxBroadcaster $ \txb -> do
-        mpool <- makeInMemPool cfg txb
+    mask_ $ bracketOnError (makeInMemPool cfg) destroyInMemPool $ \mpool -> do
         ref <- newIORef mpool
-        wk <- mkWeakIORef ref (destroyTxBroadcaster txb)
+        wk <- mkWeakIORef ref (destroyInMemPool mpool)
         back <- toMempoolBackend mpool
         let txcfg = mempoolTxConfig back
         let bsl = mempoolBlockGasLimit back
@@ -246,12 +114,17 @@ wrapBackend txcfg bsl mp =
       , mempoolMarkValidated = withRef mp . flip mempoolMarkValidated
       , mempoolMarkConfirmed = withRef mp . flip mempoolMarkConfirmed
       , mempoolReintroduce = withRef mp . flip mempoolReintroduce
-      , mempoolGetPendingTransactions = withRef mp . flip mempoolGetPendingTransactions
-      , mempoolSubscribe = withRef mp mempoolSubscribe
-      , mempoolShutdown = withRef mp mempoolShutdown
+      , mempoolGetPendingTransactions = getPnd mp
       , mempoolClear = withRef mp mempoolClear
       }
     where
+      getPnd (ref, _wk) a b = do
+          mpl <- readIORef ref
+          mb <- toMempoolBackend mpl
+          x <- mempoolGetPendingTransactions mb a b
+          writeIORef ref mpl
+          return x
+
       withRef (ref, _wk) f = do
             mpl <- readIORef ref
             mb <- toMempoolBackend mpl
@@ -272,11 +145,11 @@ reaperThread cfg dataLock restore = forever $ do
     txcfg = _inmemTxCfg cfg
     expiryTime = txMetaExpiryTime . (txMetadata txcfg)
     interval = _inmemReaperIntervalMicros cfg
-    reap (InMemoryMempoolData pendingRef _ _ _) = do
+    reap (InMemoryMempoolData pendingRef _ _ _ _) = do
         now <- Time.getCurrentTimeIntegral
         modifyIORef' pendingRef $ reapPending now
 
-    reapPending now pending =
+    reapPending !now !pending =
         let agg k _ !tx !txs = if expiryTime tx <= now
                                then (k:txs) else txs
             tooOld = PSQ.fold' agg [] pending
@@ -287,7 +160,7 @@ toMempoolBackend
     :: InMemoryMempool t
     -> IO (MempoolBackend t)
 toMempoolBackend mempool = do
-    return $ MempoolBackend
+    return $! MempoolBackend
       { mempoolTxConfig = tcfg
       , mempoolBlockGasLimit = blockSizeLimit
       , mempoolMember = member
@@ -298,26 +171,21 @@ toMempoolBackend mempool = do
       , mempoolMarkConfirmed = markConfirmed
       , mempoolReintroduce = reintroduce
       , mempoolGetPendingTransactions = getPending
-      , mempoolSubscribe = subscribe
-      , mempoolShutdown = shutdown
       , mempoolClear = clear
       }
   where
     cfg = _inmemCfg mempool
     lockMVar = _inmemDataLock mempool
-    broadcaster = _inmemBroadcaster mempool
 
     InMemConfig tcfg blockSizeLimit _ = cfg
     member = memberInMem lockMVar
     lookup = lookupInMem lockMVar
-    insert = insertInMem broadcaster cfg lockMVar
+    insert = insertInMem cfg lockMVar
     getBlock = getBlockInMem cfg lockMVar
     markValidated = markValidatedInMem cfg lockMVar
     markConfirmed = markConfirmedInMem lockMVar
-    reintroduce = reintroduceInMem broadcaster cfg lockMVar
+    reintroduce = reintroduceInMem cfg lockMVar
     getPending = getPendingInMem cfg lockMVar
-    subscribe = subscribeInMem broadcaster
-    shutdown = shutdownInMem broadcaster
     clear = clearInMem lockMVar
 
 
@@ -326,19 +194,13 @@ toMempoolBackend mempool = do
 withInMemoryMempool :: InMemConfig t
                     -> (MempoolBackend t -> IO a)
                     -> IO a
-withInMemoryMempool cfg f =
-    withTxBroadcaster $ \txB -> do
-        let inMemIO = makeInMemPool cfg txB
-        let action inMem = do
-              back <- toMempoolBackend inMem
-              f back
-        bracket inMemIO destroyInMemPool action
+withInMemoryMempool cfg f = do
+    let action inMem = do
+          back <- toMempoolBackend inMem
+          f $! back
+    bracket (makeInMemPool cfg) destroyInMemPool action
 
 ------------------------------------------------------------------------------
-destroyInMemPool :: InMemoryMempool t -> IO ()
-destroyInMemPool (InMemoryMempool _ _ _ tid) = killThread tid
-
--------------------------------------------
 memberInMem :: MVar (InMemoryMempoolData t)
             -> Vector TransactionHash
             -> IO (Vector Bool)
@@ -383,22 +245,13 @@ lookupInMem lock txs = do
 
 
 ------------------------------------------------------------------------------
-shutdownInMem :: TxBroadcaster t -> IO ()
-shutdownInMem broadcaster = atomically $ TBMChan.writeTBMChan q Close
-  where
-    q = _txbQueue broadcaster
-
-
-------------------------------------------------------------------------------
-insertInMem :: TxBroadcaster t  -- ^ transaction broadcaster
-            -> InMemConfig t    -- ^ in-memory config
+insertInMem :: InMemConfig t    -- ^ in-memory config
             -> MVar (InMemoryMempoolData t)  -- ^ in-memory state
             -> Vector t  -- ^ new transactions
             -> IO ()
-insertInMem broadcaster cfg lock txs = do
-    newTxs <- withMVarMasked lock $ \mdata ->
-        V.map fst . V.filter ((==True) . snd) <$> V.mapM (insOne mdata) txs
-    broadcastTxs newTxs broadcaster
+insertInMem cfg lock txs = do
+    withMVarMasked lock $ \mdata -> V.mapM_ (insOne mdata) txs
+
   where
     txcfg = _inmemTxCfg cfg
     validateTx = txValidate txcfg
@@ -487,14 +340,24 @@ markConfirmedInMem lock txhashes =
 ------------------------------------------------------------------------------
 getPendingInMem :: InMemConfig t
                 -> MVar (InMemoryMempoolData t)
+                -> Maybe MempoolTxId
                 -> (Vector TransactionHash -> IO ())
-                -> IO ()
-getPendingInMem cfg lock callback = do
-    psq <- readMVar lock >>= readIORef . _inmemPending
+                -> IO MempoolTxId
+getPendingInMem cfg lock _first callback = do
+    (psq, hw) <- readLock
+    -- TODO: either:
+    --  1) add a tx log, if _first is set then try to read off the tx log
+    --  2) (easier, slower) add tx id to maps and filter by it here
     (dl, sz) <- foldlM go initState psq
     void $ sendChunk dl sz
+    return hw
 
   where
+    readLock = withMVar lock $ \mdata -> do
+        !psq <- readIORef $ _inmemPending mdata
+        !hw <- withForeignPtr (_inmemNextTxId mdata) peek
+        return $! (psq, hw)
+
     initState = (id, 0)    -- difference list
     hash = txHasher $ _inmemTxCfg cfg
 
@@ -513,17 +376,13 @@ getPendingInMem cfg lock callback = do
     sendChunk dl _ = callback $ V.fromList $ dl []
 
 ------------------------------------------------------------------------------
-reintroduceInMem' :: TxBroadcaster t
-                 -> InMemConfig t
-                 -> MVar (InMemoryMempoolData t)
-                 -> Vector TransactionHash
-                 -> IO ()
-reintroduceInMem' broadcaster cfg lock txhashes = do
-    newOnes <- withMVarMasked lock $ \mdata ->
-                   V.map fromJuste . V.filter isJust <$>
-                   V.mapM (reintroduceOne mdata) txhashes
-    -- we'll rebroadcast reintroduced transactions, clients can filter.
-    broadcastTxs newOnes broadcaster
+reintroduceInMem' :: InMemConfig t
+                  -> MVar (InMemoryMempoolData t)
+                  -> Vector TransactionHash
+                  -> IO ()
+reintroduceInMem' cfg lock txhashes = do
+    withMVarMasked lock $ \mdata ->
+        V.mapM_ (reintroduceOne mdata) txhashes
 
   where
     txcfg = _inmemTxCfg cfg
@@ -534,20 +393,18 @@ reintroduceInMem' broadcaster cfg lock txhashes = do
                     in toPriority r s
     reintroduceOne mdata txhash = do
         m <- HashMap.lookup txhash <$> readIORef (_inmemValidated mdata)
-        maybe (return Nothing) (reintroduceIt mdata txhash) m
+        maybe (return ()) (reintroduceIt mdata txhash) m
     reintroduceIt mdata txhash (ValidatedTransaction _ _ tx) = do
         modifyIORef' (_inmemValidated mdata) $ HashMap.delete txhash
         modifyIORef' (_inmemPending mdata) $ PSQ.insert txhash (getPriority tx) tx
-        return $! Just tx
 
 ------------------------------------------------------------------------------
-reintroduceInMem :: TxBroadcaster t
-                 -> InMemConfig t
+reintroduceInMem :: InMemConfig t
                  -> MVar (InMemoryMempoolData t)
                  -> Vector t
                  -> IO ()
-reintroduceInMem broadcaster cfg lock txs =
-    reintroduceInMem' broadcaster cfg lock (V.map hashIt txs)
+reintroduceInMem cfg lock txs =
+    reintroduceInMem' cfg lock (V.map hashIt txs)
   where
     hashIt = txHasher $ _inmemTxCfg cfg
 
@@ -560,10 +417,3 @@ clearInMem lock = do
         writeIORef (_inmemConfirmed mdata) HashSet.empty
         -- we won't reset the broadcaster but that's ok, the same one can be
         -- re-used
-
-
-------------------------------------------------------------------------------
-nextTxId :: IORef SubscriptionId -> IO SubscriptionId
-nextTxId = flip atomicModifyIORef' (dup . (+1))
-  where
-    dup a = (a, a)

--- a/src/Chainweb/Mempool/InMem.hs
+++ b/src/Chainweb/Mempool/InMem.hs
@@ -429,5 +429,4 @@ clearInMem lock = do
         writeIORef (_inmemPending mdata) PSQ.empty
         writeIORef (_inmemValidated mdata) HashMap.empty
         writeIORef (_inmemConfirmed mdata) HashSet.empty
-        -- we won't reset the broadcaster but that's ok, the same one can be
-        -- re-used
+        writeIORef (_inmemRecentLog mdata) emptyRecentLog

--- a/src/Chainweb/Mempool/InMemTypes.hs
+++ b/src/Chainweb/Mempool/InMemTypes.hs
@@ -16,15 +16,11 @@ module Chainweb.Mempool.InMemTypes
   , PSQ
   , RecentItem
   , RecentLog(..)
-  , emptyRecentLog
-  , recordRecentTransactions
-  , getRecentTxs
   ) where
 
 ------------------------------------------------------------------------------
 import Control.Concurrent (ThreadId)
 import Control.Concurrent.MVar (MVar)
-import Control.DeepSeq
 
 import Data.HashMap.Strict (HashMap)
 import Data.HashPSQ (HashPSQ)
@@ -32,12 +28,8 @@ import Data.HashSet (HashSet)
 import Data.Int (Int64)
 import Data.IORef (IORef)
 import Data.Ord (Down(..))
-import Data.Vector (Vector)
-import qualified Data.Vector as V
 
 import Pact.Types.Gas (GasPrice(..))
-
-import Prelude hiding (pred)
 
 -- internal imports
 
@@ -94,37 +86,3 @@ data RecentLog = RecentLog {
     _rlNext :: {-# UNPACK #-} !MempoolTxId
   , _rlRecent :: ![RecentItem]
   }
-
-emptyRecentLog :: RecentLog
-emptyRecentLog = RecentLog 0 []
-
-recordRecentTransactions :: Int -> Vector TransactionHash -> RecentLog -> RecentLog
-recordRecentTransactions maxNumRecent newTxs rlog = rlog'
-  where
-    !rlog' = RecentLog { _rlNext = newNext
-                       , _rlRecent = newL
-                       }
-
-    numNewItems = V.length newTxs
-    oldNext = _rlNext rlog
-    newNext = oldNext + fromIntegral numNewItems
-    newTxs' = reverse ([oldNext..] `zip` V.toList newTxs)
-    newL' = newTxs' ++ _rlRecent rlog
-    newL = force $ take maxNumRecent newL'
-
-
--- | Get the recent transactions from the transaction log. Returns Nothing if
--- the old high water mark is too out of date.
-getRecentTxs :: Int -> MempoolTxId -> RecentLog -> Maybe (Vector TransactionHash)
-getRecentTxs maxNumRecent oldHw rlog =
-    if oldHw <= oldestHw || oldHw > oldNext
-      then Nothing
-      else if oldHw == oldNext
-              then Just V.empty
-              else Just $! txs
-
-  where
-    oldNext = _rlNext rlog
-    oldestHw = oldNext - fromIntegral maxNumRecent
-    txs = V.fromList $ map snd $ takeWhile pred $ _rlRecent rlog
-    pred x = fst x >= oldHw

--- a/src/Chainweb/Mempool/InMemTypes.hs
+++ b/src/Chainweb/Mempool/InMemTypes.hs
@@ -71,7 +71,7 @@ data InMemoryMempool t = InMemoryMempool {
     _inmemCfg :: InMemConfig t
   , _inmemDataLock :: MVar (InMemoryMempoolData t)
   , _inmemReaper :: ThreadId
-  -- TODO: reap expired transactions
+  , _inmemNonce :: ServerNonce
 }
 
 ------------------------------------------------------------------------------

--- a/src/Chainweb/Mempool/InMemTypes.hs
+++ b/src/Chainweb/Mempool/InMemTypes.hs
@@ -14,16 +14,11 @@ module Chainweb.Mempool.InMemTypes
   , InMemoryMempoolData(..)
   , Priority
   , PSQ
-  , SubscriptionId
-  , TxEdit (..)
-  , TxSubscriberMap
-  , TxBroadcaster(..)
   ) where
 
 ------------------------------------------------------------------------------
 import Control.Concurrent (ThreadId)
 import Control.Concurrent.MVar (MVar)
-import Control.Concurrent.STM.TBMChan (TBMChan)
 
 import Data.HashMap.Strict (HashMap)
 import Data.HashPSQ (HashPSQ)
@@ -31,12 +26,11 @@ import Data.HashSet (HashSet)
 import Data.Int (Int64)
 import Data.IORef (IORef)
 import Data.Ord (Down(..))
-import Data.Vector (Vector)
 import Data.Word (Word64)
 
-import Pact.Types.Gas (GasPrice(..))
+import Foreign.ForeignPtr
 
-import System.Mem.Weak (Weak)
+import Pact.Types.Gas (GasPrice(..))
 
 -- internal imports
 
@@ -51,27 +45,6 @@ type Priority = (Down GasPrice, Int64)
 -- | Priority search queue -- search by transaction hash in /O(log n)/ like a
 -- tree, find-min in /O(1)/ like a heap
 type PSQ t = HashPSQ TransactionHash Priority t
-
-type SubscriptionId = Word64
-
-------------------------------------------------------------------------------
--- | Transaction edits -- these commands will be sent to the broadcast thread
--- over an STM channel.
-data TxEdit t = Subscribe !SubscriptionId (Subscription t) (MVar (IORef (Subscription t)))
-              | Unsubscribe !SubscriptionId
-              | Transactions (Vector t)
-              | Close
-type TxSubscriberMap t = HashMap SubscriptionId (Weak (IORef (Subscription t)))
-
--- | The 'TxBroadcaster' is responsible for broadcasting new transactions out
--- to any readers. Commands are posted to the channel and are executed by a
--- helper thread.
-data TxBroadcaster t = TxBroadcaster {
-    _txbSubIdgen :: {-# UNPACK #-} !(IORef SubscriptionId)
-  , _txbThread :: {-# UNPACK #-} !(MVar ThreadId)
-  , _txbQueue :: {-# UNPACK #-} !(TBMChan (TxEdit t))
-  , _txbThreadDone :: {-# UNPACK #-} !(MVar ())
-}
 
 ------------------------------------------------------------------------------
 _defaultTxQueueLen :: Int
@@ -90,19 +63,19 @@ data InMemConfig t = InMemConfig {
 data InMemoryMempool t = InMemoryMempool {
     _inmemCfg :: InMemConfig t
   , _inmemDataLock :: MVar (InMemoryMempoolData t)
-  , _inmemBroadcaster :: TxBroadcaster t
   , _inmemReaper :: ThreadId
   -- TODO: reap expired transactions
 }
 
 ------------------------------------------------------------------------------
 data InMemoryMempoolData t = InMemoryMempoolData {
-    _inmemPending :: IORef (PSQ t)
+    _inmemPending :: !(IORef (PSQ t))
     -- | We've seen this in a valid block, but if it gets forked and loses
     -- we'll have to replay it.
     --
     -- N.B. atomic access to these IORefs is not necessary -- we hold the lock here.
-  , _inmemValidated :: IORef (HashMap TransactionHash (ValidatedTransaction t))
-  , _inmemConfirmed :: IORef (HashSet TransactionHash)
-  , _inmemLastNewBlockParent :: IORef (Maybe BlockHeader)
+  , _inmemValidated :: !(IORef (HashMap TransactionHash (ValidatedTransaction t)))
+  , _inmemConfirmed :: !(IORef (HashSet TransactionHash))
+  , _inmemLastNewBlockParent :: !(IORef (Maybe BlockHeader))
+  , _inmemNextTxId :: !(ForeignPtr Word64)   -- faster than IORef for counts
 }

--- a/src/Chainweb/Mempool/InMemTypes.hs
+++ b/src/Chainweb/Mempool/InMemTypes.hs
@@ -107,7 +107,8 @@ recordRecentTransactions maxNumRecent newTxs rlog = rlog'
     numNewItems = V.length newTxs
     oldNext = _rlNext rlog
     newNext = oldNext + fromIntegral numNewItems
-    newL' = _rlRecent rlog ++ ([oldNext..] `zip` V.toList newTxs)
+    newTxs' = reverse ([oldNext..] `zip` V.toList newTxs)
+    newL' = newTxs' ++ _rlRecent rlog
     newL = force $ take maxNumRecent newL'
 
 
@@ -124,5 +125,5 @@ getRecentTxs maxNumRecent oldHw rlog =
   where
     oldNext = _rlNext rlog
     oldestHw = oldNext - fromIntegral maxNumRecent
-    txs = V.fromList $ map snd $ filter pred $ _rlRecent rlog
+    txs = V.fromList $ map snd $ takeWhile pred $ _rlRecent rlog
     pred x = fst x >= oldHw

--- a/src/Chainweb/Mempool/Mempool.hs
+++ b/src/Chainweb/Mempool/Mempool.hs
@@ -107,7 +107,7 @@ data TransactionConfig t = TransactionConfig {
   }
 
 ------------------------------------------------------------------------------
-type MempoolTxId = Word64
+type MempoolTxId = Int64
 
 ------------------------------------------------------------------------------
 -- | Mempool backend API. Here @t@ is the transaction payload type.

--- a/src/Chainweb/Mempool/Mempool.hs
+++ b/src/Chainweb/Mempool/Mempool.hs
@@ -75,9 +75,8 @@ import Chainweb.Time (Time(..))
 import qualified Chainweb.Time as Time
 import Chainweb.Transaction
 import Chainweb.Utils
-    (Codec(..), decodeB64UrlNoPaddingText, encodeB64UrlNoPaddingText, sshow)
-import Chainweb.Utils (encodeToText)
-
+    (Codec(..), decodeB64UrlNoPaddingText, encodeB64UrlNoPaddingText,
+    encodeToText, sshow)
 import Data.LogMessage (LogFunctionText)
 
 ------------------------------------------------------------------------------
@@ -305,7 +304,7 @@ syncMempools' log0 us localMempool remoteMempool = sync
     deb :: Text -> IO ()
     deb = log0 Debug
 
-    sync = flip finally (deb "sync exiting") (initialSync >>= subsequentSync)
+    sync = finally (initialSync >>= subsequentSync) (deb "sync exiting")
 
     initialSync = do
         deb "Get full list of pending hashes from remote"

--- a/src/Chainweb/Mempool/Mempool.hs
+++ b/src/Chainweb/Mempool/Mempool.hs
@@ -20,6 +20,9 @@ module Chainweb.Mempool.Mempool
   , ValidatedTransaction(..)
   , LookupResult(..)
   , MockTx(..)
+  , ServerNonce
+  , HighwaterMark
+
   , chainwebTransactionConfig
   , mockCodec
   , mockEncode
@@ -108,6 +111,8 @@ data TransactionConfig t = TransactionConfig {
 
 ------------------------------------------------------------------------------
 type MempoolTxId = Int64
+type ServerNonce = Int
+type HighwaterMark = (ServerNonce, MempoolTxId)
 
 ------------------------------------------------------------------------------
 -- | Mempool backend API. Here @t@ is the transaction payload type.
@@ -145,9 +150,9 @@ data MempoolBackend t = MempoolBackend {
     -- the callback in chunks. No ordering of hashes is presupposed. Returns
     -- the remote high-water mark.
   , mempoolGetPendingTransactions
-      :: Maybe MempoolTxId                  -- previous high-water mark, if any
+      :: Maybe HighwaterMark                -- previous high-water mark, if any
       -> (Vector TransactionHash -> IO ())  -- chunk callback
-      -> IO MempoolTxId                     -- returns remote high water mark
+      -> IO HighwaterMark                   -- returns remote high water mark
 
   -- | A hook to clear the mempool. Intended only for the in-mem backend and
   -- only for testing.
@@ -186,7 +191,7 @@ noopMempool = do
     noopMarkValidated = const $ return ()
     noopMarkConfirmed = const $ return ()
     noopReintroduce = const $ return ()
-    noopGetPending = const $ const $ return 0
+    noopGetPending = const $ const $ return (0,0)
     noopClear = return ()
 
 

--- a/src/Chainweb/Mempool/RestAPI.hs
+++ b/src/Chainweb/Mempool/RestAPI.hs
@@ -97,8 +97,9 @@ type MempoolGetBlockApi v c t =
     QueryParam "blockSize" Int64 :> Post '[JSON] [t]
 type MempoolGetPendingApi v c t =
     'ChainwebEndpoint v :> ChainEndpoint c :> "mempool" :> "getPending" :>
+    QueryParam "nonce" ServerNonce :>
     QueryParam "since" MempoolTxId :>
-    StreamPost NetstringFraming JSON (Streams.InputStream (Either MempoolTxId [TransactionHash]))
+    StreamPost NetstringFraming JSON (Streams.InputStream (Either HighwaterMark [TransactionHash]))
 
 mempoolInsertApi :: forall (v :: ChainwebVersionT) (c :: ChainIdT) (t :: *)
                  . Proxy (MempoolInsertApi v c t)

--- a/src/Chainweb/Mempool/RestAPI/Client.hs
+++ b/src/Chainweb/Mempool/RestAPI/Client.hs
@@ -4,8 +4,8 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RankNTypes #-}
@@ -17,7 +17,6 @@
 module Chainweb.Mempool.RestAPI.Client
   ( insertClient
   , getPendingClient
-  , subscribeClient
   , memberClient
   , lookupClient
   , getBlockClient
@@ -25,10 +24,8 @@ module Chainweb.Mempool.RestAPI.Client
   ) where
 
 ------------------------------------------------------------------------------
-import Control.Concurrent
 import qualified Control.Concurrent.Async as Async
 import Control.Concurrent.STM
-import qualified Control.Concurrent.STM.TBMChan as TBMChan
 #if ! MIN_VERSION_servant(0,15,0)
 import qualified Control.Concurrent.STM.TBMChan as Chan
 #endif
@@ -36,7 +33,6 @@ import Control.DeepSeq
 import Control.Exception
 import Control.Monad
 import Control.Monad.Identity
-import Control.Monad.IO.Class
 import Data.Aeson.Types (FromJSON, ToJSON)
 import Data.Int
 import Data.IORef
@@ -45,8 +41,8 @@ import qualified Data.Vector as V
 import Prelude hiding (lookup)
 import Servant.API
 #if MIN_VERSION_servant(0,15,0)
-import Servant.Types.SourceT
 import Servant.Client.Streaming
+import Servant.Types.SourceT
 #else
 import Servant.Client
 #endif
@@ -81,8 +77,6 @@ toMempool version chain txcfg blocksizeLimit env =
     , mempoolMarkConfirmed = markConfirmed
     , mempoolReintroduce = reintroduce
     , mempoolGetPendingTransactions = getPending
-    , mempoolSubscribe = subscribe
-    , mempoolShutdown = shutdown
     , mempoolClear = clear
     }
   where
@@ -92,31 +86,18 @@ toMempool version chain txcfg blocksizeLimit env =
     lookup v = V.fromList <$> go (lookupClient version chain (V.toList v))
     insert v = void $ go (insertClient version chain (V.toList v))
     getBlock sz = V.fromList <$> go (getBlockClient version chain (Just sz))
+    getPending hw cb = do
+        hw' <- newIORef 0
+        let f = either (writeIORef hw') (cb . V.fromList)
 #if MIN_VERSION_servant(0,15,0)
-    getPending cb = withClientM (getPendingClient version chain) env $ \case
-        Left e -> throwIO e
-        Right is -> Streams.mapM_ (cb . V.fromList) is >>= Streams.skipToEof
+        withClientM (getPendingClient version chain hw) env $ \case
+            Left e -> throwIO e
+            Right is -> Streams.mapM_ f is >>= Streams.skipToEof
 #else
-    getPending cb = go (getPendingClient version chain) >>=
-                    Streams.mapM_ (cb . V.fromList) >>=
-                    Streams.skipToEof
+        go (getPendingClient version chain hw) >>= Streams.mapM_ f
+                                               >>= Streams.skipToEof
+        readIORef hw'
 #endif
-
-    subscribe = do
-        mv <- newEmptyMVar
-        !ref <- mask_ $ do
-            chan <- atomically $ TBMChan.newTBMChan 8
-            t <- Async.asyncWithUnmask $ subThread mv chan
-            let finalize = Async.uninterruptibleCancel t
-            let sub = Subscription chan finalize
-            r <- newIORef sub
-            void $ mkWeakIORef r finalize
-            return r
-        -- make sure subscription is initialized before returning.
-        takeMVar mv
-        return ref
-
-    shutdown = return ()
 
     unsupported = fail "unsupported"
     markValidated _ = unsupported
@@ -124,27 +105,6 @@ toMempool version chain txcfg blocksizeLimit env =
     reintroduce _ = unsupported
     clear = unsupported
 
-    subThread mv chan restore =
-        flip finally (tryPutMVar mv () `finally`
-                      atomically (TBMChan.closeTBMChan chan)) $
-#if MIN_VERSION_servant(0,15,0)
-        restore $ withClientM (subscribeClient version chain) env $ \case
-            Left e -> throwIO e
-            Right is -> liftIO
-                $ Streams.mapM_ (const $ tryPutMVar mv ()) is
-                >>= Streams.filter (not . null)
-                >>= Streams.mapM_
-                    (atomically . TBMChan.writeTBMChan chan . V.fromList)
-                >>= Streams.skipToEof
-#else
-        restore $ flip runClientM env $ do
-            is <- subscribeClient version chain
-            liftIO (Streams.mapM_ (const $ tryPutMVar mv ()) is
-                    >>= Streams.filter (not . null)
-                    >>= Streams.mapM_ (atomically . TBMChan.writeTBMChan chan
-                                                  . V.fromList)
-                    >>= Streams.skipToEof)
-#endif
 
 insertClient_
     :: forall (v :: ChainwebVersionT) (c :: ChainIdT) (t :: *)
@@ -223,37 +183,20 @@ getBlockClient v c mbBs = runIdentity $ do
 getPendingClient_
     :: forall (v :: ChainwebVersionT) (c :: ChainIdT)
     . (KnownChainwebVersionSymbol v, KnownChainIdSymbol c)
-    => ClientM (Streams.InputStream [TransactionHash])
+    => Maybe MempoolTxId
+    -> ClientM (Streams.InputStream (Either MempoolTxId [TransactionHash]))
 getPendingClient_ = client (mempoolGetPendingApi @v @c)
 
 getPendingClient
   :: ChainwebVersion
   -> ChainId
-  -> ClientM (Streams.InputStream [TransactionHash])
-getPendingClient v c = runIdentity $ do
+  -> Maybe MempoolTxId
+  -> ClientM (Streams.InputStream (Either MempoolTxId [TransactionHash]))
+getPendingClient v c hw = runIdentity $ do
     SomeChainwebVersionT (_ :: Proxy v) <- return $ someChainwebVersionVal v
     SomeChainIdT (_ :: Proxy c) <- return $ someChainIdVal c
-    return $ getPendingClient_ @v @c
+    return $ getPendingClient_ @v @c hw
 
-
-------------------------------------------------------------------------------
-subscribeClient_
-    :: forall (v :: ChainwebVersionT) (c :: ChainIdT) (t :: *)
-    . (KnownChainwebVersionSymbol v, KnownChainIdSymbol c, FromJSON t, Show t)
-    => ClientM (Streams.InputStream [t])
-subscribeClient_ = do
-    is <- client (mempoolSubscribeApi @v @c)
-    liftIO $ evaluate is
-
-subscribeClient
-  :: (FromJSON t, Show t)
-  => ChainwebVersion
-  -> ChainId
-  -> ClientM (Streams.InputStream [t])
-subscribeClient v c = runIdentity $ do
-    SomeChainwebVersionT (_ :: Proxy v) <- return $ someChainwebVersionVal v
-    SomeChainIdT (_ :: Proxy c) <- return $ someChainIdVal c
-    return $ subscribeClient_ @v @c
 
 
 ------------------------------------------------------------------------------

--- a/src/Chainweb/Mempool/RestAPI/Server.hs
+++ b/src/Chainweb/Mempool/RestAPI/Server.hs
@@ -26,7 +26,6 @@ import Data.Maybe (fromMaybe)
 import qualified Data.Vector as V
 import Servant
 import qualified System.IO.Streams as Streams
-import System.Timeout
 
 ------------------------------------------------------------------------------
 import Chainweb.ChainId
@@ -72,8 +71,12 @@ data GpData t = GpData {
     }
 
 
-getPendingHandler :: Show t => MempoolBackend t -> Handler (Streams.InputStream [TransactionHash])
-getPendingHandler mempool = liftIO $ mask_ $ do
+getPendingHandler
+    :: Show t
+    => MempoolBackend t
+    -> Maybe MempoolTxId
+    -> Handler (Streams.InputStream (Either MempoolTxId [TransactionHash]))
+getPendingHandler mempool hw = liftIO $ mask_ $ do
     dat <- createThread
     Streams.makeInputStream $ inputStreamAct dat
 
@@ -89,32 +92,14 @@ getPendingHandler mempool = liftIO $ mask_ $ do
 
     chanThread chan restore =
         flip finally (atomically $ Chan.closeTBMChan chan) $
-        restore $
-        mempoolGetPendingTransactions mempool (atomically . Chan.writeTBMChan chan . V.toList)
+        restore $ do
+            !hw' <- mempoolGetPendingTransactions mempool hw
+                (atomically . Chan.writeTBMChan chan . Right . V.toList)
+            atomically $ Chan.writeTBMChan chan $! Left hw'
 
     inputStreamAct (ref, _) = do
         (GpData chan _) <- readIORef ref
         atomically $ Chan.readTBMChan chan
-
-
-subscribeHandler :: Show t => Int -> MempoolBackend t -> Handler (Streams.InputStream [t])
-subscribeHandler keepaliveSecs mempool = liftIO $ do
-    subRef <- mempoolSubscribe mempool
-    s <- Streams.fromList [[],[]]  -- send empty message to start
-    -- send empty messages -- servant is messing up the framing
-    t <- Streams.makeInputStream (streamAction subRef) >>= Streams.concatLists
-    Streams.appendInputStream s t
-
-  where
-    streamAction subRef = do
-        chan <- mempoolSubChan <$> readIORef subRef
-        m <- tout $ atomically $ Chan.readTBMChan chan
-        case m of
-          Nothing -> return $! Just [[],[]]   -- keepalive
-          Just (Just xs) -> return $! Just [ V.toList xs, [] ]
-          Just Nothing -> return Nothing
-
-    tout = timeout (keepaliveSecs * 1000000)
 
 
 handleErrs :: Handler a -> Handler a
@@ -135,13 +120,12 @@ someMempoolServers v = mconcat
 
 
 mempoolServer :: Show t => Mempool_ v c t -> Server (MempoolApi v c t)
-mempoolServer (Mempool_ keepaliveSecs mempool) =
+mempoolServer (Mempool_ mempool) =
     insertHandler mempool
     :<|> memberHandler mempool
     :<|> lookupHandler mempool
     :<|> getBlockHandler mempool
     :<|> getPendingHandler mempool
-    :<|> subscribeHandler keepaliveSecs mempool
 
 
 mempoolApp

--- a/test/Chainweb/Test/Mempool.hs
+++ b/test/Chainweb/Test/Mempool.hs
@@ -73,8 +73,8 @@ genNonEmpty = do
 
 genTwoSets :: PropertyM IO ([MockTx], [MockTx])
 genTwoSets = do
-    xs <- (uniq . sortBy ord) <$> genNonEmpty
-    ys' <- (uniq . sortBy ord) <$> genNonEmpty
+    xs <- uniq . sortBy ord <$> genNonEmpty
+    ys' <- uniq . sortBy ord <$> genNonEmpty
     let ys = OL.minusBy' ord ys' xs
     pre (not $ null ys)
     return (xs, ys)

--- a/test/Chainweb/Test/Mempool/InMem.hs
+++ b/test/Chainweb/Test/Mempool/InMem.hs
@@ -5,8 +5,8 @@ module Chainweb.Test.Mempool.InMem
 ------------------------------------------------------------------------------
 import Test.Tasty
 ------------------------------------------------------------------------------
-import Chainweb.Mempool.InMemTypes (InMemConfig(..))
 import qualified Chainweb.Mempool.InMem as InMem
+import Chainweb.Mempool.InMemTypes (InMemConfig(..))
 import Chainweb.Mempool.Mempool
 import Chainweb.Test.Mempool (MempoolWithFunc(..))
 import qualified Chainweb.Test.Mempool
@@ -22,7 +22,7 @@ tests = testGroup "Chainweb.Mempool.InMem"
     txcfg = TransactionConfig mockCodec hasher hashmeta mockGasPrice mockGasLimit
                               mockMeta (const $ return True)
     -- run the reaper @100Hz for testing
-    cfg = InMemConfig txcfg mockBlockGasLimit (hz 100)
+    cfg = InMemConfig txcfg mockBlockGasLimit (hz 100) 2048
     hz x = 1000000 `div` x
     hashmeta = chainwebTestHashMeta
     hasher = chainwebTestHasher . codecEncode mockCodec

--- a/test/Chainweb/Test/Mempool/RestAPI.hs
+++ b/test/Chainweb/Test/Mempool/RestAPI.hs
@@ -14,8 +14,8 @@ import Test.Tasty
 ------------------------------------------------------------------------------
 import Chainweb.ChainId (ChainId)
 import Chainweb.Graph
-import Chainweb.Mempool.InMemTypes (InMemConfig(..))
 import qualified Chainweb.Mempool.InMem as InMem
+import Chainweb.Mempool.InMemTypes (InMemConfig(..))
 import qualified Chainweb.Mempool.InMemTypes as InMem
 import Chainweb.Mempool.Mempool
 import qualified Chainweb.Mempool.RestAPI.Client as MClient
@@ -41,7 +41,7 @@ tests = withResource (newPool cfg) Pool.destroyAllResources $
     txcfg = TransactionConfig mockCodec hasher hashmeta mockGasPrice
                               mockGasLimit mockMeta (const $ return True)
     -- run the reaper @100Hz for testing
-    cfg = InMemConfig txcfg mockBlockGasLimit (hz 100)
+    cfg = InMemConfig txcfg mockBlockGasLimit (hz 100) 2048
     hz x = 1000000 `div` x
     hashmeta = chainwebTestHashMeta
     hasher = chainwebTestHasher . codecEncode mockCodec


### PR DESCRIPTION
  - remove old subscription semantics, replace with a "recent inserts" log

  - change REST getPending API to optionally tail the recent inserts log starting from a "high water mark"

  - update current polling sync algorithm to do initial bi-directional sync, then perform subsequent sync using high water mark. Pull-only for now.