### PR TITLE
[TXG] fix sender id

### DIFF
--- a/tools/txg/TXG.hs
+++ b/tools/txg/TXG.hs
@@ -126,11 +126,12 @@ generateSimpleTransactions = do
             pure (a, b, operation)
           theCode = "(" ++ [op] ++ " " ++ show operandA ++ " " ++ show operandB ++ ")"
 
+      -- this contains the key of sender00
       kps <- testSomeKeyPairs
 
       let publicmeta = CM.PublicMeta
                        (CM.ChainId $ chainIdToText cid)
-                       ("sender" <> toText cid) 10 0.0001
+                       "sender00" 10 0.0001
           theData = object ["test-admin-keyset" .= fmap formatB16PubKey kps]
       mkExec theCode theData publicmeta kps Nothing
 


### PR DESCRIPTION
The comment in the code blow seems to indicate that the sender id should always by "sender00".

```Haskell
testSomeKeyPairs :: IO [SomeKeyPair]
testSomeKeyPairs = do
    let (pub, priv, addr, scheme) = someED25519Pair
        apiKP = ApiKeyPair priv (Just pub) (Just addr) (Just scheme)
    mkKeyPairs [apiKP]

-- | note this is "sender00"'s key
someED25519Pair :: (PublicKeyBS, PrivateKeyBS, Text, PPKScheme)
someED25519Pair =
    ( PubBS $ getByteString
        "368820f80c324bbc7c2b0610688a7da43e39f91d118732671cd9c7500ff43cca"
    , PrivBS $ getByteString
        "251a920c403ae8c8f65f59142316af3c82b631fba46ddea92ee8c95035bd2898"
    , "368820f80c324bbc7c2b0610688a7da43e39f91d118732671cd9c7500ff43cca"
    , ED25519
    )
```