### PR TITLE
Performance improvements for chainweb-node startup

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -6,6 +6,8 @@ package chainweb
 package aeson
     flags: +cffi
 
+debug-info: True
+
 source-repository-package
     type: git
     location: https://github.com/kadena-io/pact.git

--- a/cabal.project
+++ b/cabal.project
@@ -18,6 +18,6 @@ source-repository-package
 
 constraints:
       megaparsec <7.0
-    , servant < 0.15
     , neat-interpolation <0.3.2.4
     , swagger2 < 2.4
+    , these < 1

--- a/src/Chainweb/BlockHeaderDB.hs
+++ b/src/Chainweb/BlockHeaderDB.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MultiWayIf #-}
@@ -29,6 +30,7 @@ module Chainweb.BlockHeaderDB
 , initBlockHeaderDb
 , closeBlockHeaderDb
 , withBlockHeaderDb
+, pruneForks
 
 -- internal
 , seekTreeDb
@@ -40,22 +42,33 @@ import Control.Lens hiding (children)
 import Control.Monad
 import Control.Monad.Catch
 import Control.Monad.IO.Class
+import Control.Monad.ST
 import Control.Monad.Trans.Maybe
 
 import Data.Aeson
+import qualified Data.BloomFilter.Easy as BF (suggestSizing)
+import qualified Data.BloomFilter.Hash as BF
+import qualified Data.BloomFilter.Mutable as BF
 import Data.Bytes.Get
 import Data.Bytes.Put
 import Data.Function
 import Data.Hashable
 import qualified Data.HashMap.Strict as HM
+import qualified Data.HashSet as HS
 import qualified Data.List as L
+import Data.Maybe
+import Data.Semigroup
 import qualified Data.Text.Encoding as T
 
 import GHC.Generics
 
+import Numeric.Natural
+
 import Prelude hiding (lookup)
 
 import qualified Streaming.Prelude as S
+
+import System.LogLevel
 
 -- internal imports
 
@@ -63,6 +76,7 @@ import Chainweb.BlockHash
 import Chainweb.BlockHeader
 import Chainweb.BlockHeader.Genesis (genesisBlockHeader)
 import Chainweb.ChainId
+import Chainweb.Logger
 import Chainweb.TreeDB
 import Chainweb.TreeDB.Validation
 import Chainweb.Utils hiding (Codec)
@@ -171,11 +185,6 @@ data Configuration = Configuration
 data BlockHeaderDb = BlockHeaderDb
     { _chainDbId :: !ChainId
     , _chainDbChainwebVersion :: !ChainwebVersion
-    , _chainDbRocksDb :: !RocksDb
-        -- ^ Database that provides random access the block headers indexed by
-        -- their hash. The 'MVar' is used as a lock to sequentialize concurrent
-        -- access.
-
     , _chainDbCas :: !(RocksDbTable RankedBlockHash RankedBlockHeader)
         -- ^ Ranked block hashes provide fast access and iterating  by block
         -- height. Blocks of similar height are stored and cached closely
@@ -193,6 +202,156 @@ instance HasChainId BlockHeaderDb where
 instance HasChainwebVersion BlockHeaderDb where
     _chainwebVersion = _chainDbChainwebVersion
     {-# INLINE _chainwebVersion #-}
+
+-- -------------------------------------------------------------------------- --
+-- Prune Old Forks
+
+-- | Prunes most block headers and block payloads from forks that are older than
+-- the given number of blocks.
+--
+-- This function guarantees that the predecessors of all remaining nodes also
+-- remain in the database and that there are are no tangling references.
+--
+-- This function doesn't guarantee to delete all blocks on forks. A small number
+-- of fork blocks may not get deleted.
+--
+-- The function takes a callback that is invoked on each deleted block header.
+-- The callback takes a parameter that indicates whether the block payload hash
+-- is shared with any non-deleted block header. There is a small rate of false
+-- positives of block payload hashes that are marked in use.
+--
+-- This doesn't update the the cut db or the payload db.
+--
+pruneForks
+    :: Logger logger
+    => logger
+    -> BlockHeaderDb
+    -> (BlockHeader -> Bool -> IO ())
+        -- ^ Deletion call back. This hook is called /after/ the entry is
+        -- deleted from the database. It's main purpose is to delete any
+        -- resources that were related to the deleted header and that are not
+        -- needed any more. The Boolean argument indicates whether the payload
+        -- of the block is shared with any block header that isn't marked for
+        -- deletion.
+    -> Natural
+        -- ^ The depth at which the roots are collected for marking block
+        -- headers that are kept. Any fork that was active that the given depth
+        -- is kept.
+        --
+        -- The depth is computed based on the entry of maximum rank. This entry
+        -- is not necessarily included in the overall consensus of the chainweb.
+        -- In particular the the higest ranking entry is not necessarily the
+        -- entry of largest POW weight.
+        --
+        -- Usually this number would be defined in terms of the chainweb
+        -- diameter and/or the difficulty adjustment window.
+    -> IO Int
+pruneForks logger cdb callback limit = do
+
+    -- find all roots at \(maxEntry - limit\)
+    --
+    m <- maxRank cdb
+    let rootHeight = m - min m limit
+
+    roots <- keys cdb Nothing Nothing
+        (Just $ MinRank $ Min rootHeight)
+        (Just $ MaxRank $ Max rootHeight)
+        streamToHashSet_
+
+    -- Bloom filter for marking block headers
+    --
+    let s = max (int rootHeight + 10 * HS.size roots) (int rootHeight * 2)
+    let (size, hashNum) = BF.suggestSizing s 0.0001
+    marked <- stToIO $ BF.new (BF.cheapHashes hashNum) size
+
+    -- Bloom filter for marking block payload hashes
+    --
+    -- Payloads can be shared between different blocks. Thus, to be on the safe
+    -- side, we are not deleting any marked payload.
+    --
+    -- Note that we could use cuckoo hashes or counting bloom filters to do
+    -- reference counting and collect more unreferenced payloads.
+    --
+    -- TODO: would it be better to use a single shared filter?
+    --
+    let (psize, phashNum) = BF.suggestSizing s 0.0001
+    markedPayloads <- stToIO $ BF.new (BF.cheapHashes phashNum) psize
+
+    -- Iterate backwards and mark all predecessors of the roots
+    --
+    void $ branchEntries cdb Nothing Nothing Nothing Nothing mempty (HS.map UpperBound roots)
+        $ S.mapM_ $ \h -> do
+            stToIO $ do
+                BF.insert marked $ runPut $ encodeBlockHash $ _blockHash h
+                BF.insert markedPayloads
+                    $ runPut $ encodeBlockPayloadHash $ _blockPayloadHash h
+
+    -- Iterate forward and delete all non-marked block headers that are not a
+    -- predecessor of a block header that is kept.
+    --
+    entries cdb Nothing Nothing Nothing (Just $ MaxRank $ Max rootHeight)
+        $ S.foldM_ (go marked markedPayloads) (return (mempty, 0)) (return . snd)
+
+  where
+    logg = logFunctionText (setComponent "pact-tx-replay" logger)
+
+    -- The falsePositiveSet collects all deleted nodes that are known to be
+    -- false positives. We know that a node is false positive when it is in the
+    -- filter but any of its ancestors is either not in the fitler or in the
+    -- falsePositiveSet. Note that this doesn't capture all false positives, but
+    -- only those that are not connected to the main chain.
+    --
+    -- Nodes that are known to be false positives are safe to remove, if also
+    -- all of its successors are removed.
+    --
+    -- Nodes that are know to be false postives must be removed, if any of their
+    -- predecessors got removed.
+    --
+    go marked markedPayloads (falsePositiveSet, i) h = do
+        let k = runPut $ encodeBlockHash $ _blockHash h
+        let p = runPut $ encodeBlockHash $ _blockParent h
+        isMarked <- stToIO $ BF.elem k marked
+
+        let payloadHashBytes = runPut $ encodeBlockPayloadHash $ _blockPayloadHash h
+        isPayloadMarked <- stToIO $ BF.elem payloadHashBytes markedPayloads
+
+        -- Delete nodes not in the filter
+        if not isMarked
+          then do
+            deleteKey h isPayloadMarked
+            return (falsePositiveSet, succ i)
+          else do
+            -- Delete nodes which parent isn't in the filter or is in the
+            -- falsePositiveSet
+            parentIsMarked <- stToIO $ BF.elem p marked
+            if not (isGenesisBlockHeader h) && (not parentIsMarked || HS.member p falsePositiveSet)
+              then do
+                -- We know that this a false positive. We keep track of this for
+                -- future reference.
+                --
+                -- TODO: consider using cuckoo filters because entries can be
+                -- deleted from them. So we wouldn't need to keep track of
+                -- deleted falsePositives. However, with cuckoo filters we'd
+                -- have to re-hash or keep track of failing inserts.
+                deleteKey h isPayloadMarked
+                return (HS.insert k falsePositiveSet, succ i)
+              else
+                -- The key is either
+                -- 1. in the chain
+                -- 2. a false positive that is connected to the chain, i.e. has
+                -- all of its predecessors.
+                --
+                -- We accept a small number of nodes of the second case.
+                --
+                return (falsePositiveSet, i)
+
+    deleteKey h isPayloadMarked = do
+        -- TODO: make this atomic (create boilerplate to combine queries for
+        -- different tables)
+        casDelete (_chainDbCas cdb) (casKey $ RankedBlockHeader h)
+        tableDelete (_chainDbRankTable cdb) (_blockHash h)
+        logg Debug $ "deleted block header at height " <> sshow (_blockHeight h) <> " with payload mark " <> sshow isPayloadMarked
+        callback h isPayloadMarked
 
 -- -------------------------------------------------------------------------- --
 -- Insert
@@ -262,7 +421,6 @@ initBlockHeaderDb config = do
 
     !db = BlockHeaderDb cid
         (_chainwebVersion rootEntry)
-        (_configRocksDb config)
         headerTable
         rankTable
 

--- a/src/Chainweb/BlockHeaderDB.hs
+++ b/src/Chainweb/BlockHeaderDB.hs
@@ -253,7 +253,7 @@ pruneForks logger cdb callback limit = do
     m <- maxRank cdb
     let rootHeight = m - min m limit
 
-    roots <- keys cdb Nothing Nothing
+    !roots <- keys cdb Nothing Nothing
         (Just $ MinRank $ Min rootHeight)
         (Just $ MaxRank $ Max rootHeight)
         streamToHashSet_
@@ -262,7 +262,7 @@ pruneForks logger cdb callback limit = do
     --
     let s = max (int rootHeight + 10 * HS.size roots) (int rootHeight * 2)
     let (size, hashNum) = BF.suggestSizing s 0.0001
-    marked <- stToIO $ BF.new (BF.cheapHashes hashNum) size
+    !marked <- stToIO $ BF.new (BF.cheapHashes hashNum) size
 
     -- Bloom filter for marking block payload hashes
     --
@@ -275,7 +275,7 @@ pruneForks logger cdb callback limit = do
     -- TODO: would it be better to use a single shared filter?
     --
     let (psize, phashNum) = BF.suggestSizing s 0.0001
-    markedPayloads <- stToIO $ BF.new (BF.cheapHashes phashNum) psize
+    !markedPayloads <- stToIO $ BF.new (BF.cheapHashes phashNum) psize
 
     -- Iterate backwards and mark all predecessors of the roots
     --
@@ -307,7 +307,7 @@ pruneForks logger cdb callback limit = do
     -- Nodes that are know to be false postives must be removed, if any of their
     -- predecessors got removed.
     --
-    go marked markedPayloads (falsePositiveSet, i) h = do
+    go marked markedPayloads !(!falsePositiveSet, !i) !h = do
         let k = runPut $ encodeBlockHash $ _blockHash h
         let p = runPut $ encodeBlockHash $ _blockParent h
         isMarked <- stToIO $ BF.elem k marked

--- a/src/Chainweb/Pact/PactService.hs
+++ b/src/Chainweb/Pact/PactService.hs
@@ -287,12 +287,12 @@ execNewBlock mpAccess header miner = do
     let bHeight@(BlockHeight bh) = _blockHeight header
         bHash = _blockHash header
 
-    logInfo $ "execNewBlock, about to get call processFork: "
+    logDebug $ "execNewBlock, about to get call processFork: "
            <> " (height = " <> sshow bHeight <> ")"
            <> " (hash = " <> sshow bHash <> ")"
     liftIO $ mpaProcessFork mpAccess header
 
-    logInfo $ "execNewBlock, about to get new block from mempool: "
+    logDebug $ "execNewBlock, about to get new block from mempool: "
            <> " (height = " <> sshow bHeight <> ")"
            <> " (hash = " <> sshow bHash <> ")"
     newTrans <- liftIO $! mpaGetBlock mpAccess bHeight bHash header
@@ -377,14 +377,14 @@ execValidateBlock mpAccess loadingGenesis currHeader plData = do
         !bParent = _blockParent currHeader
         !isGenesisBlock = isGenesisBlockHeader currHeader
 
-    logInfo $ "execValidateBlock, about to get call setLastHeader: "
+    logDebug $ "execValidateBlock, about to get call setLastHeader: "
         <> " (height = " <> sshow bHeight <> ")"
         <> " (hash = " <> sshow bHash <> ")"
     liftIO $ mpaSetLastHeader mpAccess currHeader
 
     miner <- decodeStrictOrThrow' (_minerData $ _payloadDataMiner plData)
 
-    unless loadingGenesis $ logInfo $ "execValidateBlock: height=" ++ show bHeight ++
+    unless loadingGenesis $ logDebug $ "execValidateBlock: height=" ++ show bHeight ++
       ", parent=" ++ show bParent ++ ", hash=" ++ show bHash ++
       ", payloadHash=" ++ show (_blockPayloadHash currHeader)
 

--- a/src/Chainweb/Pact/PactService.hs
+++ b/src/Chainweb/Pact/PactService.hs
@@ -33,7 +33,7 @@ module Chainweb.Pact.PactService
 
 import Control.Concurrent
 import Control.Concurrent.STM
-import Control.Exception hiding (try)
+import Control.Exception hiding (try, finally)
 import Control.Lens
 import Control.Monad
 import Control.Monad.Catch
@@ -183,7 +183,7 @@ serviceRequests
     -> PactServiceM ()
 serviceRequests memPoolAccess reqQ = do
     logInfo "Starting service"
-    go
+    go `finally` logInfo "Stopping service"
   where
     go = do
         logDebug $ "serviceRequests: wait"

--- a/src/Chainweb/TreeDB.hs
+++ b/src/Chainweb/TreeDB.hs
@@ -306,9 +306,9 @@ class (Typeable db, TreeDbEntry (DbEntry db)) => TreeDb db where
         -> Maybe MinRank
         -> Maybe MaxRank
         -> HS.HashSet (LowerBound (DbKey db))
-            -- Upper limits
+            -- ^ Lower limits
         -> HS.HashSet (UpperBound (DbKey db))
-            -- Lower limits
+            -- ^ Upper limits
         -> (S.Stream (Of (DbKey db)) IO (Natural, Eos) -> IO a)
         -> IO a
     branchKeys db k l mir mar lower upper f =


### PR DESCRIPTION
This PR improves performance of Chainweb-node startup:

* [x] initialize chain resources for all chains concurrently
* [x] implement pruning of old forks in `BlockHeaderDB`
* [x] Use log level debug for pact execution service evaluation

The PR also contains a few small fixe along the way:

* [x] update the `cabal.project` file
* [x] fix a comment in TreeDb
* [x] fix mempool servant streaming code for servant 0.16 code branch