### PR TITLE
[pact] Put pact tx bloom cache on disk.

### DIFF
--- a/chainweb.cabal
+++ b/chainweb.cabal
@@ -238,6 +238,7 @@ library
         , QuickCheck-GenT >=0.2
         , aeson >= 1.4.3
         , aeson-pretty >= 0.8
+        , array >= 0.5
         , asn1-encoding >=0.9
         , asn1-types >=0.3
         , async >= 2.2

--- a/src/Chainweb/Chainweb.hs
+++ b/src/Chainweb/Chainweb.hs
@@ -405,7 +405,7 @@ withChainwebInternal conf logger peer rocksDb inner = do
         | _enableConfigEnabled (_configTransactionIndex conf)
             = let l = sortBy (compare `on` fst) (HM.toList cs)
                   bdbs = map (\(c, cr) -> (c, _chainResBlockHeaderDb cr)) l
-              in Bloom.withCache (cuts ^. cutsCutDb) bdbs $ \bloom ->
+              in Bloom.withCache (cuts ^. cutsCutDb) rocksDb bdbs $ \bloom ->
                  m $ map (\(c, cr) -> (c, (cuts, cr, bloom))) l
 
         | otherwise = m []


### PR DESCRIPTION
  - keep far fewer bloom filters in RAM
  - store blooms in rocksdb CAS as well as recent ones in ram, and fall back to CAS lookup if the in-mem lookup fails -- this should speed up startup