### PR TITLE
Bump Pact Version to Include SPV-based defpacts

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -11,7 +11,7 @@ debug-info: True
 source-repository-package
     type: git
     location: https://github.com/kadena-io/pact.git
-    tag: fb30307a204791914831c45e3b68c1f4eaf75f78
+    tag: d10173c574ae4dce1dae5a5dcbaf1ec4a9feb2c3
 
 source-repository-package
     type: git

--- a/default.nix
+++ b/default.nix
@@ -200,8 +200,8 @@ in
         pact = dontCheck ( addBuildDepend (self.callCabal2nix "pact" (pkgs.fetchFromGitHub {
           owner = "kadena-io";
           repo = "pact";
-          rev = "fb30307a204791914831c45e3b68c1f4eaf75f78";
-          sha256 = "1p906j6v6aym76lkazpphy058rnyz9qfdnihx68kw2wjgip2rsvp";
+          rev = "d10173c574ae4dce1dae5a5dcbaf1ec4a9feb2c3";
+          sha256 = "188ywk13rwsw8w9ba9v90lbk8asffa7izxlw0zink3qh70x019pi";
           }) {}) pkgs.z3);
 
         streaming = callHackageDirect {

--- a/src/Chainweb/Pact/PactService.hs
+++ b/src/Chainweb/Pact/PactService.hs
@@ -63,6 +63,7 @@ import qualified Pact.Interpreter as P
 import qualified Pact.Types.Command as P
 import qualified Pact.Types.Logger as P
 import qualified Pact.Types.Runtime as P
+import qualified Pact.Types.SPV as P
 
 -- internal modules
 

--- a/src/Chainweb/Pact/TransactionExec.hs
+++ b/src/Chainweb/Pact/TransactionExec.hs
@@ -66,6 +66,7 @@ import Pact.Types.Logger
 import Pact.Types.RPC
 import Pact.Types.Runtime
 import Pact.Types.Server
+import Pact.Types.SPV
 import Pact.Types.Term (DefName(..), ModuleName(..))
 
 -- internal Chainweb modules
@@ -330,13 +331,13 @@ applyContinuation'
     -> Hash
     -> SPVSupport
     -> IO EvalResult
-applyContinuation' CommandEnv{..} initState ContMsg{..} senderSigs hsh spv =
+applyContinuation' CommandEnv{..} initState cm senderSigs hsh spv =
   let sigs = userSigsToPactKeySet senderSigs
-      pactStep = Just $ PactStep _cmStep _cmRollback _cmPactId Nothing
+      pactStep = Just $ PactStep (_cmStep cm) (_cmRollback cm) (_cmPactId cm) Nothing
       evalEnv = setupEvalEnv _ceDbEnv _ceEntity _ceMode
-                (MsgData sigs _cmData pactStep hsh) initRefStore
+                (MsgData sigs (_cmData cm) pactStep hsh) initRefStore
                 _ceGasEnv permissiveNamespacePolicy spv _cePublicData
-  in evalContinuation initState evalEnv Nothing
+  in evalContinuation initState evalEnv cm
 
 
 

--- a/src/Chainweb/Pact/Types.hs
+++ b/src/Chainweb/Pact/Types.hs
@@ -66,7 +66,7 @@ import Pact.Types.Command
 import Pact.Types.Exp
 import qualified Pact.Types.Hash as H
 import Pact.Types.PactValue
-import Pact.Types.Runtime (SPVSupport(..))
+import Pact.Types.SPV
 import Pact.Types.Term (KeySet(..), Name(..))
 
 -- internal chainweb modules

--- a/stack.yaml
+++ b/stack.yaml
@@ -42,6 +42,6 @@ extra-deps:
 
   # --- Custom Pins --- #
   - git: https://github.com/kadena-io/pact.git
-    commit: fb30307a204791914831c45e3b68c1f4eaf75f78
+    commit: d10173c574ae4dce1dae5a5dcbaf1ec4a9feb2c3
   - git: https://github.com/kadena-io/thyme.git
     commit: 6ee9fcb026ebdb49b810802a981d166680d867c9

--- a/test/Chainweb/Test/Pact/Checkpointer.hs
+++ b/test/Chainweb/Test/Pact/Checkpointer.hs
@@ -22,7 +22,8 @@ import qualified Pact.Types.Hash as H
 import Pact.Types.Logger (Loggers, newLogger)
 import Pact.Types.PactValue
 import Pact.Types.RPC (ContMsg(..))
-import Pact.Types.Runtime (noSPVSupport, peStep)
+import Pact.Types.Runtime (peStep)
+import Pact.Types.SPV (noSPVSupport)
 import Pact.Types.Server (CommandEnv(..))
 import Pact.Types.Term (PactId(..), Term(..), toTList, toTerm)
 import Pact.Types.Type (PrimType(..), Type(..))

--- a/test/Chainweb/Test/Pact/RemotePactTest.hs
+++ b/test/Chainweb/Test/Pact/RemotePactTest.hs
@@ -57,6 +57,7 @@ import Test.Tasty.HUnit
 
 import Pact.ApiReq (mkExec)
 import Pact.Types.API
+import qualified Pact.Types.ChainId as CM
 import qualified Pact.Types.ChainMeta as CM
 import Pact.Types.Command
 import qualified Pact.Types.Hash as H

--- a/test/Chainweb/Test/Pact/SPV.hs
+++ b/test/Chainweb/Test/Pact/SPV.hs
@@ -52,7 +52,7 @@ import Test.Tasty.HUnit
 
 -- internal pact modules
 
-import Pact.Types.ChainMeta as Pact
+import Pact.Types.ChainId as Pact
 import Pact.Types.Term
 
 -- internal chainweb modules

--- a/test/Chainweb/Test/Pact/Utils.hs
+++ b/test/Chainweb/Test/Pact/Utils.hs
@@ -55,12 +55,13 @@ import Test.Tasty
 -- internal pact modules
 
 import Pact.ApiReq (ApiKeyPair(..), mkKeyPairs)
+import Pact.Types.ChainId
 import Pact.Types.ChainMeta
 import Pact.Types.Command
 import Pact.Types.Crypto
 import Pact.Types.Logger
 import Pact.Types.RPC (ExecMsg(..), PactRPC(Exec))
-import Pact.Types.Runtime (noSPVSupport)
+import Pact.Types.SPV (noSPVSupport)
 import Pact.Types.Util (toB16Text)
 
 -- internal modules

--- a/tools/ea/Ea.hs
+++ b/tools/ea/Ea.hs
@@ -56,7 +56,7 @@ import Chainweb.Version
 
 import Pact.ApiReq (mkApiReq)
 import Pact.Types.Command hiding (Payload)
-import Pact.Types.Runtime (noSPVSupport)
+import Pact.Types.SPV (noSPVSupport)
 
 ---
 

--- a/tools/txg/TXG.hs
+++ b/tools/txg/TXG.hs
@@ -64,6 +64,7 @@ import Text.Pretty.Simple (pPrintNoColor)
 -- PACT
 import Pact.ApiReq
 import Pact.Types.API
+import qualified Pact.Types.ChainId as CM
 import qualified Pact.Types.ChainMeta as CM
 import Pact.Types.Command
 import Pact.Types.Crypto

--- a/tools/txg/TXG/Simulate/Contracts/Common.hs
+++ b/tools/txg/TXG/Simulate/Contracts/Common.hs
@@ -44,6 +44,7 @@ import Text.Printf
 -- PACT
 
 import Pact.ApiReq (mkExec)
+import qualified Pact.Types.ChainId as CM
 import qualified Pact.Types.ChainMeta as CM
 import Pact.Types.Command (Command(..))
 import Pact.Types.Crypto (SomeKeyPair, defaultScheme, genKeyPair)


### PR DESCRIPTION
General housekeeping: 

- Pact's `ChainId` type has been moved to its own module
- `SPVSupport` now features a second function supporting SPV-based cross-chain defpact validation which needs to be filled in 
- You may now find all continuation data for defpacts (`PactExec`, `PactStep` etc.) in `Pact.Types.Continuation`. 
- You may now find all SPV-related Pact types in `Pact.Types.SPV`
- The type of `evalContinuation` has changed - it no longer takes a `Maybe PactExec`, taking a `ContMsg` instead.