### PR TITLE
fix pruning of block header db

### DIFF
--- a/src/Chainweb/Chainweb/ChainResources.hs
+++ b/src/Chainweb/Chainweb/ChainResources.hs
@@ -135,7 +135,9 @@ withChainResources v cid rdb peer logger mempoolCfg cdbv payloadDb inner =
 
             -- prune block header db
             logg Info "start pruning block header database"
-            x <- pruneForks logger cdb (\h t -> unless t $ casDelete (fromJuste payloadDb) (_blockPayloadHash h)) (diam * 3)
+            x <- pruneForks logger cdb (diam * 3) $ \h payloadInUse ->
+                unless payloadInUse
+                    $ casDelete (fromJuste payloadDb) (_blockPayloadHash h)
             logg Info $ "finished pruning block header database. Deleted " <> sshow x <> " block headers."
 
             -- replay pact


### PR DESCRIPTION
The existing implementation of pruning could in rare cases result in a block header that was missing its payload. This could happen if all blocks in a prefix of a fork were marked as false positives but the respective payloads were not marked. (False positive blocks with an unmarked predecessor are detected and deleted.)

The PR fixes the issue by detecting and deleting any falsely marked block for which the payload hasn't been marked. This correct, because the payloads for all blocks on the root forks are marked.

This guarantees that for each block header the respective payload exists. It also lowers the false positive rate for block headers even further. 

Note, that we don't require that for each payload there is a respective block header. We therefor don't do any effort to detect falsely marked payloads.