### PR TITLE
Mempool pending transactions without streaming

### DIFF
--- a/chainweb.cabal
+++ b/chainweb.cabal
@@ -257,6 +257,7 @@ library
         , deepseq >= 1.4
         , digraph >= 0.1.0.2
         , directory >= 1.3
+        , dlist >= 0.8
         , errors >= 2.3
         , exceptions >= 0.8
         , extra >= 1.6
@@ -267,7 +268,6 @@ library
         , http-client >= 0.5
         , http-client-tls >=0.3
         , http-types >= 0.12
-        , io-streams >= 1.5
         , ixset-typed >= 0.4
         , lens >= 4.16
         , loglevel >= 0.1
@@ -552,7 +552,6 @@ executable cwtool
         , http-client >= 0.5
         , http-client-tls >=0.3
         , http-types >= 0.12
-        , io-streams >= 1.5
         , lens >= 4.16
         , loglevel >= 0.1
         , managed >= 1.0

--- a/src/Chainweb/Mempool/RestAPI/Client.hs
+++ b/src/Chainweb/Mempool/RestAPI/Client.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE BangPatterns #-}
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
@@ -12,8 +11,6 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 
-{-# OPTIONS_GHC -fno-warn-orphans #-}
-
 module Chainweb.Mempool.RestAPI.Client
   ( insertClient
   , getPendingClient
@@ -24,33 +21,17 @@ module Chainweb.Mempool.RestAPI.Client
   ) where
 
 ------------------------------------------------------------------------------
-#if ! MIN_VERSION_servant(0,15,0)
-import qualified Control.Concurrent.Async as Async
-import Control.Concurrent.STM
-import qualified Control.Concurrent.STM.TBMChan as Chan
-#endif
 import Control.DeepSeq
 import Control.Exception
 import Control.Monad
-#if MIN_VERSION_servant(0,15,0)
-import Control.Monad.IO.Class
-#endif
 import Control.Monad.Identity
 import Data.Aeson.Types (FromJSON, ToJSON)
 import Data.Int
-import Data.IORef
 import Data.Proxy
 import qualified Data.Vector as V
 import Prelude hiding (lookup)
 import Servant.API
-#if MIN_VERSION_servant(0,15,0)
-import Servant.Client.Streaming
-import Servant.Types.SourceT
-#else
 import Servant.Client
-#endif
-import qualified System.IO.Streams as Streams
-import System.IO.Unsafe
 ------------------------------------------------------------------------------
 import Chainweb.ChainId
 import Chainweb.Mempool.Mempool
@@ -90,19 +71,11 @@ toMempool version chain txcfg blocksizeLimit env =
     insert v = void $ go (insertClient version chain (V.toList v))
     getBlock sz = V.fromList <$> go (getBlockClient version chain (Just sz))
     getPending hw cb = do
-        hw' <- newIORef (0, 0)
-        let f = either (writeIORef hw') (cb . V.fromList)
-#if MIN_VERSION_servant(0,15,0)
-        withClientM (getPendingClient version chain hw) env $ \case
+        runClientM (getPendingClient version chain hw) env >>= \case
             Left e -> throwIO e
-            Right is -> do
-                Streams.mapM_ f is >>= Streams.skipToEof
-                readIORef hw'
-#else
-        go (getPendingClient version chain hw) >>= Streams.mapM_ f
-                                               >>= Streams.skipToEof
-        readIORef hw'
-#endif
+            Right ptxs -> do
+                void $ cb (V.fromList $ _pendingTransationsHashes ptxs)
+                return (_pendingTransactionsHighwaterMark ptxs)
 
     unsupported = fail "unsupported"
     markValidated _ = unsupported
@@ -190,14 +163,14 @@ getPendingClient_
     . (KnownChainwebVersionSymbol v, KnownChainIdSymbol c)
     => Maybe ServerNonce
     -> Maybe MempoolTxId
-    -> ClientM (Streams.InputStream (Either HighwaterMark [TransactionHash]))
+    -> ClientM PendingTransactions
 getPendingClient_ = client (mempoolGetPendingApi @v @c)
 
 getPendingClient
   :: ChainwebVersion
   -> ChainId
   -> Maybe (ServerNonce, MempoolTxId)
-  -> ClientM (Streams.InputStream (Either HighwaterMark [TransactionHash]))
+  -> ClientM PendingTransactions
 getPendingClient v c hw = runIdentity $ do
     let nonce = fst <$> hw
     let tx = snd <$> hw
@@ -205,70 +178,3 @@ getPendingClient v c hw = runIdentity $ do
     SomeChainIdT (_ :: Proxy c) <- return $ someChainIdVal c
     return $ getPendingClient_ @v @c nonce tx
 
-
-
-------------------------------------------------------------------------------
-#if MIN_VERSION_servant(0,15,0)
-
--- TODO: the code in this module could be simplfied by replacing the use of
--- io-streams with servant's build-in SourceIO stream type.
---
-instance Show a => FromSourceIO a (Streams.InputStream a) where
-    fromSourceIO (SourceT src) = unsafePerformIO $ src $ \step ->
-        Streams.fromGenerator (go step)
-      where
-        go :: StepT IO a -> Streams.Generator a ()
-        go Stop = return ()
-        go (Error msg) = fail msg -- TODO: fail
-        go (Skip step) = go step
-        go (Yield a step) = Streams.yield a >> go step
-        go (Effect m) = liftIO m >>= go
-
-    -- FIXME: is the use of unsafePerformIO safe here? It seems that the IO in
-    -- the return type of 'Streams.fromGenerator' is needed to intialize the
-    -- 'IORef's in the streams type. The new servant streaming api enforces that
-    -- the stream is fully evaluated within a bracket, but is that enough?
-    --
-    -- The proper solution is not to use io-streams here. Let's do this once the
-    -- nix build supports servant-0.16 and we can drop the legacy code.
-
-#else
-asIoStream :: Show a => ResultStream a -> (Streams.InputStream a -> IO b) -> IO b
-asIoStream (ResultStream func) withFunc = func $ \popper -> do
-    s <- Streams.makeInputStream $ f popper
-    withFunc s
-  where
-    f popper = do
-        m <- popper
-        case m of
-            Nothing -> return Nothing
-            (Just (Left e)) -> fail e              -- todo: fail
-            (Just (Right x)) -> return $! Just x
-
-
-instance Show a => BuildFromStream a (Streams.InputStream a) where
-  buildFromStream rs = let out = unsafePerformIO go
-                       in out `seq` out
-    where
-      createThread = do
-          chan <- atomically $ Chan.newTBMChan 4
-          t <- Async.asyncWithUnmask (chanThread chan)
-          Async.link t
-          ref <- newIORef (chan, t)
-          wk <- mkWeakIORef ref (Async.uninterruptibleCancel t)
-          return $! (ref, wk)
-
-      chanThread chan restore =
-          flip finally (atomically $ Chan.closeTBMChan chan) $
-          restore $
-          asIoStream rs (
-              Streams.mapM_ (atomically . Chan.writeTBMChan chan) >=>
-              Streams.skipToEof)
-
-      go = do
-          (ref, _) <- createThread
-          Streams.makeInputStream $ do
-              chan <- fst <$> readIORef ref
-              atomically $ Chan.readTBMChan chan
-
-#endif


### PR DESCRIPTION
* [x] return mempool pending transaction responses eagerly without using streams
* [x] remote internal exception handler from mempool sync session. The P2P node logs exceptions, too.