### PR TITLE
Explicit Microseconds

### DIFF
--- a/src/Chainweb/BlockHeader.hs
+++ b/src/Chainweb/BlockHeader.hs
@@ -127,7 +127,6 @@ import Data.Function (on)
 import Data.Hashable
 import qualified Data.HashMap.Strict as HM
 import qualified Data.HashSet as HS
-import Data.Int
 import Data.Kind
 import Data.List (unfoldr)
 import qualified Data.Memory.Endian as BA
@@ -270,7 +269,7 @@ instance FromJSON Nonce where
 -- -------------------------------------------------------------------------- --
 -- Block Creation Time
 
-newtype BlockCreationTime = BlockCreationTime (Time Int64)
+newtype BlockCreationTime = BlockCreationTime (Time Micros)
     deriving stock (Show, Eq, Ord, Generic)
     deriving anyclass (NFData)
     deriving newtype (ToJSON, FromJSON, Hashable)
@@ -630,11 +629,11 @@ blockPow = to _blockPow
 
 -- | The number of `Seconds` between the creation time of two `BlockHeader`s.
 --
-timeBetween :: BlockHeader -> BlockHeader -> Seconds
+timeBetween :: BlockHeader -> BlockHeader -> Micros
 timeBetween after before = f after - f before
   where
-    f :: BlockHeader -> Seconds
-    f (_blockCreationTime -> BlockCreationTime (Time ts)) = timeSpanToSeconds ts
+    f :: BlockHeader -> Micros
+    f (_blockCreationTime -> BlockCreationTime (Time (TimeSpan ts))) = ts
 
 -- -------------------------------------------------------------------------- --
 -- Object JSON encoding
@@ -727,7 +726,7 @@ newBlockHeader
         -- ^ Randomness to affect the block hash
     -> HashTarget
         -- ^ New target for POW-mining
-    -> Time Int64
+    -> Time Micros
         -- ^ Creation time of the block
     -> BlockHeader
         -- ^ parent block header

--- a/src/Chainweb/BlockHeader.hs
+++ b/src/Chainweb/BlockHeader.hs
@@ -627,7 +627,7 @@ blockPow :: Getter BlockHeader PowHash
 blockPow = to _blockPow
 {-# INLINE blockPow #-}
 
--- | The number of `Seconds` between the creation time of two `BlockHeader`s.
+-- | The number of microseconds between the creation time of two `BlockHeader`s.
 --
 timeBetween :: BlockHeader -> BlockHeader -> Micros
 timeBetween after before = f after - f before

--- a/src/Chainweb/Cut/Test.hs
+++ b/src/Chainweb/Cut/Test.hs
@@ -60,7 +60,6 @@ import Data.Bifunctor (first)
 import Data.Foldable
 import Data.Function
 import qualified Data.HashMap.Strict as HM
-import Data.Int (Int64)
 import Data.Monoid
 import Data.Ord
 import Data.Reflection hiding (int)
@@ -90,7 +89,7 @@ import Chainweb.Graph
 import Chainweb.NodeId
 import Chainweb.Payload
 import Chainweb.Payload.PayloadStore
-import Chainweb.Time (Time, getCurrentTimeIntegral, second)
+import Chainweb.Time (Micros(..), Time, getCurrentTimeIntegral, second)
 import Chainweb.Utils
 import Chainweb.Version
 import Chainweb.WebBlockHeaderDB
@@ -115,7 +114,7 @@ testMine
     => Given WebBlockHeaderDb
     => Nonce
     -> HashTarget
-    -> Time Int64
+    -> Time Micros
     -> BlockPayloadHash
     -> NodeId
     -> cid
@@ -133,7 +132,7 @@ testMineWithPayload
     -> PayloadDb cas
     -> Nonce
     -> HashTarget
-    -> Time Int64
+    -> Time Micros
     -> PayloadWithOutputs
     -> NodeId
     -> cid
@@ -168,7 +167,7 @@ createNewCut
     => HasChainId cid
     => Nonce
     -> HashTarget
-    -> Time Int64
+    -> Time Micros
     -> BlockPayloadHash
     -> NodeId
     -> cid

--- a/src/Chainweb/Difficulty.hs
+++ b/src/Chainweb/Difficulty.hs
@@ -87,7 +87,6 @@ import qualified Data.ByteString.Short as SB
 import Data.Coerce
 import Data.DoubleWord
 import Data.Hashable
-import Data.Int (Int64)
 import Data.Ratio ((%))
 import qualified Data.Text as T
 
@@ -105,7 +104,7 @@ import Text.Printf (printf)
 import Chainweb.Crypto.MerkleLog
 import Chainweb.MerkleUniverse
 import Chainweb.PowHash
-import Chainweb.Time (Seconds(..), TimeSpan(..))
+import Chainweb.Time (Micros(..), Seconds(..), TimeSpan(..))
 import Chainweb.Utils
 import Chainweb.Version (ChainwebVersion(..))
 
@@ -482,7 +481,7 @@ minAdjust Testnet01 = Just $ MinAdjustment 3
 -- Analysis has been shown that \(Z\) should be greater than a factor of
 -- \(e = 2.71828\cdots\) (/source needed/). See also `minAdjust`.
 --
-adjust :: ChainwebVersion -> WindowWidth -> TimeSpan Int64 -> HashTarget -> HashTarget
+adjust :: ChainwebVersion -> WindowWidth -> TimeSpan Micros -> HashTarget -> HashTarget
 adjust ver (WindowWidth ww) (TimeSpan delta) oldTarget
     -- Intent: When increasing the difficulty (thereby lowering the target
     -- toward 0), the target must decrease by at least some minimum threshold

--- a/src/Chainweb/Mempool/Mempool.hs
+++ b/src/Chainweb/Mempool/Mempool.hs
@@ -78,7 +78,7 @@ import qualified Pact.Types.Hash as H
 
 import Chainweb.BlockHash
 import Chainweb.BlockHeader
-import Chainweb.Time (Time(..))
+import Chainweb.Time (Micros(..), Time(..))
 import qualified Chainweb.Time as Time
 import Chainweb.Transaction
 import Chainweb.Utils
@@ -421,8 +421,8 @@ instance FromJSON TransactionHash where
 
 ------------------------------------------------------------------------------
 data TransactionMetadata = TransactionMetadata {
-    txMetaCreationTime :: {-# UNPACK #-} !(Time Int64)
-  , txMetaExpiryTime :: {-# UNPACK #-} !(Time Int64)
+    txMetaCreationTime :: {-# UNPACK #-} !(Time Micros)
+  , txMetaExpiryTime :: {-# UNPACK #-} !(Time Micros)
   } deriving (Eq, Ord, Show, Generic)
     deriving anyclass (FromJSON, ToJSON, NFData)
 

--- a/src/Chainweb/Time.hs
+++ b/src/Chainweb/Time.hs
@@ -67,7 +67,6 @@ module Chainweb.Time
 , secondsToText
 , secondsFromText
 , Micros(..)
-, microsToSeconds
 ) where
 
 import Control.DeepSeq
@@ -282,9 +281,6 @@ newtype Micros = Micros Int64
     deriving anyclass (Hashable, NFData)
     deriving newtype (Num, Integral, Real, AdditiveGroup, AdditiveMonoid, AdditiveSemigroup)
     deriving newtype (Arbitrary, ToJSON, FromJSON)
-
-microsToSeconds :: Micros -> Seconds
-microsToSeconds (Micros m) = Seconds (int m `div` 1000000)
 
 -- -------------------------------------------------------------------------- --
 -- Arbitrary Instances

--- a/src/Chainweb/Time.hs
+++ b/src/Chainweb/Time.hs
@@ -66,6 +66,8 @@ module Chainweb.Time
 , timeSpanToSeconds
 , secondsToText
 , secondsFromText
+, Micros(..)
+, microsToSeconds
 ) where
 
 import Control.DeepSeq
@@ -111,16 +113,16 @@ newtype TimeSpan :: Type -> Type where
         , ToJSON, FromJSON
         )
 
-encodeTimeSpan :: MonadPut m => TimeSpan Int64 -> m ()
-encodeTimeSpan (TimeSpan a) = putWord64le $ unsigned a
+encodeTimeSpan :: MonadPut m => TimeSpan Micros -> m ()
+encodeTimeSpan (TimeSpan (Micros a)) = putWord64le $ unsigned a
 {-# INLINE encodeTimeSpan #-}
 
-encodeTimeSpanToWord64 :: TimeSpan Int64 -> Word64
-encodeTimeSpanToWord64 (TimeSpan a) = BA.unLE . BA.toLE $ unsigned a
+encodeTimeSpanToWord64 :: TimeSpan Micros -> Word64
+encodeTimeSpanToWord64 (TimeSpan (Micros a)) = BA.unLE . BA.toLE $ unsigned a
 {-# INLINE encodeTimeSpanToWord64 #-}
 
-decodeTimeSpan :: MonadGet m => m (TimeSpan Int64)
-decodeTimeSpan = TimeSpan . signed <$!> getWord64le
+decodeTimeSpan :: MonadGet m => m (TimeSpan Micros)
+decodeTimeSpan = TimeSpan . Micros . signed <$!> getWord64le
 {-# INLINE decodeTimeSpan #-}
 
 castTimeSpan :: NumCast a b => TimeSpan a -> TimeSpan b
@@ -177,15 +179,15 @@ getCurrentTimeIntegral = do
     t <- getPOSIXTime
     return $! Time $! TimeSpan $! round $ t * 1000000
 
-encodeTime :: MonadPut m => Time Int64 -> m ()
+encodeTime :: MonadPut m => Time Micros -> m ()
 encodeTime (Time a) = encodeTimeSpan a
 {-# INLINE encodeTime #-}
 
-encodeTimeToWord64 :: Time Int64 -> Word64
+encodeTimeToWord64 :: Time Micros -> Word64
 encodeTimeToWord64 (Time a) = encodeTimeSpanToWord64 a
 {-# INLINE encodeTimeToWord64 #-}
 
-decodeTime :: MonadGet m => m (Time Int64)
+decodeTime :: MonadGet m => m (Time Micros)
 decodeTime  = Time <$!> decodeTimeSpan
 {-# INLINE decodeTime #-}
 
@@ -272,6 +274,17 @@ instance HasTextRepresentation Seconds where
     {-# INLINE toText #-}
     fromText = secondsFromText
     {-# INLINE fromText #-}
+
+-- | Will last for around ~300,000 years after the Linux epoch.
+--
+newtype Micros = Micros Int64
+    deriving (Show, Eq, Ord, Enum, Bounded, Generic)
+    deriving anyclass (Hashable, NFData)
+    deriving newtype (Num, Integral, Real, AdditiveGroup, AdditiveMonoid, AdditiveSemigroup)
+    deriving newtype (Arbitrary, ToJSON, FromJSON)
+
+microsToSeconds :: Micros -> Seconds
+microsToSeconds (Micros m) = Seconds (int m `div` 1000000)
 
 -- -------------------------------------------------------------------------- --
 -- Arbitrary Instances

--- a/src/Chainweb/TreeDB/Difficulty.hs
+++ b/src/Chainweb/TreeDB/Difficulty.hs
@@ -17,7 +17,6 @@ import Control.Lens ((^.))
 
 import Data.Function ((&))
 import qualified Data.HashSet as HS
-import Data.Int (Int64)
 import Data.Semigroup (Max(..), Min(..))
 
 import Numeric.Natural (Natural)
@@ -28,7 +27,7 @@ import qualified Streaming.Prelude as P
 
 import Chainweb.BlockHeader
 import Chainweb.Difficulty
-import Chainweb.Time (Time(..), TimeSpan(..))
+import Chainweb.Time (Time(..), TimeSpan(..), Micros(..))
 import Chainweb.TreeDB
 import Chainweb.Utils (fromJuste, int)
 import Chainweb.Version (ChainwebVersion)
@@ -58,7 +57,7 @@ hashTarget db bh
 
         -- The time difference in microseconds between when the earliest and
         -- latest blocks in the window were mined.
-        let delta :: TimeSpan Int64
+        let delta :: TimeSpan Micros
             !delta = TimeSpan $ time bh' - time start
 
         pure . adjust ver (WindowWidth ww) delta $ _blockTarget bh'
@@ -103,5 +102,5 @@ hashTarget db bh
     lower = HS.empty
     upper = HS.singleton . UpperBound $! key bh
 
-    time :: BlockHeader -> Int64
+    time :: BlockHeader -> Micros
     time h = case _blockCreationTime h of BlockCreationTime (Time (TimeSpan n)) -> n

--- a/src/P2P/Node.hs
+++ b/src/P2P/Node.hs
@@ -67,7 +67,6 @@ import Data.Aeson hiding (Error)
 import Data.Foldable
 import Data.Hashable
 import qualified Data.HashSet as HS
-import Data.Int
 import Data.IxSet.Typed (getEQ, getGT, getGTE, getLT, size)
 import qualified Data.Map.Strict as M
 import qualified Data.Text as T
@@ -180,8 +179,8 @@ data P2pSessionInfo = P2pSessionInfo
     { _p2pSessionInfoId :: !T.Text
     , _p2pSessionInfoSource :: !PeerInfo
     , _p2pSessionInfoTarget :: !PeerInfo
-    , _p2pSessionInfoStart :: !(Time Int64)
-    , _p2pSessionInfoEnd :: !(Maybe (Time Int64))
+    , _p2pSessionInfoStart :: !(Time Micros)
+    , _p2pSessionInfoEnd :: !(Maybe (Time Micros))
     , _p2pSessionInfoResult :: !(Maybe P2pSessionResult)
     }
     deriving (Show, Eq, Ord, Generic)
@@ -226,7 +225,7 @@ addSession
     :: P2pNode
     -> PeerInfo
     -> Async (Maybe Bool)
-    -> Time Int64
+    -> Time Micros
     -> STM P2pSessionInfo
 addSession node peer session start = do
     modifyTVar' (_p2pNodeSessions node) $ M.insert peer (info, session)

--- a/test/Chainweb/Test/CutDB.hs
+++ b/test/Chainweb/Test/CutDB.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
-{-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}

--- a/test/Chainweb/Test/Roundtrips.hs
+++ b/test/Chainweb/Test/Roundtrips.hs
@@ -17,7 +17,6 @@ module Chainweb.Test.Roundtrips
 import Data.Aeson
 import qualified Data.ByteString.Lazy as BL
 import qualified Data.HashMap.Strict as HM
-import Data.Int
 import qualified Data.Text as T
 
 import Test.QuickCheck
@@ -121,8 +120,8 @@ jsonTestCases
     :: (forall a . Arbitrary a => Show a => ToJSON a => FromJSON a => Eq a => a -> Property)
     -> [TestTree]
 jsonTestCases f =
-    [ testProperty "Time Int64" $ f @(Time Int64)
-    , testProperty "TimeSpan Int64" $ f @(TimeSpan Int64)
+    [ testProperty "Time Micros" $ f @(Time Micros)
+    , testProperty "TimeSpan Micros" $ f @(TimeSpan Micros)
     , testProperty "Seconds" $ f @Seconds
     , testProperty "ChainId" $ f @ChainId
     , testProperty "NodeId" $ f @NodeId
@@ -254,4 +253,3 @@ hasTextRepresentationTests = testGroup "HasTextRepresentation roundtrips"
     , testProperty "Transaction" $ prop_iso' @_ @Transaction fromText toText
     , testProperty "TransactionOutput" $ prop_iso' @_ @TransactionOutput fromText toText
     ]
-


### PR DESCRIPTION
This PR makes us explicit about our usage of a microsecond unit in our `Time` type. This decreases chaos in Difficulty Adjustment and Hash Power Estimation.

Closes #260 