### PR TITLE
[mempool] some performance fixes.

### DIFF
--- a/src/Chainweb/Transaction.hs
+++ b/src/Chainweb/Transaction.hs
@@ -48,11 +48,6 @@ data PayloadWithText = PayloadWithText
     deriving (Show, Eq, Generic)
     deriving anyclass (NFData)
 
-{-
-instance Ord PayloadWithText where
-    compare x y = compare (payloadBytes x) (payloadBytes y)
--}
-
 instance ToJSON PayloadWithText where
     toJSON (PayloadWithText bs _) = toJSON (T.decodeUtf8 bs)
     toEncoding (PayloadWithText bs _) = toEncoding (T.decodeUtf8 bs)

--- a/src/Chainweb/Transaction.hs
+++ b/src/Chainweb/Transaction.hs
@@ -34,6 +34,7 @@ import Pact.Parse (parseExprs)
 import Pact.Types.ChainMeta
 import Pact.Types.Command
 import Pact.Types.Gas (GasLimit(..), GasPrice(..))
+import Pact.Types.Hash
 
 import Chainweb.Utils (Codec(..))
 
@@ -47,8 +48,10 @@ data PayloadWithText = PayloadWithText
     deriving (Show, Eq, Generic)
     deriving anyclass (NFData)
 
+{-
 instance Ord PayloadWithText where
     compare x y = compare (payloadBytes x) (payloadBytes y)
+-}
 
 instance ToJSON PayloadWithText where
     toJSON (PayloadWithText bs _) = toJSON (T.decodeUtf8 bs)
@@ -70,10 +73,12 @@ newtype HashableTrans a = HashableTrans { unHashable :: Command a }
     deriving (Eq, Functor, Ord)
 
 instance Hashable (HashableTrans PayloadWithText) where
-    hashWithSalt s (HashableTrans t) = hashWithSalt s (hashCode :: Int)
+    hashWithSalt s (HashableTrans t) = hashWithSalt s hashCode
       where
-        hashCode = either error id $ runGetS (fromIntegral <$> getWord64host)
-                   (B.take 8 (codecEncode chainwebPayloadCodec t))
+        (TypedHash hc) = _cmdHash t
+        decHC = runGetS getWord64host
+        !hashCode = either error id $ decHC (B.take 8 hc)
+    {-# INLINE hashWithSalt #-}
 
 -- | A codec for (Command PayloadWithText) transactions.
 chainwebPayloadCodec :: Codec (Command PayloadWithText)


### PR DESCRIPTION
1. improve Hashable instance for pact transactions (use existing _cmdHash instead of re-encoding and hashing)

2. fix O(n^2) vector cons loops in Chainweb.Mempool.Consensus

3. strictify some folds