### PR TITLE
optimize limit cut function

### DIFF
--- a/src/Chainweb/Cut.hs
+++ b/src/Chainweb/Cut.hs
@@ -247,7 +247,7 @@ limitCut wdb h c
     fastRoute1 cid x = do
         !db <- give wdb $ getWebBlockHeaderDb cid
         let l = min (_blockHeight x) (int ch)
-        !a <- S.toList_ & entries db Nothing (Just 2) (Just $ int l) (Just $ int l)
+        a <- S.toList_ & entries db Nothing (Just 2) (Just $ int l) (Just $ int l)
         case a of
             [r] -> return r
             _ -> fastRoute2 db x

--- a/src/Chainweb/Cut.hs
+++ b/src/Chainweb/Cut.hs
@@ -106,6 +106,7 @@ import qualified Streaming.Prelude as S
 import Chainweb.BlockHash
 import Chainweb.BlockHeader
 import Chainweb.BlockHeader.Genesis (genesisBlockHeaders)
+import Chainweb.BlockHeaderDB (BlockHeaderDb)
 import Chainweb.ChainId
 import Chainweb.Graph
 import Chainweb.TreeDB hiding (properties)
@@ -207,11 +208,11 @@ cutAdjs c cid = HM.intersection
 -- -------------------------------------------------------------------------- --
 -- Limit Cut Hashes By Height
 
--- | Find a cut that is a predecessor of the given cut and has a block height
--- that is smaller or equal the given height.
+-- | Find a `Cut` that is a predecessor of the given one, and that has a block
+-- height that is smaller or equal the given height.
 --
--- If the requested limit has larger or equal the current height the given cut
--- is returned.
+-- If the requested limit is larger or equal to the current height, the given
+-- cut is returned.
 --
 -- Otherwise, the requested height limit is divided by the number of chains
 -- (rounded down) and the result is used such that for each chain the
@@ -229,21 +230,25 @@ limitCut wdb h c
     | otherwise = do
         c & (cutHeaders . itraverse) fastRoute1
   where
+    gorder :: Natural
     gorder = order $ _chainGraph wdb
+
+    ch :: BlockHeight
     ch = h `div` int gorder
 
-    -- if there is only a single block at the requested block height, it must be
+    -- If there is only a single block at the requested block height, it must be
     -- a predecessor of any block of larger height. We first do an efficient
     -- pointwise lookup and return the result if it is unique. Otherwise we fall
     -- back to a traversing backward from the block in the given cut.
     --
-    -- Since we prune databases on startup older parts of the history are
-    -- expected to be linear. Also, generally, there aren't many forks.
-    -- Therefore, we expect this fast code path to be successful in most cases
-    -- where the requested height is further down in the history. If the
-    -- requested height is recent we don't care because the overhead of the
-    -- backward traversal is low.
+    -- Since we prune databases on startup, older parts of the history are
+    -- expected to be linear. Also, generally, there aren't many forks past the
+    -- initial moments of the network. Therefore, we expect this fast code path
+    -- to be successful in most cases where the requested height is further down
+    -- in the history. If the requested height is recent, we don't care because
+    -- the overhead of the backward traversal is low.
     --
+    fastRoute1 :: ChainId -> BlockHeader -> IO BlockHeader
     fastRoute1 cid x = do
         !db <- give wdb $ getWebBlockHeaderDb cid
         let l = min (_blockHeight x) (int ch)
@@ -252,16 +257,17 @@ limitCut wdb h c
             [r] -> return r
             _ -> fastRoute2 db x
 
-    -- If it turns out that the fastRoute doesn't return a result we start a
-    -- backward traversal with all blocks that are a constant number blocks above
-    -- the target block height. With high probability the history will have
-    -- narrowed to a single block once we reach the target height.
+    -- If it turns out that the fastRoute doesn't return a result, we start a
+    -- backward traversal with all blocks that are a constant number blocks
+    -- above the target block height. With high probability the history will
+    -- have narrowed to a single block once we reach the target height.
     --
+    fastRoute2 :: BlockHeaderDb -> BlockHeader -> IO BlockHeader
     fastRoute2 db x = do
         let l = int ch + gorder * 2
 
-        -- if l is much smaller than height of block in given cut, pick the
-        -- faster route
+        -- If l is much smaller than the height of the block in the given cut,
+        -- pick the faster route.
         if l < int (_blockHeight x)
           then do
             -- get all blocks at height l
@@ -284,6 +290,7 @@ limitCut wdb h c
     -- We find the predecessor of requested height of the block in the given cut
     -- by traversing along the parent relation.
     --
+    slowRoute :: BlockHeaderDb -> BlockHeader -> IO BlockHeader
     slowRoute db x = do
         !a <- S.head_ & branchEntries db
             Nothing (Just 1)

--- a/src/Chainweb/TreeDB.hs
+++ b/src/Chainweb/TreeDB.hs
@@ -331,12 +331,19 @@ class (Typeable db, TreeDbEntry (DbEntry db)) => TreeDb db where
     branchEntries
         :: db
         -> Maybe (NextItem (DbKey db))
+            -- ^ Cursor
         -> Maybe Limit
+            -- ^ Maximum number of items that are returned
         -> Maybe MinRank
+            -- ^ Minimum rank for returned items
         -> Maybe MaxRank
+            -- ^ Maximum rank for returned items
         -> HS.HashSet (LowerBound (DbKey db))
+            -- ^ Lower bounds for the returned items
         -> HS.HashSet (UpperBound (DbKey db))
+            -- ^ Upper bounds for the returned items
         -> (S.Stream (Of (DbEntry db)) IO (Natural, Eos) -> IO a)
+            -- ^ continuation that is provided the stream of result items
         -> IO a
     branchEntries db k l mir mar lower upper f = f $
         getBranch db lower upper


### PR DESCRIPTION
When getting new cuts nodes requests cuts that are only at most 1000 blocks ahead of the current cut of the node. The reason for that is to make nodes catching up more iteratively by going in chunks of 1000 blocks.

On the server side a limited cut is computed by using `branchEntries` which traverses the block header dbs backward until it reaches blocks at the target height. This traversal is currently not optimized. It follows the parent pointer with point wise lookups instead of using a reverse iterator, which has complexity `O(n)`. This works well for most cases because most of the time the number of traversed blocks is relatively small, and, thus, `n` is constant. For `limitCut` the `n` is in the order of the block height of the chain for each 1000-block chunk, and the overall complexity of catching up becomes `O(n*n)`. Since the node queries cuts from each active peer (testnet uses a peer count of 10 in the default configuration), this quadratic overhead incurs on 10 nodes. Moreover, for very large cut heights the `GET cut` queries timeout and the catch-up node spins making calls to peers, effectively running a DOS attack against the network.

Optimizing the `brachEntries` call by using a reverse iterator wouldn't resolve the overall problem.

This PR makes the assumption that for block heights further down in the history the history is linear and there is only a single block at that height. A fast code path is added that makes a point lookup for blocks at the given height. If there is only a single block it is used. Otherwise the expensive traversal is used as fall back to determine which block is on the main fork.

This approach is further refined, but by starting a backward traversal from all blocks at a constant number of blocks above the target height. By the time the target height is reached the set of ancestors has narrowed to a single block with high probability.