### PR TITLE
Copy (presumably short) bytestrings decoded as merkle hashes

### DIFF
--- a/src/Chainweb/MerkleLogHash.hs
+++ b/src/Chainweb/MerkleLogHash.hs
@@ -83,7 +83,7 @@ newtype MerkleLogHash = MerkleLogHash (MerkleRoot (HashAlg ChainwebHashTag))
 -- | Smart constructor
 --
 merkleLogHash :: MonadThrow m => B.ByteString -> m MerkleLogHash
-merkleLogHash = fmap MerkleLogHash . decodeMerkleRoot
+merkleLogHash = fmap MerkleLogHash . decodeMerkleRoot . B.copy
 {-# INLINE merkleLogHash #-}
 
 unsafeMerkleLogHash :: HasCallStack => B.ByteString -> MerkleLogHash


### PR DESCRIPTION
Try to make sure we don't accidentally pin a huge bytestring when decoding a merkle hash.