### PR TITLE
Fix a Chainweb-storage bug and make initialization more robust

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -21,7 +21,7 @@ source-repository-package
 source-repository-package
     type: git
     location: https://github.com/kadena-io/chainweb-storage.git
-    tag: 216b059889dab8b2bdf19a9d41c79fbb2cdd7771
+    tag: 351ace4436b1d88f96e9d17dfeecfcb58f205027
 
 constraints:
       megaparsec <7.0

--- a/default.nix
+++ b/default.nix
@@ -314,8 +314,8 @@ in
         chainweb-storage = pkgs.haskell.lib.dontCheck (self.callCabal2nix "chainweb-storage" (pkgs.fetchFromGitHub {
           owner = "kadena-io";
           repo = "chainweb-storage";
-          rev = "4a345323cd50f1fd24ed9565c0deeea5cc376db6";
-          sha256 = "0alqvb3hx7bvhq1mcpq8m0l2jcwz4b4xdp1d20r2fflbraqrvmgs";
+          rev = "351ace4436b1d88f96e9d17dfeecfcb58f205027";
+          sha256 = "0hsp7qpzas1lmxymxmkys20bdzvqr6rfvrbb89y7adyqima8qxhj";
         }) {});
 
         # Our own custom fork

--- a/stack.yaml
+++ b/stack.yaml
@@ -46,4 +46,4 @@ extra-deps:
   - github: kadena-io/thyme
     commit: 6ee9fcb026ebdb49b810802a981d166680d867c9
   - github: kadena-io/chainweb-storage
-    commit: 4a345323cd50f1fd24ed9565c0deeea5cc376db6
+    commit: 351ace4436b1d88f96e9d17dfeecfcb58f205027


### PR DESCRIPTION
This PR updates the pin for [chainweb-storage](https://github.com/kadena-io/chainweb-storage). The review should include the commits

* https://github.com/kadena-io/chainweb-storage/commit/5d12e51fc97183d9d52e8ceb634e0aab627590dc and
* https://github.com/kadena-io/chainweb-storage/commit/351ace4436b1d88f96e9d17dfeecfcb58f205027.

This PR also fixes a bug, that causes a dead-lock during initialization of a CutDB with a corrupted database. When the stored 'CutHashes' referred to a block header that was missing from the local chained, the CutDB tried to load the missing header from the network by queuing a task for it. But during CutDB initialization, the process for serving the queue and fetching and validating remote headers and payloads hasn't yet started.

This PR fixes the issue by restricting the lookup for block headers to locally stored blocks. That makes the lookup fail fast. As before the fall back solution is to use the genesis cut. This results in a reevaluation of the complete chain, including pact replay. It would be possible to avoid this reevaluation and replay from genesis. However, it seems a good idea to do this in any when a data base corruption is encountered. Also, most resources are expected to be available locally, so the reevaluation is usually fast. 

