### PR TITLE
Fix spinning of RTS monitor without `+RTS -T`

### DIFF
--- a/chainweb.cabal
+++ b/chainweb.cabal
@@ -320,6 +320,7 @@ library
         , text >= 1.2
         , time >= 1.8
         , tls >=1.5
+        , token-bucket >= 0.1
         , transformers >= 0.5
         , unordered-containers >= 0.2
         , uuid >= 1.3

--- a/src/Chainweb/Logging/Amberdata.hs
+++ b/src/Chainweb/Logging/Amberdata.hs
@@ -167,17 +167,13 @@ instance FromJSON AmberdataConfig where
 -- Monitor
 
 amberdataBlockMonitor :: Logger logger => logger -> CutDb cas -> IO ()
-amberdataBlockMonitor logger db
-    = L.withLoggerLabel ("component", "amberdata-block-monitor") logger $ \l ->
-        runForever (logFunctionText l) "Chainweb.Logging.amberdataBlockMonitor" (go l)
+amberdataBlockMonitor logger db = do
+    logFunctionText logger Info "Initialized Amberdata Block Monitor"
+    void
+        $ S.mapM_ (logAllBlocks logger)
+        $ S.map cutToAmberdataBlocks
+        $ cutStream db
   where
-    go l = do
-        logFunctionText l Info "Initialized Amberdata Block Monitor"
-        void
-            $ S.mapM_ (logAllBlocks l)
-            $ S.map cutToAmberdataBlocks
-            $ cutStream db
-
     logAllBlocks :: Logger logger => logger -> [AmberdataBlock] -> IO ()
     logAllBlocks l = mapM_ (logFunctionJson l Info)
 

--- a/src/Chainweb/Utils.hs
+++ b/src/Chainweb/Utils.hs
@@ -123,6 +123,7 @@ module Chainweb.Utils
 , trySynchronous
 , tryAllSynchronous
 , runForever
+, runForeverThrottled
 
 -- * Command Line Options
 , OptionParser
@@ -170,6 +171,7 @@ import Configuration.Utils hiding (Error, Lens)
 
 import Control.Concurrent.Async
 import Control.Concurrent.MVar
+import Control.Concurrent.TokenBucket
 import Control.DeepSeq
 import Control.Exception
     (IOException, SomeAsyncException(..), bracket, evaluate)
@@ -826,7 +828,35 @@ runForever logfun name a = mask $ \umask -> do
     logfun Info $ "start " <> name
     let go = do
             forever (umask a) `catchAllSynchronous` \e ->
-                logfun Error $ name <> " failed: " <> sshow e
+                logfun Error $ name <> " failed: " <> sshow e <> ". Restarting ..."
+            go
+    void go `finally` logfun Info (name <> " stopped")
+
+-- | Repeatedly run a computation 'forever' at the given rate until it is
+-- stopped by receiving 'SomeAsyncException'.
+--
+-- If the computation throws an exception that is not contained in
+-- 'SomeAsyncException' an error message is logged and the function continues to
+-- repeat the computation 'forever'.
+--
+-- An info-level message is logged when processing starts and stops.
+--
+runForeverThrottled
+    :: (LogLevel -> T.Text -> IO ())
+    -> T.Text
+    -> Word64
+        -- ^ burst size (number of calls)
+    -> Word64
+        -- ^ rate limit (usec / call)
+    -> IO ()
+    -> IO ()
+runForeverThrottled logfun name burst rate a = mask $ \umask -> do
+    tokenBucket <- newTokenBucket
+    logfun Info $ "start " <> name
+    let runThrottled = tokenBucketWait tokenBucket burst rate >> a
+        go = do
+            forever (umask runThrottled) `catchAllSynchronous` \e ->
+                logfun Error $ name <> " failed: " <> sshow e <> ". Restarting ..."
             go
     void go `finally` logfun Info (name <> " stopped")
 


### PR DESCRIPTION
This PR

* [x] fixes the immediate cause for the rts-monitor to spin when a chainweb-node runs without `+RTS -T` that was introduced in #279 

* [x] Implements a solution to the more general problem of monitors spinning in a tight loop in case of failures.

The solution is agnostic of the case of failure that just does a best effort for the general case where failure may or may not be permanent. It also assumes that the node shouldn't be killed completely in case of an unknown failure in a monitor and that submitting error logs is sufficient.

Handlers for specific failure modes of monitors should be added in addition and on top of the strategy implement in this PR.