### PR TITLE
implement blockStream and cutStreamToHeaderStream

### DIFF
--- a/chainweb.cabal
+++ b/chainweb.cabal
@@ -289,6 +289,7 @@ library
         , loglevel >= 0.1
         , memory >=0.14
         , merkle-log
+        , mmorph >= 1.1
         , monad-control >= 1.0
         , mtl >= 2.2
         , mwc-random >= 0.13

--- a/src/Chainweb/Cut.hs
+++ b/src/Chainweb/Cut.hs
@@ -73,6 +73,9 @@ module Chainweb.Cut
 -- * Meet
 , meet
 
+-- * Misc internal tools
+, zipCuts
+
 ) where
 
 import Control.DeepSeq


### PR DESCRIPTION
The PR provides stream that provide all bocks in a branch of a Chainweb represented by a stream of cuts.

* [x] `blockStream` provides *all* new blocks in the winning branch of a chainweb.
* [x] `cutStreamToHeaderStream` provides *all* blocks "in-between" the first cut in the input stream and the most recent cut in the input stream. In case of forks, the block stream rewinds to the fork point and continues from there.

`blockStream` is a prerequisite for the follow up PR for #292 that will ensure that actually all blocks are published to Amberdata and blocks aren't published twice.