### PR TITLE
force bloom filter calculation in bloom tx cache

### DIFF
--- a/src/Chainweb/Pact/BloomCache.hs
+++ b/src/Chainweb/Pact/BloomCache.hs
@@ -219,7 +219,7 @@ updateChain' cutDb bdb minHeight blockHeader0 mp0 = go mp0 blockHeader0
             let payloadHash = _blockPayloadHash blockHeader
             (PayloadWithOutputs txsBs _ _ _ _ _) <- MaybeT $ casLookup pdb payloadHash
             hashes <- mapM (fmap (H.toUntypedHash . _cmdHash) . fromTx) txsBs
-            let ~bloom = Bloom.easyList bloomFalsePositiveRate $ toList hashes
+            let !bloom = Bloom.easyList bloomFalsePositiveRate $ toList hashes
             return $! HashMap.insert hkey bloom mp
 
     pdb = cutDb ^. CutDB.cutDbPayloadCas


### PR DESCRIPTION
Femove lazy pattern match in creation of bloom filters. Instead force bloom filter computation to prevent them from retaining all resources of all transaction that were added to the bloom filters.