### PR TITLE
Increase block gas limit to allow blocks of up 1000 tx in devnet

### DIFF
--- a/src/Chainweb/Chainweb.hs
+++ b/src/Chainweb/Chainweb.hs
@@ -342,7 +342,7 @@ mempoolConfig enableReIntro = Mempool.InMemConfig
     maxRecentLog
     enableReIntro
   where
-    blockGasLimit = 1000000               -- TODO: policy decision
+    blockGasLimit = 100000               -- TODO: policy decision
     mempoolReapInterval = 60 * 20 * 1000000   -- 20 mins
     maxRecentLog = 2048                   -- store 2k recent transaction hashes
 

--- a/src/Chainweb/Pact/Service/PactInProcApi.hs
+++ b/src/Chainweb/Pact/Service/PactInProcApi.hs
@@ -101,7 +101,7 @@ withPactService' ver cid logger memPoolAccess cdbv bhDb pdb dbDir nodeid resetDb
 -- TODO: get from config
 -- TODO: why is this declared both here and in Mempool
 maxBlockSize :: GasLimit
-maxBlockSize = 10000
+maxBlockSize = 100000
 
 pactMemPoolAccess
     :: Logger logger


### PR DESCRIPTION
NOTE: The function `Chainweb.Mempool.InMem.getBlockInMem` takes `InMemConfig t` as parameter, which contains `blockGasLimit` as configured in `Chainweb.Chainweb`. However, it ignores it and instead uses the hard-coded value `Chainweb.Pact.Service.PactInProcApi.maxBlockSize` that is provided as extra argument. That’s confusing. Which value is supposed to be used?