### PR TITLE
persist validated tx in the Mempool into RocksDB

### DIFF
--- a/src/Chainweb/Chainweb/ChainResources.hs
+++ b/src/Chainweb/Chainweb/ChainResources.hs
@@ -128,7 +128,7 @@ withChainResources
     -> IO a
 withChainResources v cid rdb peer logger mempoolCfg cdbv payloadDb prune dbDir nodeid resetDb inner =
     withBlockHeaderDb rdb v cid $ \cdb ->
-      Mempool.withInMemoryMempool mempoolCfg $ \mempool -> do
+      Mempool.withInMemoryMempool mempoolCfg rdb $ \mempool -> do
         mpc <- MPCon.mkMempoolConsensus reIntroEnabled mempool cdb $ Just payloadDb
         withPactService v cid (setComponent "pact" logger) mpc cdbv cdb payloadDb dbDir nodeid resetDb $
           \requestQ -> do

--- a/src/Chainweb/Mempool/InMem.hs
+++ b/src/Chainweb/Mempool/InMem.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE ExistentialQuantification #-}
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeFamilies #-}
@@ -28,8 +29,9 @@ import Control.DeepSeq
 import Control.Exception (bracket, bracketOnError, mask_)
 import Control.Monad (forever, void, (<$!>))
 
+import Data.Aeson
+import qualified Data.ByteString.Short as SB
 import Data.Foldable (foldl', foldlM)
-import qualified Data.HashMap.Strict as HashMap
 import qualified Data.HashPSQ as PSQ
 import qualified Data.HashSet as HashSet
 import Data.IORef
@@ -50,8 +52,9 @@ import System.Random
 import Chainweb.Mempool.InMemTypes
 import Chainweb.Mempool.Mempool
 import qualified Chainweb.Time as Time
-import Chainweb.Utils (fromJuste, ssnd)
+import Chainweb.Utils (fromJuste, ssnd, encodeToByteString, decodeStrictOrThrow')
 
+import Data.CAS.RocksDB
 
 ------------------------------------------------------------------------------
 toPriority :: GasPrice -> GasLimit -> Priority
@@ -59,11 +62,14 @@ toPriority r s = (Down r, s)
 
 
 ------------------------------------------------------------------------------
-makeInMemPool :: InMemConfig t
+makeInMemPool :: ToJSON t
+              => FromJSON t
+              => InMemConfig t
+              -> RocksDb
               -> IO (InMemoryMempool t)
-makeInMemPool cfg = mask_ $ do
+makeInMemPool cfg db = mask_ $ do
     nonce <- randomIO
-    dataLock <- newInMemMempoolData >>= newMVar
+    dataLock <- newInMemMempoolData db >>= newMVar
     tid <- forkIOWithUnmask (reaperThread cfg dataLock)
     return $! InMemoryMempool cfg dataLock tid nonce
 
@@ -72,19 +78,25 @@ destroyInMemPool = mask_ . killThread . _inmemReaper
 
 
 ------------------------------------------------------------------------------
-newInMemMempoolData :: IO (InMemoryMempoolData t)
-newInMemMempoolData = InMemoryMempoolData <$!> newIORef PSQ.empty
-                           <*> newIORef HashMap.empty
+newInMemMempoolData :: ToJSON t => FromJSON t => RocksDb -> IO (InMemoryMempoolData t)
+newInMemMempoolData db = InMemoryMempoolData <$!> newIORef PSQ.empty
+                           <*> pure (newTable db valCodec keyCodec ["mempool", "validated"])
                            <*> newIORef HashSet.empty
                            <*> newIORef Nothing
                            <*> newIORef emptyRecentLog
+  where
+    valCodec = Codec (encodeToByteString) (decodeStrictOrThrow')
+    keyCodec = Codec (\(TransactionHash h) -> SB.fromShort h) (decodeStrictOrThrow')
 
 
 ------------------------------------------------------------------------------
-makeSelfFinalizingInMemPool :: InMemConfig t
+makeSelfFinalizingInMemPool :: FromJSON t
+                            => ToJSON t
+                            => InMemConfig t
+                            -> RocksDb
                             -> IO (MempoolBackend t)
-makeSelfFinalizingInMemPool cfg =
-    mask_ $ bracketOnError (makeInMemPool cfg) destroyInMemPool $ \mpool -> do
+makeSelfFinalizingInMemPool cfg db =
+    mask_ $ bracketOnError (makeInMemPool cfg db) destroyInMemPool $ \mpool -> do
         ref <- newIORef mpool
         wk <- mkWeakIORef ref (destroyInMemPool mpool)
         back <- toMempoolBackend mpool
@@ -193,14 +205,17 @@ toMempoolBackend mempool = do
 
 ------------------------------------------------------------------------------
 -- | A 'bracket' function for in-memory mempools.
-withInMemoryMempool :: InMemConfig t
+withInMemoryMempool :: ToJSON t
+                    => FromJSON t
+                    => InMemConfig t
+                    -> RocksDb
                     -> (MempoolBackend t -> IO a)
                     -> IO a
-withInMemoryMempool cfg f = do
+withInMemoryMempool cfg db f = do
     let action inMem = do
           back <- toMempoolBackend inMem
           f $! back
-    bracket (makeInMemPool cfg) destroyInMemPool action
+    bracket (makeInMemPool cfg db) destroyInMemPool action
 
 ------------------------------------------------------------------------------
 memberInMem :: MVar (InMemoryMempoolData t)
@@ -209,16 +224,18 @@ memberInMem :: MVar (InMemoryMempoolData t)
 memberInMem lock txs = do
     (q, validated, confirmed) <- withMVarMasked lock $ \mdata -> do
         q <- readIORef $ _inmemPending mdata
-        validated <- readIORef $ _inmemValidated mdata
+        let validated = _inmemValidated mdata
         confirmed <- readIORef $ _inmemConfirmed mdata
         return $! (q, validated, confirmed)
-    return $! V.map (memberOne q validated confirmed) txs
+    V.mapM (memberOne q validated confirmed) txs
 
   where
-    memberOne q validated confirmed txHash =
-        PSQ.member txHash q ||
-        HashMap.member txHash validated ||
-        HashSet.member txHash confirmed
+    memberOne q validated confirmed txHash = do
+        v <- maybe False (const True) <$> tableLookup validated txHash
+        return $!
+            PSQ.member txHash q ||
+            v ||
+            HashSet.member txHash confirmed
 
 ------------------------------------------------------------------------------
 lookupInMem :: MVar (InMemoryMempoolData t)
@@ -227,19 +244,21 @@ lookupInMem :: MVar (InMemoryMempoolData t)
 lookupInMem lock txs = do
     (q, validated, confirmed) <- withMVarMasked lock $ \mdata -> do
         q <- readIORef $ _inmemPending mdata
-        validated <- readIORef $ _inmemValidated mdata
+        let validated = _inmemValidated mdata
         confirmed <- readIORef $ _inmemConfirmed mdata
         return $! (q, validated, confirmed)
-    return $! V.map (fromJuste . lookupOne q validated confirmed) txs
+    V.mapM (fmap fromJuste . lookupOne q validated confirmed) txs
   where
-    lookupOne q validated confirmed txHash =
-        lookupQ q txHash <|>
-        lookupVal validated txHash <|>
-        lookupConfirmed confirmed txHash <|>
-        pure Missing
+    lookupOne q validated confirmed txHash = do
+        v <- fmap Validated <$> tableLookup validated txHash
+        return $!
+            lookupQ q txHash <|>
+            v <|>
+            lookupConfirmed confirmed txHash <|>
+            pure Missing
 
     lookupQ q txHash = Pending . snd <$> PSQ.lookup txHash q
-    lookupVal val txHash = Validated <$> HashMap.lookup txHash val
+    -- lookupVal val txHash = Validated <$> HashMap.lookup txHash val
     lookupConfirmed confirmed txHash =
         if HashSet.member txHash confirmed
           then Just Confirmed
@@ -270,9 +289,9 @@ insertInMem cfg lock txs = do
                         s = txGasLimit txcfg x
                     in toPriority r s
     exists mdata txhash = do
-        valMap <- readIORef $ _inmemValidated mdata
+        inValMap <- maybe False (const True) <$> tableLookup (_inmemValidated mdata) txhash
         confMap <- readIORef $ _inmemConfirmed mdata
-        return $! (HashMap.member txhash valMap || HashSet.member txhash confMap)
+        return $! (inValMap || HashSet.member txhash confMap)
     insOne mdata tx = do
         b <- exists mdata txhash
         v <- validateTx tx
@@ -329,7 +348,7 @@ markValidatedInMem cfg lock txs = withMVarMasked lock $ \mdata ->
     validateOne mdata tx = do
         let txhash = hash $ validatedTransaction tx
         modifyIORef' (_inmemPending mdata) $ PSQ.delete txhash
-        modifyIORef' (_inmemValidated mdata) $ HashMap.insert txhash tx
+        tableInsert (_inmemValidated mdata) txhash tx
 
 
 ------------------------------------------------------------------------------
@@ -341,7 +360,7 @@ markConfirmedInMem lock txhashes =
   where
     confirmOne mdata txhash = do
         modifyIORef' (_inmemPending mdata) $ PSQ.delete txhash
-        modifyIORef' (_inmemValidated mdata) $ HashMap.delete txhash
+        tableDelete (_inmemValidated mdata) txhash
         modifyIORef' (_inmemConfirmed mdata) $ HashSet.insert txhash
 
 
@@ -415,10 +434,10 @@ reintroduceInMem' cfg lock txhashes = do
                         s = limit x
                     in toPriority r s
     reintroduceOne mdata txhash = do
-        m <- HashMap.lookup txhash <$> readIORef (_inmemValidated mdata)
+        m <- tableLookup (_inmemValidated mdata) txhash
         maybe (return ()) (reintroduceIt mdata txhash) m
     reintroduceIt mdata txhash (ValidatedTransaction _ _ tx) = do
-        modifyIORef' (_inmemValidated mdata) $ HashMap.delete txhash
+        tableDelete (_inmemValidated mdata) txhash
         modifyIORef' (_inmemPending mdata) $ PSQ.insert txhash (getPriority tx) tx
 
 ------------------------------------------------------------------------------
@@ -436,7 +455,7 @@ clearInMem :: MVar (InMemoryMempoolData t) -> IO ()
 clearInMem lock = do
     withMVarMasked lock $ \mdata -> do
         writeIORef (_inmemPending mdata) PSQ.empty
-        writeIORef (_inmemValidated mdata) HashMap.empty
+        -- writeIORef (_inmemValidated mdata) HashMap.empty
         writeIORef (_inmemConfirmed mdata) HashSet.empty
         writeIORef (_inmemRecentLog mdata) emptyRecentLog
 

--- a/src/Chainweb/Mempool/InMemTypes.hs
+++ b/src/Chainweb/Mempool/InMemTypes.hs
@@ -22,7 +22,6 @@ module Chainweb.Mempool.InMemTypes
 import Control.Concurrent (ThreadId)
 import Control.Concurrent.MVar (MVar)
 
-import Data.HashMap.Strict (HashMap)
 import Data.HashPSQ (HashPSQ)
 import Data.HashSet (HashSet)
 import Data.IORef (IORef)
@@ -36,6 +35,8 @@ import Pact.Types.Gas (GasPrice(..))
 
 import Chainweb.BlockHeader
 import Chainweb.Mempool.Mempool
+
+import Data.CAS.RocksDB
 
 ------------------------------------------------------------------------------
 -- | Priority for the search queue
@@ -75,7 +76,8 @@ data InMemoryMempoolData t = InMemoryMempoolData {
     -- we'll have to replay it.
     --
     -- N.B. atomic access to these IORefs is not necessary -- we hold the lock here.
-  , _inmemValidated :: !(IORef (HashMap TransactionHash (ValidatedTransaction t)))
+  -- , _inmemValidated :: !(IORef (HashMap TransactionHash (ValidatedTransaction t)))
+  , _inmemValidated :: RocksDbTable TransactionHash (ValidatedTransaction t)
   , _inmemConfirmed :: !(IORef (HashSet TransactionHash))
   , _inmemLastNewBlockParent :: !(IORef (Maybe BlockHeader))
   , _inmemRecentLog :: !(IORef RecentLog)

--- a/test/Chainweb/Test/Mempool/InMem.hs
+++ b/test/Chainweb/Test/Mempool/InMem.hs
@@ -11,13 +11,14 @@ import Chainweb.Mempool.Mempool
 import Chainweb.Test.Mempool (MempoolWithFunc(..))
 import qualified Chainweb.Test.Mempool
 import Chainweb.Utils (Codec(..))
+import Data.CAS.RocksDB
 ------------------------------------------------------------------------------
 
-tests :: TestTree
-tests = testGroup "Chainweb.Mempool.InMem"
+tests :: RocksDb -> TestTree
+tests rdb = testGroup "Chainweb.Mempool.InMem"
             $ Chainweb.Test.Mempool.tests
             $ MempoolWithFunc
-            $ InMem.withInMemoryMempool cfg
+            $ InMem.withInMemoryMempool cfg rdb
   where
     txcfg = TransactionConfig mockCodec hasher hashmeta mockGasPrice mockGasLimit
                               mockMeta (const $ return True)

--- a/test/ChainwebTests.hs
+++ b/test/ChainwebTests.hs
@@ -91,9 +91,9 @@ suite rdb =
         , Chainweb.Test.RestAPI.tests rdb
         , Chainweb.Test.SPV.tests rdb
         , Chainweb.Test.Pact.SPV.tests
-        , Chainweb.Test.Mempool.InMem.tests
-        , Chainweb.Test.Mempool.Sync.tests
-        , Chainweb.Test.Mempool.RestAPI.tests
+        , Chainweb.Test.Mempool.InMem.tests rdb
+        , Chainweb.Test.Mempool.Sync.tests rdb
+        , Chainweb.Test.Mempool.RestAPI.tests rdb
         , Chainweb.Test.BlockHeader.Genesis.tests
         , testProperties "Chainweb.BlockHeaderDb.RestAPI.Server" Chainweb.Utils.Paging.properties
         , testProperties "Chainweb.HostAddress" Chainweb.HostAddress.properties


### PR DESCRIPTION
This persists the validated transactions into RocksDB.

The main motivation for this PR is to store the validated transactions in encoded form which is more memory efficient than storing the parsed Command along with all its dependencies, and the encoded transaction in memory.

Well, from there it was just a tiny step to use `RocksDbTable` instead of an in memory table/map.