### PR TITLE
Amberdata logging: Adds payload tx and size & allows sending single chain

### DIFF
--- a/chainweb.cabal
+++ b/chainweb.cabal
@@ -498,6 +498,7 @@ executable chainweb-node
         , lens >= 4.16
         , loglevel >= 0.1
         , managed >= 1.0
+        , mtl >= 2.2
         , streaming >= 0.2
         , text >= 1.2
         , unordered-containers >= 0.2

--- a/node/ChainwebNode.hs
+++ b/node/ChainwebNode.hs
@@ -10,6 +10,7 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
 
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
@@ -79,6 +80,7 @@ import Chainweb.Logging.Amberdata
 import Chainweb.Logging.Config
 import Chainweb.Logging.Miner
 import Chainweb.Mempool.Consensus (ReintroducedTxsLog)
+import Chainweb.Payload.PayloadStore.Types
 import Chainweb.Sync.WebBlockHeaderStore
 import Chainweb.Utils
 import Chainweb.Utils.RequestLog
@@ -175,7 +177,7 @@ runCutMonitor logger db = L.withLoggerLabel ("component", "cut-monitor") logger 
             $ S.map (cutToCutHashes Nothing)
             $ cutStream db
 
-runAmberdataBlockMonitor :: Logger logger => Maybe ChainId -> logger -> CutDb cas -> IO ()
+runAmberdataBlockMonitor :: (PayloadCas cas, Logger logger) => Maybe ChainId -> logger -> CutDb cas -> IO ()
 runAmberdataBlockMonitor cid logger db
     = L.withLoggerLabel ("component", "amberdata-block-monitor") logger $ \l ->
         runMonitorLoop "Chainweb.Logging.amberdataBlockMonitor" l (amberdataBlockMonitor cid l db)

--- a/src/Utils/Logging/Config.hs
+++ b/src/Utils/Logging/Config.hs
@@ -51,7 +51,7 @@ import Configuration.Utils.Validation
 import Control.DeepSeq
 import Control.Lens.TH
 import Control.Monad.Catch
-import Control.Monad.Error.Class (throwError)
+import Control.Monad.Writer (tell)
 
 import qualified Data.CaseInsensitive as CI
 import Data.String
@@ -197,8 +197,7 @@ validateBackendConfig o = do
         validateHandleConfig $ _backendConfigHandle o
         case (_backendConfigHandle o, _backendConfigColor o) of
             (FileHandle _, ColorTrue) ->
-              throwError
-              "log messages are formatted using ANSI color escape codes but are written to a file"
+              tell ["log messages are formatted using ANSI color escape codes but are written to a file"]
             _ -> return ()
 
 instance ToJSON BackendConfig where

--- a/src/Utils/Logging/Config.hs
+++ b/src/Utils/Logging/Config.hs
@@ -52,6 +52,7 @@ import Control.DeepSeq
 import Control.Lens.TH
 import Control.Monad.Catch
 import Control.Monad.Writer
+import Control.Monad.Error.Class (throwError)
 
 import qualified Data.CaseInsensitive as CI
 import Data.String
@@ -197,7 +198,8 @@ validateBackendConfig o = do
         validateHandleConfig $ _backendConfigHandle o
         case (_backendConfigHandle o, _backendConfigColor o) of
             (FileHandle _, ColorTrue) ->
-                tell ["log messages are formatted using ANSI color escape codes but are written to a file"]
+              liftIO $ throwError
+              $ error "log messages are formatted using ANSI color escape codes but are written to a file"
             _ -> return ()
 
 instance ToJSON BackendConfig where

--- a/src/Utils/Logging/Config.hs
+++ b/src/Utils/Logging/Config.hs
@@ -51,7 +51,6 @@ import Configuration.Utils.Validation
 import Control.DeepSeq
 import Control.Lens.TH
 import Control.Monad.Catch
-import Control.Monad.Writer
 import Control.Monad.Error.Class (throwError)
 
 import qualified Data.CaseInsensitive as CI
@@ -198,8 +197,8 @@ validateBackendConfig o = do
         validateHandleConfig $ _backendConfigHandle o
         case (_backendConfigHandle o, _backendConfigColor o) of
             (FileHandle _, ColorTrue) ->
-              liftIO $ throwError
-              $ error "log messages are formatted using ANSI color escape codes but are written to a file"
+              throwError
+              "log messages are formatted using ANSI color escape codes but are written to a file"
             _ -> return ()
 
 instance ToJSON BackendConfig where


### PR DESCRIPTION
Version 2 of Amberdata logging.

- Improves amberdata config flags.
- Amberdata can now be enabled/disabled via `--enable-amberdata-logger`. Disabled by default.
- Enables config validation
- Adds flag for only sending single chain information. If flag missing or null in the config file, then all chain information will be sent.
```
$stack exec -- chainweb-node --enable-amberdata-logger --amberdata-chain-id 0
```
- Adds payload transactions to blocks logging
- Adds payload size to blocks logging

To test:
```
$ stack exec -- chainweb-node --enable-amberdata-logger --amberdata-host <HOST>:<PORT> --amberdata-api-key <API-KEY> --amberdata-blockchain-id<BLOCKCHAIN-ID> --enable-amberdata-debug
```