### PR TITLE
Remote Miner Communication Resiliance 

### DIFF
--- a/chainweb.cabal
+++ b/chainweb.cabal
@@ -374,6 +374,7 @@ test-suite chainweb-tests
         Chainweb.Test.Mempool.InMem
         Chainweb.Test.Mempool.RestAPI
         Chainweb.Test.Mempool.Sync
+        Chainweb.Test.Misc
         Chainweb.Test.Orphans.Internal
         Chainweb.Test.Pact.PactInProcApi
         Chainweb.Test.P2P.Peer.BootstrapConfig
@@ -433,6 +434,7 @@ test-suite chainweb-tests
         , reflection >= 2.1
         , resource-pool >= 0.2
         , resourcet >= 1.2
+        , scheduler >= 1.4
         , servant >= 0.14
         , servant-client >= 0.14
         , servant-client-core >= 0.14

--- a/chainweb.cabal
+++ b/chainweb.cabal
@@ -294,6 +294,7 @@ library
         , mwc-random >= 0.13
         , neat-interpolation >= 0.3.2
         , network >= 2.6
+        , nonempty-containers >= 0.3
         , optparse-applicative >= 0.14
         , pact >= 2.6
         , paths >= 0.2

--- a/src/Chainweb/Chainweb/MinerResources.hs
+++ b/src/Chainweb/Chainweb/MinerResources.hs
@@ -20,9 +20,10 @@ module Chainweb.Chainweb.MinerResources
   , runMiner
   ) where
 
+import Data.List.NonEmpty (NonEmpty)
 import qualified Data.List.NonEmpty as NEL
-import Data.Set.NonEmpty (NESet)
-import qualified Data.Set.NonEmpty as NES
+import Data.Set (Set)
+import qualified Data.Set as S
 import qualified Data.Text as T
 
 import Network.HTTP.Client (defaultManagerSettings, newManager)
@@ -110,8 +111,8 @@ runMiner v mr = do
             m <- newManager defaultManagerSettings
             pure $ remoteMining m rs
 
-    g :: [HostAddress] -> Maybe (NESet BaseUrl)
-    g = fmap (NES.fromList . NEL.map f) . NEL.nonEmpty
+    g :: Set HostAddress -> Maybe (NonEmpty BaseUrl)
+    g = fmap (NEL.map f) . NEL.nonEmpty . S.toList
 
     f :: HostAddress -> BaseUrl
     f (HostAddress hn p) = BaseUrl Http hn' p' ""

--- a/src/Chainweb/Chainweb/MinerResources.hs
+++ b/src/Chainweb/Chainweb/MinerResources.hs
@@ -21,6 +21,7 @@ module Chainweb.Chainweb.MinerResources
   ) where
 
 import qualified Data.List.NonEmpty as NEL
+import Data.Set.NonEmpty (NESet)
 import qualified Data.Set.NonEmpty as NES
 import qualified Data.Text as T
 
@@ -103,11 +104,14 @@ runMiner v mr = do
         pure $ localTest gen miners
 
     powMiner :: IO (BlockHeader -> IO BlockHeader)
-    powMiner = case NEL.nonEmpty $ _configRemoteMiners conf of
+    powMiner = case g $ _configRemoteMiners conf of
         Nothing -> pure $ localPOW v
         Just rs -> do
             m <- newManager defaultManagerSettings
-            pure . remoteMining m . NES.fromList $ NEL.map f rs
+            pure $ remoteMining m rs
+
+    g :: [HostAddress] -> Maybe (NESet BaseUrl)
+    g = fmap (NES.fromList . NEL.map f) . NEL.nonEmpty
 
     f :: HostAddress -> BaseUrl
     f (HostAddress hn p) = BaseUrl Http hn' p' ""

--- a/src/Chainweb/Chainweb/MinerResources.hs
+++ b/src/Chainweb/Chainweb/MinerResources.hs
@@ -20,6 +20,8 @@ module Chainweb.Chainweb.MinerResources
   , runMiner
   ) where
 
+import qualified Data.List.NonEmpty as NEL
+import qualified Data.Set.NonEmpty as NES
 import qualified Data.Text as T
 
 import Network.HTTP.Client (defaultManagerSettings, newManager)
@@ -101,11 +103,11 @@ runMiner v mr = do
         pure $ localTest gen miners
 
     powMiner :: IO (BlockHeader -> IO BlockHeader)
-    powMiner = case _configRemoteMiners conf of
-        [] -> pure $ localPOW v
-        rs -> do
+    powMiner = case NEL.nonEmpty $ _configRemoteMiners conf of
+        Nothing -> pure $ localPOW v
+        Just rs -> do
             m <- newManager defaultManagerSettings
-            pure . remoteMining m $ map f rs
+            pure . remoteMining m . NES.fromList $ NEL.map f rs
 
     f :: HostAddress -> BaseUrl
     f (HostAddress hn p) = BaseUrl Http hn' p' ""

--- a/src/Chainweb/Miner/Config.hs
+++ b/src/Chainweb/Miner/Config.hs
@@ -19,6 +19,9 @@ import Configuration.Utils
 
 import Control.Lens hiding ((.=))
 
+import Data.Set (Set)
+import qualified Data.Set as S
+
 import GHC.Generics (Generic)
 
 import Numeric.Natural (Natural)
@@ -39,7 +42,7 @@ makeLenses ''MinerCount
 data MinerConfig = MinerConfig
     { _configTestMiners :: !MinerCount
     , _configMinerInfo :: !MinerInfo
-    , _configRemoteMiners :: ![HostAddress]
+    , _configRemoteMiners :: !(Set HostAddress)
     }
     deriving (Show, Eq, Generic)
 
@@ -49,7 +52,7 @@ defaultMinerConfig :: MinerConfig
 defaultMinerConfig = MinerConfig
     { _configTestMiners = MinerCount 10
     , _configMinerInfo = noMiner
-    , _configRemoteMiners = []
+    , _configRemoteMiners = S.empty
     }
 
 instance ToJSON MinerConfig where
@@ -71,7 +74,7 @@ pMinerConfig = id
         % long "test-miners"
         <> short 'm'
         <> help "testing only: number of known miner nodes"
-    <*< configRemoteMiners %:: pLeftMonoidalUpdate (pure <$> pRemoteMiner)
+    <*< configRemoteMiners %:: pLeftMonoidalUpdate (S.singleton <$> pRemoteMiner)
   where
     pRemoteMiner = textOption
         % long "remote-miner"

--- a/src/Chainweb/Miner/Miners.hs
+++ b/src/Chainweb/Miner/Miners.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE TypeOperators #-}
-{-# LANGUAGE ViewPatterns #-}
 
 -- |
 -- Module: Chainweb.Miner.Miners
@@ -21,10 +20,9 @@ module Chainweb.Miner.Miners
   , remoteMining
   ) where
 
+import Data.List.NonEmpty (NonEmpty)
 import qualified Data.List.NonEmpty as NEL
 import Data.Proxy (Proxy(..))
-import Data.Set.NonEmpty (NESet)
-import qualified Data.Set.NonEmpty as NES
 import Data.These (these)
 
 import Control.Concurrent (threadDelay)
@@ -101,8 +99,10 @@ submit :<|> poll = client (Proxy :: Proxy MiningAPI)
 -- on a different machine, may be on multiple machines, may be arbitrarily
 -- multithreaded.
 --
-remoteMining :: Manager -> NESet BaseUrl -> BlockHeader -> IO BlockHeader
-remoteMining m (NES.toList -> urls) bh = submission >> polling
+-- ASSUMPTION: The contents of the given @NonEmpty BaseUrl@ are unique.
+--
+remoteMining :: Manager -> NonEmpty BaseUrl -> BlockHeader -> IO BlockHeader
+remoteMining m urls bh = submission >> polling
   where
     -- TODO Report /all/ miner calls that errored?
     -- | Submit work to each given mining client. Will succeed so long as at

--- a/test/Chainweb/Test/Misc.hs
+++ b/test/Chainweb/Test/Misc.hs
@@ -1,0 +1,37 @@
+-- |
+-- Module: Chainweb.Test.Misc
+-- Copyright: Copyright © 2019 Kadena LLC.
+-- License: MIT
+-- Maintainer: Colin Woodbury <colin@kadena.io>
+-- Stability: experimental
+--
+-- Miscellaneous tests.
+--
+module Chainweb.Test.Misc
+  ( tests
+  ) where
+
+import Control.Concurrent (threadDelay)
+import Control.Scheduler (Comp(..), scheduleWork, terminateWith, withScheduler)
+
+import Test.Tasty
+import Test.Tasty.HUnit
+
+---
+
+tests :: TestTree
+tests = testGroup "Misc. Unit Tests"
+    [ testGroup "scheduler"
+          [ testCase "early termination result order" terminateOrder
+          ]
+    ]
+
+-- | Guarantee that `terminateWith` makes the scheduler's "head" return value be
+-- the default that was given.
+--
+terminateOrder :: Assertion
+terminateOrder = do
+    r <- withScheduler Par' $ \sch -> do
+        scheduleWork sch (threadDelay 5000000 >> pure 1)
+        scheduleWork sch (terminateWith sch 10)
+    head r @?= (10 :: Int)

--- a/test/ChainwebTests.hs
+++ b/test/ChainwebTests.hs
@@ -30,6 +30,7 @@ import qualified Chainweb.Test.Mempool.Consensus
 import qualified Chainweb.Test.Mempool.InMem
 import qualified Chainweb.Test.Mempool.RestAPI
 import qualified Chainweb.Test.Mempool.Sync
+import qualified Chainweb.Test.Misc
 import qualified Chainweb.Test.Pact.Checkpointer
 import qualified Chainweb.Test.Pact.PactExec
 import qualified Chainweb.Test.Pact.PactInProcApi
@@ -101,6 +102,7 @@ suite rdb =
         , Chainweb.Test.Mempool.InMem.tests rdb
         , Chainweb.Test.Mempool.Sync.tests rdb
         , Chainweb.Test.Mempool.RestAPI.tests rdb
+        , Chainweb.Test.Misc.tests
         , Chainweb.Test.BlockHeader.Genesis.tests
         , testProperties "Chainweb.BlockHeaderDb.RestAPI.Server" Chainweb.Utils.Paging.properties
         , testProperties "Chainweb.HostAddress" Chainweb.HostAddress.properties


### PR DESCRIPTION
This PR ensures that brittle/failing connections between `chainweb-node` and `chainweb-miner` processes will not cause problems.