### PR TITLE
Miner takes a Byte out of Life

### DIFF
--- a/chainweb.cabal
+++ b/chainweb.cabal
@@ -378,6 +378,7 @@ test-suite chainweb-tests
         Chainweb.Test.Mempool.InMem
         Chainweb.Test.Mempool.RestAPI
         Chainweb.Test.Mempool.Sync
+        Chainweb.Test.Miner.Core
         Chainweb.Test.Misc
         Chainweb.Test.Orphans.Internal
         Chainweb.Test.Pact.PactInProcApi
@@ -530,6 +531,8 @@ executable chainweb-miner
         , base-prelude >= 1.3
         , containers >= 0.5
         , errors >= 2.3
+        , mtl >= 2.2
+        , mwc-random >= 0.13
         , optparse-applicative >= 0.14
         , pretty-simple >= 2.1
         , scheduler >= 1.4.1

--- a/chainweb.cabal
+++ b/chainweb.cabal
@@ -299,7 +299,6 @@ library
         , mwc-random >= 0.13
         , neat-interpolation >= 0.3.2
         , network >= 2.6
-        , nonempty-containers >= 0.3
         , optparse-applicative >= 0.14
         , pact >= 2.6
         , paths >= 0.2

--- a/chainweb.cabal
+++ b/chainweb.cabal
@@ -531,7 +531,6 @@ executable chainweb-miner
         , base-prelude >= 1.3
         , containers >= 0.5
         , errors >= 2.3
-        , mtl >= 2.2
         , mwc-random >= 0.13
         , optparse-applicative >= 0.14
         , pretty-simple >= 2.1

--- a/src/Chainweb/Miner/Coordinator.hs
+++ b/src/Chainweb/Miner/Coordinator.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}

--- a/src/Chainweb/Miner/Core.hs
+++ b/src/Chainweb/Miner/Core.hs
@@ -57,6 +57,7 @@ newtype HeaderBytes = HeaderBytes { _headerBytes :: B.ByteString }
 --
 newtype TargetBytes = TargetBytes { _targetBytes :: B.ByteString }
 
+-- TODO This needs a unit test.
 unbites :: Bites -> T2 TargetBytes HeaderBytes
 unbites = undefined
 

--- a/src/Chainweb/Miner/Core.hs
+++ b/src/Chainweb/Miner/Core.hs
@@ -1,4 +1,6 @@
 {-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
@@ -12,7 +14,8 @@
 -- Stability: experimental
 
 module Chainweb.Miner.Core
-  ( usePowHash
+  ( HeaderBytes(..)
+  , usePowHash
   , mine
   ) where
 
@@ -29,6 +32,8 @@ import Foreign.Marshal.Alloc (allocaBytes)
 import Foreign.Ptr (Ptr, castPtr)
 import Foreign.Storable (peekElemOff, poke)
 
+import Servant.API
+
 -- internal modules
 
 import Chainweb.BlockHeader
@@ -37,6 +42,11 @@ import Chainweb.Utils (int, runGet)
 import Chainweb.Version (ChainwebVersion(..))
 
 ---
+
+-- | The encoded form of a `BlockHeader`.
+--
+newtype HeaderBytes = HeaderBytes { _headerBytes :: B.ByteString }
+    deriving newtype (MimeRender OctetStream, MimeUnrender OctetStream)
 
 -- | Select a hashing algorithm.
 --

--- a/src/Chainweb/Miner/Miners.hs
+++ b/src/Chainweb/Miner/Miners.hs
@@ -116,13 +116,13 @@ toBytes bh = T2 t h
 type MiningAPI =
     "submit" :> Capture "chainid" ChainId
              :> Capture "blockheight" BlockHeight
-             :> ReqBody '[OctetStream] Bites
+             :> ReqBody '[OctetStream] WorkBytes
              :> Post '[JSON] ()
     :<|> "poll" :> Capture "chainid" ChainId
                 :> Capture "blockheight" BlockHeight
                 :> Get '[OctetStream] HeaderBytes
 
-submit :: ChainId -> BlockHeight -> Bites -> ClientM ()
+submit :: ChainId -> BlockHeight -> WorkBytes -> ClientM ()
 poll   :: ChainId -> BlockHeight -> ClientM HeaderBytes
 submit :<|> poll = client (Proxy :: Proxy MiningAPI)
 
@@ -137,8 +137,8 @@ remoteMining m urls bh = submission >> polling
   where
     T2 tbytes hbytes = toBytes bh
 
-    bs :: Bites
-    bs = bites tbytes hbytes
+    bs :: WorkBytes
+    bs = workBytes tbytes hbytes
 
     cid :: ChainId
     cid = _blockChainId bh

--- a/src/Chainweb/Miner/Miners.hs
+++ b/src/Chainweb/Miner/Miners.hs
@@ -28,6 +28,7 @@ module Chainweb.Miner.Miners
   ) where
 
 import Data.Bytes.Put (runPutS)
+import qualified Data.ByteString as B
 import Data.List.NonEmpty (NonEmpty)
 import qualified Data.List.NonEmpty as NEL
 import Data.Proxy (Proxy(..))
@@ -173,7 +174,8 @@ remoteMining m urls bh = submission >> polling
             -- This prevents scheduled retries from slamming the miners.
             threadDelay 100000
             runClientM (poll cid bht) (ClientEnv m url Nothing) >>= \case
-                Right new -> terminateWith sch new
+                -- NOTE The failure case for poll is an empty `ByteString`.
+                Right new | B.length (_headerBytes new) > 0 -> terminateWith sch new
                 -- While it looks as if the stale `hbytes` is being returned
                 -- here, this is only to satisfy type checking. The only
                 -- `HeaderBytes` value actually yielded from this entire

--- a/src/Chainweb/Miner/Miners.hs
+++ b/src/Chainweb/Miner/Miners.hs
@@ -171,8 +171,9 @@ remoteMining m urls bh = submission >> polling
             threadDelay 100000
             runClientM (poll cid bht) (ClientEnv m url Nothing) >>= \case
                 Right new -> terminateWith sch new
-                -- While it looks as if the stale `bh` is being returned here,
-                -- this is only to satisfy type checking. The only `BlockHeader`
-                -- value actually yielded from this entire operation is the
-                -- freshly mined one supplied by `terminateWith` above.
+                -- While it looks as if the stale `hbytes` is being returned
+                -- here, this is only to satisfy type checking. The only
+                -- `HeaderBytes` value actually yielded from this entire
+                -- operation is the freshly mined one supplied by
+                -- `terminateWith` above.
                 _ -> scheduleWork sch (go sch url) >> pure hbytes

--- a/src/Chainweb/Miner/Miners.hs
+++ b/src/Chainweb/Miner/Miners.hs
@@ -23,13 +23,11 @@ module Chainweb.Miner.Miners
     localPOW
   , localTest
     -- * Remote Mining
-  , HeaderBytes(..)
   , MiningAPI
   , remoteMining
   ) where
 
 import Data.Bytes.Put (runPutS)
-import Data.ByteString (ByteString)
 import Data.List.NonEmpty (NonEmpty)
 import qualified Data.List.NonEmpty as NEL
 import Data.Proxy (Proxy(..))
@@ -54,7 +52,7 @@ import qualified System.Random.MWC.Distributions as MWC
 import Chainweb.BlockHeader
 import Chainweb.Difficulty (BlockRate(..), blockRate)
 import Chainweb.Miner.Config (MinerCount(..))
-import Chainweb.Miner.Core (mine, usePowHash)
+import Chainweb.Miner.Core (HeaderBytes(..), mine, usePowHash)
 import Chainweb.RestAPI.Orphans ()
 #if !MIN_VERSION_servant_client(0,16,0)
 import Chainweb.RestAPI.Utils
@@ -94,11 +92,6 @@ localPOW v = usePowHash v mine
 
 -- -----------------------------------------------------------------------------
 -- Remote Mining
-
--- | The encoded form of a `BlockHeader`.
---
-newtype HeaderBytes = HeaderBytes { _headerBytes :: ByteString }
-    deriving newtype (MimeRender OctetStream, MimeUnrender OctetStream)
 
 -- | Shared between the `remoteMining` function here and the /chainweb-miner/
 -- executable.

--- a/src/Chainweb/Miner/Miners.hs
+++ b/src/Chainweb/Miner/Miners.hs
@@ -28,7 +28,6 @@ module Chainweb.Miner.Miners
   ) where
 
 import Data.Bytes.Put (runPutS)
-import Data.Coerce (coerce)
 import Data.List.NonEmpty (NonEmpty)
 import qualified Data.List.NonEmpty as NEL
 import Data.Proxy (Proxy(..))
@@ -140,8 +139,8 @@ remoteMining m urls bh = submission >> polling
     tbytes :: TargetBytes
     tbytes = TargetBytes . runPutS . encodeHashTarget $ _blockTarget bh
 
-    bites :: Bites
-    bites = Bites $ coerce tbytes <> coerce hbytes
+    bs :: Bites
+    bs = bites tbytes hbytes
 
     cid :: ChainId
     cid = _blockChainId bh
@@ -158,7 +157,7 @@ remoteMining m urls bh = submission >> polling
         these (throwM . NEL.head) (\_ -> pure ()) (\_ _ -> pure ()) rs
       where
         f :: BaseUrl -> IO (Either ClientError ())
-        f url = runClientM (submit cid bht bites) $ ClientEnv m url Nothing
+        f url = runClientM (submit cid bht bs) $ ClientEnv m url Nothing
 
     -- TODO Use different `Comp`?
     polling :: IO BlockHeader

--- a/test/Chainweb/Test/Miner/Core.hs
+++ b/test/Chainweb/Test/Miner/Core.hs
@@ -1,0 +1,46 @@
+-- |
+-- Module: Chainweb.Test.Miner.Core
+-- Copyright: Copyright © 2019 Kadena LLC.
+-- License: MIT
+-- Maintainer: Colin Woodbury <colin@kadena.io>
+-- Stability: experimental
+--
+-- TODO
+--
+module Chainweb.Test.Miner.Core
+  ( tests
+  ) where
+
+import Data.Bytes.Put (runPutS)
+import Data.Tuple.Strict (T2(..))
+
+import Test.Tasty
+import Test.Tasty.HUnit
+
+-- internal modules
+
+import Chainweb.BlockHeader (BlockHeader(..), encodeBlockHeaderWithoutHash)
+import Chainweb.BlockHeader.Genesis (genesisBlockHeader)
+import Chainweb.Difficulty (encodeHashTarget)
+import Chainweb.Graph (petersonChainGraph)
+import Chainweb.Miner.Core
+import Chainweb.Version (ChainwebVersion(..), someChainId)
+
+---
+
+tests :: TestTree
+tests = testGroup "Core Mining Logic"
+    [ testCase "bites/unbites Isomorphism" bitesIso
+    ]
+
+bitesIso :: Assertion
+bitesIso = unbites (bites tbytes hbytes) @?= T2 tbytes hbytes
+  where
+    v :: ChainwebVersion
+    v = Test petersonChainGraph
+
+    bh :: BlockHeader
+    bh = genesisBlockHeader v $ someChainId v
+
+    hbytes = HeaderBytes . runPutS $ encodeBlockHeaderWithoutHash bh
+    tbytes = TargetBytes . runPutS . encodeHashTarget $ _blockTarget bh

--- a/test/Chainweb/Test/Miner/Core.hs
+++ b/test/Chainweb/Test/Miner/Core.hs
@@ -30,11 +30,11 @@ import Chainweb.Version (ChainwebVersion(..), someChainId)
 
 tests :: TestTree
 tests = testGroup "Core Mining Logic"
-    [ testCase "bites/unbites Isomorphism" bitesIso
+    [ testCase "workBytes/unWorkBytes Isomorphism" workBytesIso
     ]
 
-bitesIso :: Assertion
-bitesIso = unbites (bites tbytes hbytes) @?= T2 tbytes hbytes
+workBytesIso :: Assertion
+workBytesIso = unWorkBytes (workBytes tbytes hbytes) @?= T2 tbytes hbytes
   where
     v :: ChainwebVersion
     v = Test petersonChainGraph

--- a/test/Chainweb/Test/Miner/Core.hs
+++ b/test/Chainweb/Test/Miner/Core.hs
@@ -11,7 +11,6 @@ module Chainweb.Test.Miner.Core
   ( tests
   ) where
 
-import Data.Bytes.Put (runPutS)
 import Data.Tuple.Strict (T2(..))
 
 import Test.Tasty
@@ -19,11 +18,11 @@ import Test.Tasty.HUnit
 
 -- internal modules
 
-import Chainweb.BlockHeader (BlockHeader(..), encodeBlockHeaderWithoutHash)
+import Chainweb.BlockHeader (BlockHeader(..))
 import Chainweb.BlockHeader.Genesis (genesisBlockHeader)
-import Chainweb.Difficulty (encodeHashTarget)
 import Chainweb.Graph (petersonChainGraph)
 import Chainweb.Miner.Core
+import Chainweb.Miner.Miners (transferableBytes)
 import Chainweb.Version (ChainwebVersion(..), someChainId)
 
 ---
@@ -42,5 +41,4 @@ workBytesIso = unWorkBytes (workBytes tbytes hbytes) @?= T2 tbytes hbytes
     bh :: BlockHeader
     bh = genesisBlockHeader v $ someChainId v
 
-    hbytes = HeaderBytes . runPutS $ encodeBlockHeaderWithoutHash bh
-    tbytes = TargetBytes . runPutS . encodeHashTarget $ _blockTarget bh
+    T2 tbytes hbytes = transferableBytes bh

--- a/test/ChainwebTests.hs
+++ b/test/ChainwebTests.hs
@@ -30,6 +30,7 @@ import qualified Chainweb.Test.Mempool.Consensus
 import qualified Chainweb.Test.Mempool.InMem
 import qualified Chainweb.Test.Mempool.RestAPI
 import qualified Chainweb.Test.Mempool.Sync
+import qualified Chainweb.Test.Miner.Core
 import qualified Chainweb.Test.Misc
 import qualified Chainweb.Test.Pact.Checkpointer
 import qualified Chainweb.Test.Pact.PactExec
@@ -102,6 +103,7 @@ suite rdb =
         , Chainweb.Test.Mempool.InMem.tests
         , Chainweb.Test.Mempool.Sync.tests
         , Chainweb.Test.Mempool.RestAPI.tests
+        , Chainweb.Test.Miner.Core.tests
         , Chainweb.Test.Misc.tests
         , Chainweb.Test.BlockHeader.Genesis.tests
         , testProperties "Chainweb.BlockHeaderDb.RestAPI.Server" Chainweb.Utils.Paging.properties


### PR DESCRIPTION
This PR alters the `MiningAPI` type to expect pre-encoded versions of every argument. This way, our Mining Client (or any such 3rd-party client) needs to know *very* little about how our types are constructed. This should make it even easier to write new clients.

As evidence, the `Chainweb.Miner.Core` module (which powers both our in-process POW mining and our remote POW mining) now has but a single Chainweb import: the `Version` module.