### PR TITLE
New Chainweb Version - FastTimedCPM

### DIFF
--- a/src/Chainweb/BlockHeader/Genesis.hs
+++ b/src/Chainweb/BlockHeader/Genesis.hs
@@ -83,6 +83,7 @@ genesisTime Test{} = BlockCreationTime epoch
 genesisTime TimedConsensus{} = BlockCreationTime epoch
 genesisTime PowConsensus{} = BlockCreationTime epoch
 genesisTime TimedCPM{} = BlockCreationTime epoch
+genesisTime FastTimedCPM{} = BlockCreationTime epoch
 -- Thursday, 2019 July 17, 11:28 AM
 genesisTime Development = BlockCreationTime . Time $ TimeSpan 1563388117613832
 -- Tuesday, 2019 February 26, 10:55 AM
@@ -96,6 +97,7 @@ genesisMiner Test{} p = ChainNodeId (_chainId p) 0
 genesisMiner TimedConsensus{} p = ChainNodeId (_chainId p) 0
 genesisMiner PowConsensus{} p = ChainNodeId (_chainId p) 0
 genesisMiner TimedCPM{} p = ChainNodeId (_chainId p) 0
+genesisMiner FastTimedCPM{} p = ChainNodeId (_chainId p) 0
 -- Development Instances
 genesisMiner Development p = ChainNodeId (_chainId p) 0
 -- Production Instances
@@ -114,6 +116,7 @@ genesisBlockPayload Test{} _ = emptyPayload
 genesisBlockPayload TimedConsensus{} _ = emptyPayload
 genesisBlockPayload PowConsensus{} _ = emptyPayload
 genesisBlockPayload TimedCPM{} _ = TN.payloadBlock
+genesisBlockPayload FastTimedCPM{} _ = TN.payloadBlock
 -- Development Instances
 genesisBlockPayload Development _ = DN.payloadBlock
 -- Production Instances

--- a/src/Chainweb/Chainweb.hs
+++ b/src/Chainweb/Chainweb.hs
@@ -573,6 +573,7 @@ runChainweb cw = do
         TimedConsensus{} -> disabled
         PowConsensus{} -> disabled
         TimedCPM{} -> enabled c
+        FastTimedCPM{} -> enabled c
         Development -> enabled c
         Testnet02 -> enabled c
       where

--- a/src/Chainweb/Chainweb/ChainResources.hs
+++ b/src/Chainweb/Chainweb/ChainResources.hs
@@ -170,6 +170,7 @@ withChainResources v cid rdb peer logger mempoolCfg cdbv payloadDb prune dbDir n
         TimedConsensus{} -> emptyPactExecutionService
         PowConsensus{} -> emptyPactExecutionService
         TimedCPM{} -> mkPactExecutionService requestQ
+        FastTimedCPM{} -> mkPactExecutionService requestQ
         Development -> mkPactExecutionService requestQ
         Testnet02 -> mkPactExecutionService requestQ
 

--- a/src/Chainweb/Difficulty.hs
+++ b/src/Chainweb/Difficulty.hs
@@ -324,8 +324,8 @@ blockRate Test{} = Nothing
 blockRate TimedConsensus{} = Just $ BlockRate 4
 blockRate PowConsensus{} = Just $ BlockRate 10
 blockRate TimedCPM{} = Just $ BlockRate 4
-blockRate FastTimedCPM{} = Just $ BlockRate 1
 -- 120 blocks per hour, 2,880 per day, 20,160 per week, 1,048,320 per year.
+blockRate FastTimedCPM{} = Just $ BlockRate 1
 blockRate Development = Just $ BlockRate 30
 -- 120 blocks per hour, 2,880 per day, 20,160 per week, 1,048,320 per year.
 blockRate Testnet02 = Just $ BlockRate 30

--- a/src/Chainweb/Difficulty.hs
+++ b/src/Chainweb/Difficulty.hs
@@ -324,6 +324,7 @@ blockRate Test{} = Nothing
 blockRate TimedConsensus{} = Just $ BlockRate 4
 blockRate PowConsensus{} = Just $ BlockRate 10
 blockRate TimedCPM{} = Just $ BlockRate 4
+blockRate FastTimedCPM{} = Just $ BlockRate 1
 -- 120 blocks per hour, 2,880 per day, 20,160 per week, 1,048,320 per year.
 blockRate Development = Just $ BlockRate 30
 -- 120 blocks per hour, 2,880 per day, 20,160 per week, 1,048,320 per year.
@@ -344,6 +345,7 @@ window TimedConsensus{} = Nothing
 -- 5 blocks, should take 50 seconds.
 window PowConsensus{} = Just $ WindowWidth 8
 window TimedCPM{} = Nothing
+window FastTimedCPM{} = Nothing
 -- 120 blocks, should take 1 hour given a 30 second BlockRate.
 window Development = Just $ WindowWidth 120
 -- 120 blocks, should take 1 hour given a 30 second BlockRate.
@@ -363,6 +365,7 @@ minAdjust Test{} = Nothing
 minAdjust TimedConsensus{} = Nothing
 minAdjust PowConsensus{} = Just $ MinAdjustment 3
 minAdjust TimedCPM{} = Nothing
+minAdjust FastTimedCPM{} = Nothing
 -- See `adjust` for motivation.
 minAdjust Development = Just $ MinAdjustment 3
 minAdjust Testnet02 = Just $ MinAdjustment 3

--- a/src/Chainweb/Miner/Core.hs
+++ b/src/Chainweb/Miner/Core.hs
@@ -80,6 +80,7 @@ usePowHash Test{} f = f $ Proxy @SHA512t_256
 usePowHash TimedConsensus{} f = f $ Proxy @SHA512t_256
 usePowHash PowConsensus{} f = f $ Proxy @SHA512t_256
 usePowHash TimedCPM{} f = f $ Proxy @SHA512t_256
+usePowHash FastTimedCPM{} f = f $ Proxy @SHA512t_256
 usePowHash Development f = f $ Proxy @SHA512t_256
 usePowHash Testnet02 f = f $ Proxy @SHA512t_256
 

--- a/src/Chainweb/Pact/PactService.hs
+++ b/src/Chainweb/Pact/PactService.hs
@@ -213,6 +213,7 @@ initialPayloadState Test{} _ = pure ()
 initialPayloadState TimedConsensus{} _ = pure ()
 initialPayloadState PowConsensus{} _ = pure ()
 initialPayloadState v@TimedCPM{} cid = initializeCoinContract v cid TN.payloadBlock
+initialPayloadState v@FastTimedCPM{} cid = initializeCoinContract v cid TN.payloadBlock
 initialPayloadState v@Development cid = initializeCoinContract v cid DN.payloadBlock
 initialPayloadState v@Testnet02 cid = initializeCoinContract v cid TN.payloadBlock
 

--- a/src/Chainweb/PowHash.hs
+++ b/src/Chainweb/PowHash.hs
@@ -140,6 +140,7 @@ powHash Test{} = cryptoHash @SHA512t_256
 powHash TimedConsensus{} = cryptoHash @SHA512t_256
 powHash PowConsensus{} = cryptoHash @SHA512t_256
 powHash TimedCPM{} = cryptoHash @SHA512t_256
+powHash FastTimedCPM{} = cryptoHash @SHA512t_256
 powHash Development = cryptoHash @SHA512t_256
 powHash Testnet02 = cryptoHash @SHA512t_256
 

--- a/src/Chainweb/Version.hs
+++ b/src/Chainweb/Version.hs
@@ -183,6 +183,21 @@ data ChainwebVersion
         -- This is primarily used in our @run-nodes@ executable.
         --
 
+    | FastTimedCPM ChainGraph
+        -- ^ Test instance for confirming the combined behaviour of our Consensus
+        -- mechanisms, Pact code processing and validation, and Mempool, where:
+        --
+        -- * the underlying `ChainGraph` is configurable,
+        -- * the genesis block time is the Linux epoch,
+        -- * each `HashTarget` is maxBound,
+        -- * each mining `Nonce` is constant,
+        -- * the creationTime of `BlockHeader`'s is the actual time,
+        -- * POW is not simulated by poison process thread delay, and
+        -- * the Pact Service and Mempool operations are running.
+        --
+        -- This is primarily used in our @standalone@ executable.
+        --
+
     ------------------------
     -- DEVELOPMENT INSTANCES
     ------------------------
@@ -219,6 +234,7 @@ chainwebVersionId v@Test{} = toTestChainwebVersion v
 chainwebVersionId v@TimedConsensus{} = toTestChainwebVersion v
 chainwebVersionId v@PowConsensus{} = toTestChainwebVersion v
 chainwebVersionId v@TimedCPM{} = toTestChainwebVersion v
+chainwebVersionId v@FastTimedCPM{} = toTestChainwebVersion v
 chainwebVersionId Development = 0x00000001
 chainwebVersionId Testnet02 = 0x00000004
 {-# INLINABLE chainwebVersionId #-}
@@ -291,6 +307,7 @@ miningProtocol :: ChainwebVersion -> MiningProtocol
 miningProtocol Test{} = Timed
 miningProtocol TimedConsensus{} = Timed
 miningProtocol TimedCPM{} = Timed
+miningProtocol FastTimedCPM{} = Timed
 miningProtocol PowConsensus{} = ProofOfWork
 miningProtocol Development = ProofOfWork
 miningProtocol Testnet02 = ProofOfWork
@@ -306,6 +323,7 @@ chainwebVersions = HM.fromList $
     <> f TimedConsensus "timedConsensus"
     <> f PowConsensus "powConsensus"
     <> f TimedCPM "timedCPM"
+    <> f FastTimedCPM "fastTimedCPM"
     <> [ ("development", Development)
        , ("testnet02", Testnet02)
        ]
@@ -365,6 +383,7 @@ codeToTestVersion 0x80000000 = Test
 codeToTestVersion 0x80000001 = TimedConsensus
 codeToTestVersion 0x80000002 = PowConsensus
 codeToTestVersion 0x80000003 = TimedCPM
+codeToTestVersion 0x80000004 = FastTimedCPM
 codeToTestVersion _ = error "Unknown ChainwebVersion Code"
 
 testVersionToCode :: ChainwebVersion -> Word32
@@ -372,6 +391,7 @@ testVersionToCode Test{} = 0x80000000
 testVersionToCode TimedConsensus{} = 0x80000001
 testVersionToCode PowConsensus{} = 0x80000002
 testVersionToCode TimedCPM{} = 0x80000003
+testVersionToCode FastTimedCPM{} = 0x80000004
 testVersionToCode Development =
     error "Illegal ChainwebVersion passed to toTestChainwebVersion"
 testVersionToCode Testnet02 =
@@ -389,6 +409,7 @@ chainwebVersionGraph (Test g) = g
 chainwebVersionGraph (TimedConsensus g) = g
 chainwebVersionGraph (PowConsensus g) = g
 chainwebVersionGraph (TimedCPM g) = g
+chainwebVersionGraph (FastTimedCPM g) = g
 chainwebVersionGraph Development = petersonChainGraph
 chainwebVersionGraph Testnet02 = petersonChainGraph
 

--- a/src/P2P/Peer.hs
+++ b/src/P2P/Peer.hs
@@ -451,6 +451,7 @@ bootstrapPeerInfos Test{} = [testBootstrapPeerInfos]
 bootstrapPeerInfos TimedConsensus{} = [testBootstrapPeerInfos]
 bootstrapPeerInfos PowConsensus{} = [testBootstrapPeerInfos]
 bootstrapPeerInfos TimedCPM{} = [testBootstrapPeerInfos]
+bootstrapPeerInfos FastTimedCPM{} = [testBootstrapPeerInfos]
 bootstrapPeerInfos Development = productionBootstrapPeerInfo
 bootstrapPeerInfos Testnet02 = productionBootstrapPeerInfo
 

--- a/test/Chainweb/Test/Orphans/Internal.hs
+++ b/test/Chainweb/Test/Orphans/Internal.hs
@@ -62,6 +62,8 @@ instance Arbitrary ChainwebVersion where
         , PowConsensus petersonChainGraph
         , TimedCPM singletonChainGraph
         , TimedCPM petersonChainGraph
+        , FastTimedCPM singletonChainGraph
+        , FastTimedCPM petersonChainGraph
         , Development
         , Testnet02
         ]

--- a/test/Chainweb/Test/P2P/Peer/BootstrapConfig.hs
+++ b/test/Chainweb/Test/P2P/Peer/BootstrapConfig.hs
@@ -38,6 +38,7 @@ bootstrapPeerConfig v@Test{} = testBootstrapPeerConfig v
 bootstrapPeerConfig v@TimedConsensus{} = testBootstrapPeerConfig v
 bootstrapPeerConfig v@PowConsensus{} = testBootstrapPeerConfig v
 bootstrapPeerConfig v@TimedCPM{} = testBootstrapPeerConfig v
+bootstrapPeerConfig v@FastTimedCPM{} = testBootstrapPeerConfig v
 bootstrapPeerConfig Development = error
     $ "bootstrap peer config isn't defined for chainweb version Development"
 bootstrapPeerConfig Testnet02 = error
@@ -67,6 +68,7 @@ bootstrapCertificate Test{} = testBootstrapCertificate
 bootstrapCertificate TimedConsensus{} = testBootstrapCertificate
 bootstrapCertificate PowConsensus{} = testBootstrapCertificate
 bootstrapCertificate TimedCPM{} = testBootstrapCertificate
+bootstrapCertificate FastTimedCPM{} = testBootstrapCertificate
 bootstrapCertificate Development = error
     $ "bootstrap certificate isn't defined for chainweb version Development"
 bootstrapCertificate Testnet02 = error
@@ -126,6 +128,7 @@ bootstrapKey Test{} = testBootstrapKey
 bootstrapKey TimedConsensus{} = testBootstrapKey
 bootstrapKey PowConsensus{} = testBootstrapKey
 bootstrapKey TimedCPM{} = testBootstrapKey
+bootstrapKey FastTimedCPM{} = testBootstrapKey
 bootstrapKey Development = error
     $ "bootstrap key isn't defined for chainweb version Development"
 bootstrapKey Testnet02 = error


### PR DESCRIPTION
This chainweb version is for use primarily with the upcoming
standalone executable.