### PR TITLE
Pact 3.3.0 Version Bump

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -11,7 +11,8 @@ debug-info: True
 source-repository-package
     type: git
     location: https://github.com/kadena-io/pact.git
-    tag: 31801b112f46f08bb4ca3c488dd947573f21043f
+    tag: 2730879a233137778646e67ca3346e7267c5f82f
+
 source-repository-package
     type: git
     location: https://github.com/kadena-io/thyme.git
@@ -26,4 +27,3 @@ constraints:
       swagger2 < 2.4
     , these < 1
     , base-unicode-symbols < 0.2.4
-

--- a/default.nix
+++ b/default.nix
@@ -185,8 +185,8 @@ in
         pact = dontCheck ( addBuildDepend (self.callCabal2nix "pact" (pkgs.fetchFromGitHub {
           owner = "kadena-io";
           repo = "pact";
-          rev = "31801b112f46f08bb4ca3c488dd947573f21043f";
-          sha256 = "05ixk4v87xxm45sjl400gqrlm4f83q4rbbfmvj23pkdyca06qfzn";
+          rev = "2730879a233137778646e67ca3346e7267c5f82f";
+          sha256 = "1akgrmf4yfdsxmpj45kva99d29pr1vgx83dyxn14l3kcrspzpqnn";
           }) {}) pkgs.z3);
 
         streaming = callHackageDirect {

--- a/stack.yaml
+++ b/stack.yaml
@@ -44,7 +44,7 @@ extra-deps:
 
   # --- Custom Pins --- #
   - github: kadena-io/pact
-    commit: 31801b112f46f08bb4ca3c488dd947573f21043f
+    commit: 2730879a233137778646e67ca3346e7267c5f82f
   - github: kadena-io/thyme
     commit: 6ee9fcb026ebdb49b810802a981d166680d867c9
   - github: kadena-io/chainweb-storage


### PR DESCRIPTION
This version of Pact gets us the following: 

- Fixes for duplicate name bugs (unique names now enforced across modules)
- Fixes for typecheck bugs when typechecking interfaces
- Adds an import system to Pact so that you can explicitly import Function, Constant, and Schema names.