### PR TITLE
Make pact /poll endpoint use the pactdb tx index.

### DIFF
--- a/chainweb.cabal
+++ b/chainweb.cabal
@@ -357,7 +357,6 @@ library
         , wai-middleware-throttle >= 0.3
         , warp >= 3.2
         , warp-tls >= 3.2.7
-        , witherable >= 0.2
         , x509 >=1.7
         , x509-system >=1.6
         , x509-validation >=1.6

--- a/src/Chainweb/Pact/Backend/InMemoryCheckpointer.hs
+++ b/src/Chainweb/Pact/Backend/InMemoryCheckpointer.hs
@@ -21,6 +21,7 @@ import qualified Data.HashMap.Strict as HMS
 import Data.HashSet (HashSet)
 import qualified Data.HashSet as HashSet
 import Data.Text (pack)
+import Data.Tuple.Strict
 
 import Pact.Interpreter
 import Pact.Persist.Pure
@@ -147,9 +148,11 @@ doRegisterSuccessful lock hash =
         let out = (pset', mp)
         return $! out
 
-doLookupSuccessful :: MVar Store -> PactHash -> IO (Maybe (BlockHeight, BlockHash))
+doLookupSuccessful :: MVar Store -> PactHash -> IO (Maybe (T2 BlockHeight BlockHash))
 doLookupSuccessful lock hash =
     withMVar lock $
     \(Store _ _ _ played) -> do
         (_, mp) <- readMVar played
-        return $! HMS.lookup hash mp
+        return $! fmap toS $! HMS.lookup hash mp
+  where
+    toS (a,b) = T2 a b

--- a/src/Chainweb/Pact/Backend/RelationalCheckpointer.hs
+++ b/src/Chainweb/Pact/Backend/RelationalCheckpointer.hs
@@ -28,6 +28,7 @@ import qualified Data.HashMap.Strict as HashMap
 import qualified Data.List as List
 import Data.Serialize hiding (get)
 import qualified Data.Text as T
+import Data.Tuple.Strict
 import qualified Data.Vector as V
 import qualified Data.Vector.Algorithms.Tim as TimSort
 
@@ -236,7 +237,7 @@ doRegisterSuccessful dbenv (TypedHash hash) =
     runBlockEnv dbenv (indexPactTransaction hash)
 
 
-doLookupSuccessful :: Db -> PactHash -> IO (Maybe (BlockHeight, BlockHash))
+doLookupSuccessful :: Db -> PactHash -> IO (Maybe (T2 BlockHeight BlockHash))
 doLookupSuccessful dbenv (TypedHash hash) = runBlockEnv dbenv $ do
     r <- callDb "doLookupSuccessful" $ \db ->
          qry db qtext [ SBlob hash ] [RInt, RBlob] >>= mapM go
@@ -249,5 +250,5 @@ doLookupSuccessful dbenv (TypedHash hash) = runBlockEnv dbenv $ do
             \USING (blockheight) WHERE txhash = ?;"
     go [SInt h, SBlob blob] = do
         !hsh <- either fail return $ Data.Serialize.decode blob
-        return $! (fromIntegral h, hsh)
+        return $! T2 (fromIntegral h) hsh
     go _ = fail "impossible"

--- a/src/Chainweb/Pact/Backend/Types.hs
+++ b/src/Chainweb/Pact/Backend/Types.hs
@@ -104,6 +104,7 @@ import Data.Hashable (Hashable)
 import Data.HashMap.Strict (HashMap)
 import Data.HashSet (HashSet)
 import Data.Map.Strict (Map)
+import Data.Tuple.Strict
 import Data.Vector (Vector)
 
 import Database.SQLite3.Direct as SQ3
@@ -293,7 +294,7 @@ data Checkpointer = Checkpointer
     , _cpRegisterProcessedTx :: !(P.PactHash -> IO ())
 
       -- TODO: this would be nicer as a batch lookup :(
-    , _cpLookupProcessedTx :: !(P.PactHash -> IO (Maybe (BlockHeight, BlockHash)))
+    , _cpLookupProcessedTx :: !(P.PactHash -> IO (Maybe (T2 BlockHeight BlockHash)))
     }
 
 data CheckpointEnv = CheckpointEnv

--- a/src/Chainweb/Pact/PactService.hs
+++ b/src/Chainweb/Pact/PactService.hs
@@ -278,8 +278,8 @@ serviceRequests memPoolAccess reqQ = do
                         _valResultVar
                         (return . flip validateHashes _valBlockHeader)
                         (execValidateBlock _valBlockHeader _valPayloadData)
-            LookupRequestsMsg (LookupRequestsReq _restorePoint _txHashes _resultVar) -> do
-                tryOne "execLookupRequests" _resultVar $ fail "TODO: unimplemented"
+            LookupPactTxsMsg (LookupPactTxsReq _restorePoint _txHashes _resultVar) -> do
+                tryOne "execLookupPactTxs" _resultVar $ fail "TODO: unimplemented"
     toPactInternalError e = Left $ PactInternalError $ T.pack $ show e
 
 

--- a/src/Chainweb/Pact/PactService.hs
+++ b/src/Chainweb/Pact/PactService.hs
@@ -833,7 +833,6 @@ execLookupPactTxs
     -> Vector P.PactHash
     -> PactServiceM cas (Vector (Maybe (T2 BlockHeight BlockHash)))
 execLookupPactTxs (T2 leafHeight leafHash) txs =
-    withDiscardedBatch $
     withCheckpointerRewind (Just (leafHeight + 1, leafHash))
                            "lookupPactTxs" $ \_pdbenv -> do
         cp <- getCheckpointer

--- a/src/Chainweb/Pact/RestAPI/Server.hs
+++ b/src/Chainweb/Pact/RestAPI/Server.hs
@@ -23,7 +23,7 @@ module Chainweb.Pact.RestAPI.Server
 import Control.Applicative
 import Control.Concurrent.STM (atomically, retry)
 import Control.Concurrent.STM.TVar
-import Control.Lens ((^.))
+import Control.Lens ((^.), view)
 import Control.Monad (when)
 import Control.Monad.Catch hiding (Handler)
 import Control.Monad.Reader
@@ -237,9 +237,12 @@ internalPoll
     -> Cut
     -> NonEmpty RequestKey
     -> IO (HashMap RequestKey (CommandResult Hash))
-internalPoll cutR cid chain cut requestKeys =
-    HM.fromList <$> wither lookup (NEL.toList requestKeys)
+internalPoll cutR cid chain cut requestKeys0 =
+    HM.fromList <$> wither lookup requestKeys
   where
+    _pactEx = view chainResPact chain
+    requestKeys = NEL.toList requestKeys0
+
     lookup :: RequestKey -> IO (Maybe (RequestKey, CommandResult Hash))
     lookup key = fmap (key,) <$> lookupRequestKey cid cut cutR chain key
 

--- a/src/Chainweb/Pact/Service/BlockValidation.hs
+++ b/src/Chainweb/Pact/Service/BlockValidation.hs
@@ -16,12 +16,17 @@ module Chainweb.Pact.Service.BlockValidation
 ( validateBlock
 , newBlock
 , local
+, lookupPactTxs
 ) where
 
 
 import Control.Concurrent.MVar.Strict
 import Control.Concurrent.STM.TQueue
+import Data.Tuple.Strict
+import Data.Vector (Vector)
+import qualified Pact.Types.Hash as P
 
+import Chainweb.BlockHash
 import Chainweb.BlockHeader
 import Chainweb.Miner.Pact
 import Chainweb.Pact.Service.PactQueue
@@ -62,5 +67,18 @@ local ct reqQ = do
     let !msg = LocalMsg LocalReq
           { _localRequest = ct
           , _localResultVar = resultVar }
+    addRequest reqQ msg
+    return resultVar
+
+lookupPactTxs
+    :: T2 BlockHeight BlockHash
+    -> Vector P.PactHash
+    -> TQueue RequestMsg
+    -> IO (MVar (Either PactException
+                     (Vector (Maybe (T2 BlockHeight BlockHash)))))
+lookupPactTxs restorePoint txs reqQ = do
+    resultVar <- newEmptyMVar
+    let !req = LookupPactTxsReq restorePoint txs resultVar
+    let !msg = LookupPactTxsMsg req
     addRequest reqQ msg
     return resultVar

--- a/src/Chainweb/Pact/Service/Types.hs
+++ b/src/Chainweb/Pact/Service/Types.hs
@@ -48,7 +48,7 @@ internalError' = internalError . pack
 data RequestMsg = NewBlockMsg NewBlockReq
                 | ValidateBlockMsg ValidateBlockReq
                 | LocalMsg LocalReq
-                | LookupRequestsMsg LookupRequestsReq
+                | LookupPactTxsMsg LookupPactTxsReq
                 | CloseMsg
                 deriving (Show)
 
@@ -74,11 +74,11 @@ data LocalReq = LocalReq
     }
 instance Show LocalReq where show LocalReq{..} = show (_localRequest)
 
-data LookupRequestsReq = LookupRequestsReq
+data LookupPactTxsReq = LookupPactTxsReq
     { _lookupRestorePoint :: !(T2 BlockHeight BlockHash)
     , _lookupKeys :: !(Vector P.PactHash)
     , _lookupResultVar :: !(PactExMVar (Vector (Maybe (T2 BlockHeight BlockHash))))
     }
-instance Show LookupRequestsReq where
-    show (LookupRequestsReq (T2 he ha) _ _) =
-        "LookupRequestsReq@" ++ show he ++ ":" ++ show ha
+instance Show LookupPactTxsReq where
+    show (LookupPactTxsReq (T2 he ha) _ _) =
+        "LookupPactTxsReq@" ++ show he ++ ":" ++ show ha

--- a/src/Chainweb/WebPactExecutionService.hs
+++ b/src/Chainweb/WebPactExecutionService.hs
@@ -15,8 +15,10 @@ import Control.Concurrent.STM.TQueue
 import Control.Exception (evaluate)
 import Control.Monad.Catch
 import qualified Data.HashMap.Strict as HM
+import Data.Tuple.Strict
 import qualified Data.Vector as V
 
+import Chainweb.BlockHash
 import Chainweb.BlockHeader
 import Chainweb.ChainId
 import Chainweb.Miner.Pact
@@ -26,24 +28,37 @@ import Chainweb.Pact.Types
 import Chainweb.Payload
 import Chainweb.WebPactExecutionService.Types
 
-_webPactNewBlock :: WebPactExecutionService -> Miner -> BlockHeader -> IO PayloadWithOutputs
+_webPactNewBlock
+    :: WebPactExecutionService
+    -> Miner
+    -> BlockHeader
+    -> IO PayloadWithOutputs
 _webPactNewBlock = _pactNewBlock . _webPactExecutionService
 {-# INLINE _webPactNewBlock #-}
 
-_webPactValidateBlock :: WebPactExecutionService -> BlockHeader -> PayloadData -> IO PayloadWithOutputs
+_webPactValidateBlock
+    :: WebPactExecutionService
+    -> BlockHeader
+    -> PayloadData
+    -> IO PayloadWithOutputs
 _webPactValidateBlock = _pactValidateBlock . _webPactExecutionService
 {-# INLINE _webPactValidateBlock #-}
 
-mkWebPactExecutionService :: HM.HashMap ChainId PactExecutionService -> WebPactExecutionService
+mkWebPactExecutionService
+    :: HM.HashMap ChainId PactExecutionService
+    -> WebPactExecutionService
 mkWebPactExecutionService hm = WebPactExecutionService $ PactExecutionService
   { _pactValidateBlock = \h pd -> withChainService h $ \p -> _pactValidateBlock p h pd
   , _pactNewBlock = \m h -> withChainService h $ \p -> _pactNewBlock p m h
   , _pactLocal = \_ct -> throwM $ userError "No web-level local execution supported"
-  , _pactLookup = error "TODO"
+  , _pactLookup = \h txs -> withChainService h $ \p -> _pactLookup p h txs
   }
-  where withChainService h act = case HM.lookup (_chainId h) hm of
-          Just p -> act p
-          Nothing -> throwM (userError $ "PactExecutionService: Invalid chain ID in header: " ++ show h)
+  where
+    withChainService h act = case HM.lookup (_chainId h) hm of
+        Just p -> act p
+        Nothing ->
+            let msg = "PactExecutionService: Invalid chain ID in header: " ++ show h
+            in throwM $ userError msg
 
 mkPactExecutionService
     :: TQueue RequestMsg
@@ -62,8 +77,16 @@ mkPactExecutionService q = PactExecutionService
   , _pactLocal = \ct -> do
       mv <- local ct q
       takeMVar mv
-  , _pactLookup = error "TODO"
+  , _pactLookup = \h txs -> do
+      mv <- lookupPactTxs (blockHeaderToRestorePoint h) txs q
+      takeMVar mv
   }
+
+blockHeaderToRestorePoint :: BlockHeader -> T2 BlockHeight BlockHash
+blockHeaderToRestorePoint bh = T2 height hash
+  where
+    !height = _blockHeight bh
+    !hash = _blockHash bh
 
 -- | A mock execution service for testing scenarios. Throws out anything it's
 -- given.

--- a/src/Chainweb/WebPactExecutionService.hs
+++ b/src/Chainweb/WebPactExecutionService.hs
@@ -15,6 +15,7 @@ import Control.Concurrent.STM.TQueue
 import Control.Exception (evaluate)
 import Control.Monad.Catch
 import qualified Data.HashMap.Strict as HM
+import qualified Data.Vector as V
 
 import Chainweb.BlockHeader
 import Chainweb.ChainId
@@ -38,6 +39,7 @@ mkWebPactExecutionService hm = WebPactExecutionService $ PactExecutionService
   { _pactValidateBlock = \h pd -> withChainService h $ \p -> _pactValidateBlock p h pd
   , _pactNewBlock = \m h -> withChainService h $ \p -> _pactNewBlock p m h
   , _pactLocal = \_ct -> throwM $ userError "No web-level local execution supported"
+  , _pactLookup = error "TODO"
   }
   where withChainService h act = case HM.lookup (_chainId h) hm of
           Just p -> act p
@@ -60,6 +62,7 @@ mkPactExecutionService q = PactExecutionService
   , _pactLocal = \ct -> do
       mv <- local ct q
       takeMVar mv
+  , _pactLookup = error "TODO"
   }
 
 -- | A mock execution service for testing scenarios. Throws out anything it's
@@ -70,4 +73,5 @@ emptyPactExecutionService = PactExecutionService
     { _pactValidateBlock = \_ _ -> pure emptyPayload
     , _pactNewBlock = \_ _ -> pure emptyPayload
     , _pactLocal = \_ -> throwM (userError $ "emptyPactExecutionService: attempted `local` call")
+    , _pactLookup = \_ v -> return $! Right $! V.map (const Nothing) v
     }

--- a/src/Chainweb/WebPactExecutionService/Types.hs
+++ b/src/Chainweb/WebPactExecutionService/Types.hs
@@ -22,8 +22,8 @@ data PactExecutionService = PactExecutionService
   , _pactNewBlock :: Miner -> BlockHeader -> IO PayloadWithOutputs
   , _pactLocal :: ChainwebTransaction -> IO (Either PactException HashCommandResult)
   , _pactLookup
-        :: T2 BlockHeight BlockHash    -- restore point
-        -> Vector P.PactHash           -- txs to lookup
+        :: BlockHeader          -- restore point
+        -> Vector P.PactHash    -- txs to lookup
         -> IO (Either PactException (Vector (Maybe (T2 BlockHeight BlockHash))))
   }
 

--- a/src/Chainweb/WebPactExecutionService/Types.hs
+++ b/src/Chainweb/WebPactExecutionService/Types.hs
@@ -5,6 +5,11 @@ module Chainweb.WebPactExecutionService.Types
   , PactExecutionService(..)
   ) where
 
+import Data.Tuple.Strict
+import Data.Vector (Vector)
+import qualified Pact.Types.Hash as P
+
+import Chainweb.BlockHash
 import Chainweb.BlockHeader
 import Chainweb.Miner.Pact
 import Chainweb.Pact.Service.Types
@@ -16,6 +21,10 @@ data PactExecutionService = PactExecutionService
   { _pactValidateBlock :: BlockHeader -> PayloadData -> IO PayloadWithOutputs
   , _pactNewBlock :: Miner -> BlockHeader -> IO PayloadWithOutputs
   , _pactLocal :: ChainwebTransaction -> IO (Either PactException HashCommandResult)
+  , _pactLookup
+        :: T2 BlockHeight BlockHash    -- restore point
+        -> Vector P.PactHash           -- txs to lookup
+        -> IO (Either PactException (Vector (Maybe (T2 BlockHeight BlockHash))))
   }
 
 newtype WebPactExecutionService = WebPactExecutionService

--- a/test/Chainweb/Test/CutDB.hs
+++ b/test/Chainweb/Test/CutDB.hs
@@ -491,6 +491,7 @@ fakePact = WebPactExecutionService $ PactExecutionService
         return $ newPayloadWithOutputs fakeMiner coinbase payload
 
   , _pactLocal = \_t -> error "Unimplemented"
+  , _pactLookup = error "Unimplemented"
   }
   where
     getFakeOutput (Transaction txBytes) = TransactionOutput txBytes

--- a/test/Chainweb/Test/Pact/PactInProcApi.hs
+++ b/test/Chainweb/Test/Pact/PactInProcApi.hs
@@ -11,7 +11,7 @@
 -- Maintainer: Mark Nichols <mark@kadena.io>
 -- Stability: experimental
 --
--- Unit test for Pact execution via (inprocess) API  in Chainweb
+-- Unit test for Pact execution via (inprocess) API in Chainweb
 --
 module Chainweb.Test.Pact.PactInProcApi
 ( tests

--- a/test/Chainweb/Test/Pact/RemotePactTest.hs
+++ b/test/Chainweb/Test/Pact/RemotePactTest.hs
@@ -124,8 +124,6 @@ responseGolden networkIO rksIO = golden "command-0-resp" $ do
     rks <- rksIO
     cwEnv <- _getClientEnv <$> networkIO
     (PollResponses theMap) <- testPoll testCmds cwEnv rks
-    putStrLn $ "keys: " ++ show rks
-    putStrLn $ "oof: " ++ show theMap
     let values = mapMaybe (\rk -> _crResult <$> HM.lookup rk theMap) (NEL.toList $ _rkRequestKeys rks)
     return $! toS $! foldMap A.encode values
 

--- a/test/Chainweb/Test/Pact/RemotePactTest.hs
+++ b/test/Chainweb/Test/Pact/RemotePactTest.hs
@@ -12,7 +12,8 @@
 -- Maintainer: Mark Nichols <mark@kadena.io>
 -- Stability: experimental
 --
--- Unit test for Pact execution via the Http Pact interface (/send, etc.)(inprocess) API  in Chainweb
+-- Unit test for Pact execution via the Http Pact interface (/send,
+-- etc.) (inprocess) API in Chainweb
 module Chainweb.Test.Pact.RemotePactTest
 ( tests
 , withNodes
@@ -123,6 +124,8 @@ responseGolden networkIO rksIO = golden "command-0-resp" $ do
     rks <- rksIO
     cwEnv <- _getClientEnv <$> networkIO
     (PollResponses theMap) <- testPoll testCmds cwEnv rks
+    putStrLn $ "keys: " ++ show rks
+    putStrLn $ "oof: " ++ show theMap
     let values = mapMaybe (\rk -> _crResult <$> HM.lookup rk theMap) (NEL.toList $ _rkRequestKeys rks)
     return $! toS $! foldMap A.encode values
 

--- a/test/Chainweb/Test/Pact/Utils.hs
+++ b/test/Chainweb/Test/Pact/Utils.hs
@@ -348,6 +348,8 @@ testPactExecutionService v cid cutDB bhdbIO pdbIO mempoolAccess sqlenv = do
             evalPactServiceM ctx $ execValidateBlock h d
         , _pactLocal = error
             "Chainweb.Test.Pact.Utils.testPactExecutionService._pactLocal: not implemented"
+        , _pactLookup = error
+            "Chainweb.Test.Pact.Utils.testPactExecutionService._pactLookup: not implemented"
         }
 
 -- | A test PactExecutionService for a chainweb


### PR DESCRIPTION
Lars and Emily also need the new included internal pact execution service lookup method for SPV.