### PR TITLE
Quieter logging defaults using new Notice level

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -181,6 +181,14 @@ in
         });
         # --- end of `tasty` dependents --- #
 
+        # our own fork
+        loglevel = self.callCabal2nix "loglevel" (pkgs.fetchFromGitHub {
+          owner = "kadena-io";
+          repo = "loglevel";
+          rev = "f0c79b865da64c65488ba83c3f0511a27f8067ce";
+          sha256 = "0bzyqmj82kj62aqk44fs35yn23hdsmaf70pfnz91vflixvxmq7yj";
+        }) {};
+
         # pact-3.2.1
         pact = dontCheck ( addBuildDepend (self.callCabal2nix "pact" (pkgs.fetchFromGitHub {
           owner = "kadena-io";
@@ -201,11 +209,13 @@ in
           sha256 = "0rgh2698h6xc6q462lbmdb637wz2kkbnkgbhv1h7a6p3zv097dg2";
         });
 
-        yet-another-logger = callHackageDirect {
-          pkg = "yet-another-logger";
-          ver = "0.3.1";
-          sha256 = "17i5km3bxlp568q9pbnbp2nvpfgnmccpfnvcci0z1f56cw95679n";
-        };
+        # our own fork
+        yet-another-logger = self.callCabal2nix "yet-another-logger" (pkgs.fetchFromGitHub {
+          owner = "kadena-io";
+          repo = "hs-yet-another-logger";
+          rev = "e8f3b1d696deb5ce904028706c9ae44bcfab92f8";
+          sha256 = "0hspyqq3f900jzi8mnx6yaj03l812rf00lh1dxwcxdrxqf6xv3jw";
+        }) {};
 
         # test suite fails to build with for older versions
         scotty = callHackageDirect {

--- a/node/ChainwebNode.hs
+++ b/node/ChainwebNode.hs
@@ -188,7 +188,7 @@ runMonitorLoop label logger = runForeverThrottled
 runCutMonitor :: Logger logger => logger -> CutDb cas -> IO ()
 runCutMonitor logger db = L.withLoggerLabel ("component", "cut-monitor") logger $ \l ->
     runMonitorLoop "ChainwebNode.runCutMonitor" l $ do
-        logFunctionText l Info $ "Initialized Cut Monitor"
+        logFunctionText l Notice $ "Initialized Cut Monitor"
         S.mapM_ (logFunctionJson l Info)
             $ S.map (cutToCutHashes Nothing)
             $ cutStream db
@@ -217,7 +217,7 @@ runRtsMonitor logger = L.withLoggerLabel ("component", "rts-monitor") logger go
         False -> do
             logFunctionText l Warn "RTS Stats isn't enabled. Run with '+RTS -T' to enable it."
         True -> do
-            logFunctionText l Info $ "Initialized RTS Monitor"
+            logFunctionText l Notice $ "Initialized RTS Monitor"
             runMonitorLoop "Chainweb.Node.runRtsMonitor" l $ do
                 stats <- getRTSStats
                 logFunctionText l Info $ "got stats"
@@ -239,7 +239,7 @@ runQueueMonitor :: Logger logger => logger -> CutDb cas -> IO ()
 runQueueMonitor logger cutDb = L.withLoggerLabel ("component", "queue-monitor") logger go
   where
     go l = do
-        logFunctionText l Info $ "Initialized Queue Monitor"
+        logFunctionText l Notice $ "Initialized Queue Monitor"
         runMonitorLoop "ChainwebNode.runQueueMonitor" l $ do
             stats <- QueueStats
                 <$> cutDbQueueSize cutDb
@@ -261,7 +261,7 @@ node conf logger = do
     rocksDbDir <- getRocksDbDir
     when (_nodeConfigResetChainDbs conf) $ destroyRocksDb rocksDbDir
     withRocksDb rocksDbDir $ \rocksDb -> do
-        logFunctionText logger Info $ "opened rocksdb in directory " <> sshow rocksDbDir
+        logFunctionText logger Notice $ "opened rocksdb in directory " <> sshow rocksDbDir
         withChainweb cwConf logger rocksDb (_nodeConfigDatabaseDirectory conf) (_nodeConfigResetChainDbs conf) $ \cw -> mapConcurrently_ id
             [ runChainweb cw
             , runCutMonitor (_chainwebLogger cw) (_cutResCutDb $ _chainwebCutResources cw)

--- a/src/Chainweb/Chainweb.hs
+++ b/src/Chainweb/Chainweb.hs
@@ -434,14 +434,14 @@ withChainwebInternal conf logger peer rocksDb dbDir nodeid resetDb inner = do
             -- takes long (why would it?) we want this to happen before we go
             -- online.
             --
-            logg Info "start synchronizing Pact DBs"
+            logg Notice "start synchronizing Pact DBs"
             synchronizePactDb cs mCutDb
-            logg Info "finished synchronizing Pact DBs"
+            logg Notice "finished synchronizing Pact DBs"
 
             withPactData cs cuts $ \pactData -> do
-                logg Info "start initializing miner resources"
+                logg Notice "start initializing miner resources"
                 withMinerResources mLogger mConf cwnid mCutDb $ \m -> do
-                    logg Info "finished initializing miner resources"
+                    logg Notice "finished initializing miner resources"
                     inner Chainweb
                         { _chainwebHostAddress = _peerConfigAddr $ _p2pConfigPeer $ _configP2p conf
                         , _chainwebChains = cs
@@ -516,7 +516,7 @@ runChainweb
     => Chainweb logger cas
     -> IO ()
 runChainweb cw = do
-    logg Info "start chainweb node"
+    logg Notice "start chainweb node"
     concurrently_
         -- 1. Start serving Rest API
         (serve (throttle (_chainwebThrottler cw) . httpLog))

--- a/src/Chainweb/CutDB.hs
+++ b/src/Chainweb/CutDB.hs
@@ -299,10 +299,10 @@ startCutDb config logfun headerStore payloadStore cutHashesStore = mask_ $ do
     logg Debug "obtain initial cut"
     cutVar <- newTVarIO =<< initialCut
     c <- readTVarIO cutVar
-    logg Info $ "got initial cut: " <> sshow c
+    logg Notice $ "got initial cut: " <> sshow c
     queue <- newEmptyPQueue
     cutAsync <- asyncWithUnmask $ \u -> u $ processor queue cutVar
-    logg Info "CutDB started"
+    logg Notice "CutDB started"
     return $! CutDb
         { _cutDbCut = cutVar
         , _cutDbQueue = queue

--- a/src/Chainweb/Logger.hs
+++ b/src/Chainweb/Logger.hs
@@ -86,6 +86,7 @@ l2l :: LogLevel -> L.LogLevel
 l2l Quiet = L.Quiet
 l2l Error = L.Error
 l2l Warn = L.Warn
+l2l Notice = L.Notice
 l2l Info = L.Info
 l2l Debug = L.Debug
 l2l (Other _) = L.Debug
@@ -95,6 +96,7 @@ l2l' :: L.LogLevel -> LogLevel
 l2l' L.Quiet = Quiet
 l2l' L.Error = Error
 l2l' L.Warn = Warn
+l2l' L.Notice = Notice
 l2l' L.Info = Info
 l2l' L.Debug = Debug
 {-# INLINE l2l' #-}
@@ -139,4 +141,3 @@ instance L.LoggerCtx GenericLogger SomeLogMessage where
 --
 genericLogger :: LogLevel -> (T.Text -> IO ()) -> GenericLogger
 genericLogger level fun = GenericLogger [] level fun
-

--- a/src/Chainweb/Pact/PactService.hs
+++ b/src/Chainweb/Pact/PactService.hs
@@ -166,15 +166,12 @@ initPactService' ver cid chainwebLogger spv bhDb pdb dbDir nodeid
     sqlitedir <- getSqliteDir
     when doResetDb $ resetDb sqlitedir
     createDirectoryIfMissing True sqlitedir
-    logFunctionText chainwebLogger Info $
+    let sqlitefile = getSqliteFile sqlitedir
+    logFunctionText chainwebLogger Notice $
         mconcat [ "opened sqlitedb for "
                 , sshow cid
-                , " in directory "
-                , sshow sqlitedir ]
-
-    let sqlitefile = getSqliteFile sqlitedir
-    logFunctionText chainwebLogger Info $
-        "opening sqlitedb named " <> (T.pack sqlitefile)
+                , " from file "
+                , sshow sqlitefile ]
 
     withSQLiteConnection sqlitefile chainwebPragmas False $ \sqlenv -> do
       checkpointEnv <- initRelationalCheckpointer


### PR DESCRIPTION
This PR gives us much quieter logging by default that is more suitable to what will be useful to end users.  It does this by adding a new Notice level between Warn and Info.  The idea is that Notice messages are expected in normal operation (unlike Warn) and that they should never be high volume (unlike Info).  We can move more logging messages to Notice in future PRs as we see the need.

The vision here is that Notice should be things end users care about such as:

New unseen block from P2P
Pact API message from end user on `/send`, `/local`, etc
Miner started/stopped
New block received from miner
A few startup messages with important information useful to someone running the node

Also, because Notice is explicitly not a high-volume message, this makes it reasonable in the future to change log delivery so that messages Notice and higher never get dropped by the logger.  Only Info and Debug should get dropped.