### PR TITLE
[mempool] add a pre-insert check.

### DIFF
--- a/src/Chainweb/Chainweb.hs
+++ b/src/Chainweb/Chainweb.hs
@@ -76,6 +76,7 @@ module Chainweb.Chainweb
 -- ** Mempool integration
 , ChainwebTransaction
 , Mempool.chainwebTransactionConfig
+, validatingMempoolConfig
 
 , withChainweb
 , runChainweb

--- a/src/Chainweb/Chainweb/ChainResources.hs
+++ b/src/Chainweb/Chainweb/ChainResources.hs
@@ -156,7 +156,7 @@ withChainResources v cid rdb peer logger mempoolCfg0 cdbv payloadDb prune dbDir 
                     return ()
                 logg Info $ "finished pruning block header database. Deleted " <> sshow x <> " block headers."
             let pex = pes requestQ
-            putMVar (pexMv) pex
+            putMVar pexMv pex
 
             -- run inner
             inner $ ChainResources

--- a/src/Chainweb/Mempool/InMem.hs
+++ b/src/Chainweb/Mempool/InMem.hs
@@ -113,7 +113,7 @@ toMempoolBackend mempool = do
     nonce = _inmemNonce mempool
     lockMVar = _inmemDataLock mempool
 
-    InMemConfig tcfg blockSizeLimit _ = cfg
+    InMemConfig tcfg blockSizeLimit _ _ = cfg
     member = memberInMem lockMVar
     lookup = lookupInMem tcfg lockMVar
     insert = insertInMem cfg lockMVar
@@ -203,10 +203,11 @@ maxNumPending = 100000
 ------------------------------------------------------------------------------
 insertInMem :: InMemConfig t    -- ^ in-memory config
             -> MVar (InMemoryMempoolData t)  -- ^ in-memory state
+            -> Bool
             -> Vector t  -- ^ new transactions
             -> IO ()
-insertInMem cfg lock txs0 = do
-    txs1 <- V.filterM preGossipCheck txs0
+insertInMem cfg lock runCheck txs0 = do
+    txs1 <- preInsertFilter txs0
     withMVarMasked lock $ \mdata -> do
         let countRef = _inmemCountPending mdata
         cnt <- readIORef countRef
@@ -222,9 +223,14 @@ insertInMem cfg lock txs0 = do
             recordRecentTransactions maxRecent newHashes
 
   where
-    preGossipCheck tx = do
-        -- TODO: other well-formedness checks go here (e.g. ttl check)
-        return $! sizeOK tx
+    preInsertFilter = if runCheck then preInsertFilterReal else return
+    preInsertFilterReal txs = do
+        let chk = _inmemPreInsertCheck cfg
+        let out1 = V.map sizeOK txs
+        out2 <- chk txs
+        let oks = V.zipWith (&&) out1 out2
+        -- keep the good txs only
+        return $! V.map fst $ V.filter snd $ V.zip txs oks
 
     txcfg = _inmemTxCfg cfg
     encodeTx = codecEncode (txCodec txcfg)

--- a/src/Chainweb/Mempool/InMem.hs
+++ b/src/Chainweb/Mempool/InMem.hs
@@ -203,7 +203,7 @@ maxNumPending = 100000
 ------------------------------------------------------------------------------
 insertInMem :: InMemConfig t    -- ^ in-memory config
             -> MVar (InMemoryMempoolData t)  -- ^ in-memory state
-            -> Bool
+            -> InsertType
             -> Vector t  -- ^ new transactions
             -> IO ()
 insertInMem cfg lock runCheck txs0 = do
@@ -223,7 +223,9 @@ insertInMem cfg lock runCheck txs0 = do
             recordRecentTransactions maxRecent newHashes
 
   where
-    preInsertFilter = if runCheck then preInsertFilterReal else return
+    preInsertFilter = if runCheck == CheckedInsert
+                        then preInsertFilterReal
+                        else return
     preInsertFilterReal txs = do
         let chk = _inmemPreInsertCheck cfg
         let out1 = V.map sizeOK txs

--- a/src/Chainweb/Mempool/InMemTypes.hs
+++ b/src/Chainweb/Mempool/InMemTypes.hs
@@ -50,6 +50,8 @@ data InMemConfig t = InMemConfig {
     _inmemTxCfg :: {-# UNPACK #-} !(TransactionConfig t)
   , _inmemTxBlockSizeLimit :: !GasLimit
   , _inmemMaxRecentItems :: {-# UNPACK #-} !Int
+    -- Here True means 'OK to insert'
+  , _inmemPreInsertCheck :: !(V.Vector t -> IO (V.Vector Bool))
 }
 
 ------------------------------------------------------------------------------

--- a/src/Chainweb/Mempool/RestAPI/Client.hs
+++ b/src/Chainweb/Mempool/RestAPI/Client.hs
@@ -65,7 +65,7 @@ toMempool version chain txcfg blocksizeLimit env =
 
     member v = V.fromList <$> go (memberClient version chain (V.toList v))
     lookup v = V.fromList <$> go (lookupClient txcfg version chain (V.toList v))
-    insert v = void $ go (insertClient txcfg version chain (V.toList v))
+    insert _ v = void $ go (insertClient txcfg version chain (V.toList v))
 
     -- TODO: should we permit remote getBlock?
     -- getBlock sz = V.fromList <$> go (getBlockClient version chain (Just sz))

--- a/src/Chainweb/Mempool/RestAPI/Server.hs
+++ b/src/Chainweb/Mempool/RestAPI/Server.hs
@@ -40,7 +40,7 @@ insertHandler mempool txsBS = handleErrs (NoContent <$ begin)
     begin = do
         txs <- mapM decode txsBS
         let txV = V.fromList txs
-        liftIO $ mempoolInsert mempool txV
+        liftIO $ mempoolInsert mempool True txV
 
 
 memberHandler :: Show t => MempoolBackend t -> [TransactionHash] -> Handler [Bool]

--- a/src/Chainweb/Mempool/RestAPI/Server.hs
+++ b/src/Chainweb/Mempool/RestAPI/Server.hs
@@ -40,7 +40,7 @@ insertHandler mempool txsBS = handleErrs (NoContent <$ begin)
     begin = do
         txs <- mapM decode txsBS
         let txV = V.fromList txs
-        liftIO $ mempoolInsert mempool True txV
+        liftIO $ mempoolInsert mempool CheckedInsert txV
 
 
 memberHandler :: Show t => MempoolBackend t -> [TransactionHash] -> Handler [Bool]

--- a/src/Chainweb/Pact/RestAPI/Server.hs
+++ b/src/Chainweb/Pact/RestAPI/Server.hs
@@ -165,7 +165,7 @@ sendHandler logger mempool (SubmitBatch cmds) = Handler $ do
     liftIO $ logg Info (PactCmdLogSend cmds)
     case traverse validateCommand cmds of
       Right enriched -> do
-        liftIO $ mempoolInsert mempool $! V.fromList $ NEL.toList enriched
+        liftIO $ mempoolInsert mempool True $! V.fromList $ NEL.toList enriched
         return $! RequestKeys $ NEL.map cmdToRequestKey enriched
       Left err ->
         throwError $ err400 { errBody = "Validation failed: " <> BSL8.pack err }

--- a/src/Chainweb/Pact/RestAPI/Server.hs
+++ b/src/Chainweb/Pact/RestAPI/Server.hs
@@ -73,7 +73,7 @@ import Chainweb.Chainweb.CutResources
 import Chainweb.Cut
 import qualified Chainweb.CutDB as CutDB
 import Chainweb.Logger
-import Chainweb.Mempool.Mempool (MempoolBackend(..))
+import Chainweb.Mempool.Mempool (MempoolBackend(..), InsertType(..))
 import Chainweb.Pact.RestAPI
 import Chainweb.RestAPI.Orphans ()
 import Chainweb.RestAPI.Utils
@@ -165,7 +165,8 @@ sendHandler logger mempool (SubmitBatch cmds) = Handler $ do
     liftIO $ logg Info (PactCmdLogSend cmds)
     case traverse validateCommand cmds of
       Right enriched -> do
-        liftIO $ mempoolInsert mempool True $! V.fromList $ NEL.toList enriched
+        liftIO $ mempoolInsert mempool CheckedInsert
+               $! V.fromList $ NEL.toList enriched
         return $! RequestKeys $ NEL.map cmdToRequestKey enriched
       Left err ->
         throwError $ err400 { errBody = "Validation failed: " <> BSL8.pack err }

--- a/src/Chainweb/Pact/Service/PactInProcApi.hs
+++ b/src/Chainweb/Pact/Service/PactInProcApi.hs
@@ -146,7 +146,7 @@ pactProcessFork mpc theLogger bHeader = do
                            <> " transactions to reintroduce"
     -- No need to run pre-insert check here -- we know these are ok, and
     -- calling the pre-check would block here (it calls back into pact service)
-    mempoolInsert (mpcMempool mpc) False reintroTxs
+    mempoolInsert (mpcMempool mpc) UncheckedInsert reintroTxs
     mempoolMarkValidated (mpcMempool mpc) $ fmap hasher validatedTxs
 
   where

--- a/src/Chainweb/Pact/Service/PactInProcApi.hs
+++ b/src/Chainweb/Pact/Service/PactInProcApi.hs
@@ -144,7 +144,9 @@ pactProcessFork mpc theLogger bHeader = do
     (reintroTxs, validatedTxs) <- forkFunc bHeader
     (logFn theLogger) Info $! "pactMemPoolAccess - " <> sshow (length reintroTxs)
                            <> " transactions to reintroduce"
-    mempoolInsert (mpcMempool mpc) reintroTxs
+    -- No need to run pre-insert check here -- we know these are ok, and
+    -- calling the pre-check would block here (it calls back into pact service)
+    mempoolInsert (mpcMempool mpc) False reintroTxs
     mempoolMarkValidated (mpcMempool mpc) $ fmap hasher validatedTxs
 
   where

--- a/test/Chainweb/Test/Mempool.hs
+++ b/test/Chainweb/Test/Mempool.hs
@@ -151,7 +151,7 @@ propOverlarge (txs, overlarge0) _ mempool = runExceptT $ do
   where
     txcfg = mempoolTxConfig mempool
     hash = txHasher txcfg
-    insert v = mempoolInsert mempool True $ V.fromList v
+    insert v = mempoolInsert mempool CheckedInsert $ V.fromList v
     lookup = mempoolLookup mempool . V.fromList . map hash
     overlarge = setOverlarge overlarge0
     setOverlarge = map (\x -> x { mockGasLimit = mockBlockGasLimit + 100 })
@@ -174,7 +174,7 @@ propPreInsert (txs, badTxs) gossipMV mempool =
         liftIO (lookup badTxs) >>= V.mapM_ lookupIsMissing
     txcfg = mempoolTxConfig mempool
     hash = txHasher txcfg
-    insert v = mempoolInsert mempool True $ V.fromList v
+    insert v = mempoolInsert mempool CheckedInsert $ V.fromList v
     lookup = mempoolLookup mempool . V.fromList . map hash
     checkNotBad xs = return $! V.map (not . (`elem` badTxs)) xs
 
@@ -197,7 +197,7 @@ propTrivial txs _ mempool = runExceptT $ do
                   in V.and ffs
     txcfg = mempoolTxConfig mempool
     hash = txHasher txcfg
-    insert v = mempoolInsert mempool True $ V.fromList v
+    insert v = mempoolInsert mempool CheckedInsert $ V.fromList v
     lookup = mempoolLookup mempool . V.fromList . map hash
 
     getBlock = mempoolGetBlock mempool noopMempoolPreBlockCheck 0 nullBlockHash
@@ -230,7 +230,7 @@ propGetPending txs0 _ mempool = runExceptT $ do
     onFees x = (Down (mockGasPrice x), mockGasLimit x, mockNonce x)
     hash = txHasher $ mempoolTxConfig mempool
     getPending = mempoolGetPendingTransactions mempool
-    insert v = mempoolInsert mempool True $ V.fromList v
+    insert v = mempoolInsert mempool CheckedInsert $ V.fromList v
 
 propHighWater
     :: ([MockTx], [MockTx])
@@ -260,7 +260,7 @@ propHighWater (txs0, txs1) _ mempool = runExceptT $ do
     txdata = sort $ map hash txs1
     hash = txHasher $ mempoolTxConfig mempool
     getPending = mempoolGetPendingTransactions mempool
-    insert txs = mempoolInsert mempool True $ V.fromList txs
+    insert txs = mempoolInsert mempool CheckedInsert $ V.fromList txs
 
 
 uniq :: Eq a => [a] -> [a]

--- a/test/Chainweb/Test/Mempool.hs
+++ b/test/Chainweb/Test/Mempool.hs
@@ -8,6 +8,7 @@ module Chainweb.Test.Mempool
   ( tests
   , remoteTests
   , MempoolWithFunc(..)
+  , InsertCheck
   , mempoolTestCase
   , mempoolProperty
   , lookupIsPending
@@ -15,6 +16,8 @@ module Chainweb.Test.Mempool
   ) where
 
 import Control.Applicative
+import Control.Concurrent.MVar
+import Control.Exception (bracket)
 import Control.Monad (void, when)
 import Control.Monad.IO.Class
 import Control.Monad.Trans.Except
@@ -25,6 +28,7 @@ import Data.IORef
 import Data.List (sort, sortBy)
 import qualified Data.List.Ordered as OL
 import Data.Ord (Down(..))
+import Data.Vector (Vector)
 import qualified Data.Vector as V
 import Prelude hiding (lookup)
 import System.Timeout (timeout)
@@ -53,6 +57,7 @@ remoteTests withMempool = map ($ withMempool) [
       mempoolTestCase "nil case (startup/destroy)" testStartup
     , mempoolProperty "overlarge transactions are rejected" genTwoSets
                       propOverlarge
+    , mempoolProperty "pre-insert checks" genTwoSets propPreInsert
     , mempoolProperty "insert + lookup + getBlock" genNonEmpty propTrivial
     , mempoolProperty "getPending" genNonEmpty propGetPending
     , mempoolProperty "getPending high water marks" hwgen propHighWater
@@ -101,10 +106,14 @@ instance Arbitrary MockTx where
     where
       emptyMeta = TransactionMetadata Time.minTime Time.maxTime
 
-data MempoolWithFunc = MempoolWithFunc (forall a . (MempoolBackend MockTx -> IO a) -> IO a)
+type InsertCheck = MVar (Vector MockTx -> IO (Vector Bool))
+data MempoolWithFunc =
+    MempoolWithFunc (forall a
+                     . ((InsertCheck -> MempoolBackend MockTx -> IO a)
+                       -> IO a))
 
 mempoolTestCase :: TestName
-                -> (MempoolBackend MockTx -> IO ())
+                -> (InsertCheck -> MempoolBackend MockTx -> IO ())
                 -> MempoolWithFunc
                 -> TestTree
 mempoolTestCase name test (MempoolWithFunc withMempool) =
@@ -113,11 +122,12 @@ mempoolTestCase name test (MempoolWithFunc withMempool) =
     tout m = timeout 60000000 m >>= maybe (fail "timeout") return
 
 
-mempoolProperty :: TestName
-                -> PropertyM IO a
-                -> (a -> MempoolBackend MockTx -> IO (Either String ()))
-                -> MempoolWithFunc
-                -> TestTree
+mempoolProperty
+    :: TestName
+    -> PropertyM IO a
+    -> (a -> InsertCheck -> MempoolBackend MockTx -> IO (Either String ()))
+    -> MempoolWithFunc
+    -> TestTree
 mempoolProperty name gen test (MempoolWithFunc withMempool) = testProperty name go
   where
     go = monadicIO (gen >>= run . tout . withMempool . test
@@ -125,26 +135,56 @@ mempoolProperty name gen test (MempoolWithFunc withMempool) = testProperty name 
 
     tout m = timeout 60000000 m >>= maybe (fail "timeout") return
 
-testStartup :: MempoolBackend MockTx -> IO ()
-testStartup = const $ return ()
+testStartup :: InsertCheck -> MempoolBackend MockTx -> IO ()
+testStartup = const $ const $ return ()
 
 
-propOverlarge :: ([MockTx], [MockTx]) -> MempoolBackend MockTx -> IO (Either String ())
-propOverlarge (txs, overlarge0) mempool = runExceptT $ do
+propOverlarge
+    :: ([MockTx], [MockTx])
+    -> InsertCheck
+    -> MempoolBackend MockTx
+    -> IO (Either String ())
+propOverlarge (txs, overlarge0) _ mempool = runExceptT $ do
     liftIO $ insert $ txs ++ overlarge
     liftIO (lookup txs) >>= V.mapM_ lookupIsPending
     liftIO (lookup overlarge) >>= V.mapM_ lookupIsMissing
   where
     txcfg = mempoolTxConfig mempool
     hash = txHasher txcfg
-    insert v = mempoolInsert mempool $ V.fromList v
+    insert v = mempoolInsert mempool True $ V.fromList v
     lookup = mempoolLookup mempool . V.fromList . map hash
     overlarge = setOverlarge overlarge0
     setOverlarge = map (\x -> x { mockGasLimit = mockBlockGasLimit + 100 })
 
+propPreInsert
+    :: ([MockTx], [MockTx])
+    -> InsertCheck
+    -> MempoolBackend MockTx
+    -> IO (Either String ())
+propPreInsert (txs, badTxs) gossipMV mempool =
+   bracket (readMVar gossipMV)
+           (\old -> modifyMVar_ gossipMV (const $ return old))
+           (const go)
 
-propTrivial :: [MockTx] -> MempoolBackend MockTx -> IO (Either String ())
-propTrivial txs mempool = runExceptT $ do
+  where
+    go = runExceptT $ do
+        liftIO $ modifyMVar_ gossipMV $ const $ return checkNotBad
+        liftIO $ insert $ txs ++ badTxs
+        liftIO (lookup txs) >>= V.mapM_ lookupIsPending
+        liftIO (lookup badTxs) >>= V.mapM_ lookupIsMissing
+    txcfg = mempoolTxConfig mempool
+    hash = txHasher txcfg
+    insert v = mempoolInsert mempool True $ V.fromList v
+    lookup = mempoolLookup mempool . V.fromList . map hash
+    checkNotBad xs = return $! V.map (not . (`elem` badTxs)) xs
+
+
+propTrivial
+    :: [MockTx]
+    -> InsertCheck
+    -> MempoolBackend MockTx
+    -> IO (Either String ())
+propTrivial txs _ mempool = runExceptT $ do
     liftIO $ insert txs
     liftIO (lookup txs) >>= V.mapM_ lookupIsPending
     block <- liftIO getBlock
@@ -157,7 +197,7 @@ propTrivial txs mempool = runExceptT $ do
                   in V.and ffs
     txcfg = mempoolTxConfig mempool
     hash = txHasher txcfg
-    insert v = mempoolInsert mempool $ V.fromList v
+    insert v = mempoolInsert mempool True $ V.fromList v
     lookup = mempoolLookup mempool . V.fromList . map hash
 
     getBlock = mempoolGetBlock mempool noopMempoolPreBlockCheck 0 nullBlockHash
@@ -165,8 +205,12 @@ propTrivial txs mempool = runExceptT $ do
     onFees x = (Down (mockGasPrice x), mockGasLimit x)
 
 
-propGetPending :: [MockTx] -> MempoolBackend MockTx -> IO (Either String ())
-propGetPending txs0 mempool = runExceptT $ do
+propGetPending
+    :: [MockTx]
+    -> InsertCheck
+    -> MempoolBackend MockTx
+    -> IO (Either String ())
+propGetPending txs0 _ mempool = runExceptT $ do
     liftIO $ insert txs
     pendingOps <- liftIO $ newIORef []
     void $ liftIO $ getPending Nothing $ \v -> modifyIORef' pendingOps (v:)
@@ -186,10 +230,14 @@ propGetPending txs0 mempool = runExceptT $ do
     onFees x = (Down (mockGasPrice x), mockGasLimit x, mockNonce x)
     hash = txHasher $ mempoolTxConfig mempool
     getPending = mempoolGetPendingTransactions mempool
-    insert v = mempoolInsert mempool $ V.fromList v
+    insert v = mempoolInsert mempool True $ V.fromList v
 
-propHighWater :: ([MockTx], [MockTx]) -> MempoolBackend MockTx -> IO (Either String ())
-propHighWater (txs0, txs1) mempool = runExceptT $ do
+propHighWater
+    :: ([MockTx], [MockTx])
+    -> InsertCheck
+    -> MempoolBackend MockTx
+    -> IO (Either String ())
+propHighWater (txs0, txs1) _ mempool = runExceptT $ do
     liftIO $ insert txs0
     hw <- liftIO $ getPending Nothing $ const (return ())
     liftIO $ insert txs1
@@ -212,7 +260,7 @@ propHighWater (txs0, txs1) mempool = runExceptT $ do
     txdata = sort $ map hash txs1
     hash = txHasher $ mempoolTxConfig mempool
     getPending = mempoolGetPendingTransactions mempool
-    insert txs = mempoolInsert mempool $ V.fromList txs
+    insert txs = mempoolInsert mempool True $ V.fromList txs
 
 
 uniq :: Eq a => [a] -> [a]

--- a/test/Chainweb/Test/Mempool/Sync.hs
+++ b/test/Chainweb/Test/Mempool/Sync.hs
@@ -24,7 +24,7 @@ import Chainweb.Mempool.InMem
 import Chainweb.Mempool.InMemTypes
 import Chainweb.Mempool.Mempool
 import Chainweb.Test.Mempool
-    (MempoolWithFunc(..), lookupIsPending, mempoolProperty)
+    (InsertCheck, MempoolWithFunc(..), lookupIsPending, mempoolProperty)
 import Chainweb.Utils (Codec(..))
 ------------------------------------------------------------------------------
 
@@ -32,9 +32,18 @@ import Chainweb.Utils (Codec(..))
 tests :: TestTree
 tests = testGroup "Chainweb.Mempool.sync" [
             mempoolProperty "Mempool.syncMempools" gen propSync
-                $ MempoolWithFunc $ withInMemoryMempool testInMemCfg
+                $ MempoolWithFunc wf
          ]
   where
+    wf f = do
+        mv <- newMVar (V.mapM (const $ return True))
+        let cfg = InMemConfig txcfg mockBlockGasLimit 2048 (checkMv mv)
+        withInMemoryMempool cfg $ f mv
+
+    checkMv mv xs = do
+        f <- readMVar mv
+        f xs
+
     gen :: PropertyM IO (Set MockTx, Set MockTx, Set MockTx)
     gen = do
       (xs, ys, zs) <- pick arbitrary
@@ -44,23 +53,26 @@ tests = testGroup "Chainweb.Mempool.sync" [
       pre (not (Set.null xss || Set.null yss || Set.null zss) && length ys < 10000 && length zs < 10000)
       return (xss, yss, zss)
 
-testInMemCfg :: InMemConfig MockTx
-testInMemCfg = InMemConfig txcfg mockBlockGasLimit 2048
+txcfg :: TransactionConfig MockTx
+txcfg = TransactionConfig mockCodec hasher hashmeta mockGasPrice
+                          mockGasLimit mockMeta
   where
-    txcfg = TransactionConfig mockCodec hasher hashmeta mockGasPrice
-                              mockGasLimit mockMeta
     hashmeta = chainwebTestHashMeta
     hasher = chainwebTestHasher . codecEncode mockCodec
 
+testInMemCfg :: InMemConfig MockTx
+testInMemCfg = InMemConfig txcfg mockBlockGasLimit 2048 (V.mapM $ const $ return True)
+
 propSync
     :: (Set MockTx, Set MockTx , Set MockTx)
+    -> InsertCheck
     -> MempoolBackend MockTx
     -> IO (Either String ())
-propSync (txs, missing, later) localMempool' =
+propSync (txs, missing, later) _ localMempool' =
     withInMemoryMempool testInMemCfg $ \remoteMempool -> do
-        mempoolInsert localMempool' txsV
-        mempoolInsert remoteMempool txsV
-        mempoolInsert remoteMempool missingV
+        mempoolInsert localMempool' True txsV
+        mempoolInsert remoteMempool True txsV
+        mempoolInsert remoteMempool True missingV
 
         syncThMv <- newEmptyMVar
         syncFinished <- newEmptyMVar
@@ -91,7 +103,7 @@ propSync (txs, missing, later) localMempool' =
             -- We should now be subscribed and waiting for V.length laterV
             -- more transactions before getting killed. Transactions
             -- inserted into remote should get synced to us.
-            mempoolInsert remoteMempool laterV
+            mempoolInsert remoteMempool True laterV
             Async.wait syncTh
 
         maybe (fail "timeout") return m
@@ -122,8 +134,8 @@ timebomb k act mp = do
     ref <- newIORef k
     return $! mp { mempoolInsert = ins ref }
   where
-    ins ref v = do
-        mempoolInsert mp v
+    ins ref t v = do
+        mempoolInsert mp t v
         c <- atomicModifyIORef' ref (\x -> let !x' = x - V.length v
                                            in (x', x'))
         when (c == 0) $ void act     -- so that the bomb only triggers once

--- a/test/Chainweb/Test/Mempool/Sync.hs
+++ b/test/Chainweb/Test/Mempool/Sync.hs
@@ -70,9 +70,9 @@ propSync
     -> IO (Either String ())
 propSync (txs, missing, later) _ localMempool' =
     withInMemoryMempool testInMemCfg $ \remoteMempool -> do
-        mempoolInsert localMempool' True txsV
-        mempoolInsert remoteMempool True txsV
-        mempoolInsert remoteMempool True missingV
+        mempoolInsert localMempool' CheckedInsert txsV
+        mempoolInsert remoteMempool CheckedInsert txsV
+        mempoolInsert remoteMempool CheckedInsert missingV
 
         syncThMv <- newEmptyMVar
         syncFinished <- newEmptyMVar
@@ -103,7 +103,7 @@ propSync (txs, missing, later) _ localMempool' =
             -- We should now be subscribed and waiting for V.length laterV
             -- more transactions before getting killed. Transactions
             -- inserted into remote should get synced to us.
-            mempoolInsert remoteMempool True laterV
+            mempoolInsert remoteMempool CheckedInsert laterV
             Async.wait syncTh
 
         maybe (fail "timeout") return m

--- a/tools/standalone/Standalone/Chainweb.hs
+++ b/tools/standalone/Standalone/Chainweb.hs
@@ -55,7 +55,6 @@ import Chainweb.WebBlockHeaderDB
 import Chainweb.WebPactExecutionService
 import qualified Chainweb.Mempool.InMem as Mempool
 import qualified Chainweb.Mempool.InMemTypes as Mempool
-import qualified Chainweb.Mempool.Mempool as Mempool
 
 import Standalone.Utils
 
@@ -96,7 +95,7 @@ withChainResourcesStandalone
     -> RocksDb
     -> PeerResources logger
     -> logger
-    -> Mempool.InMemConfig ChainwebTransaction
+    -> (MVar PactExecutionService -> Mempool.InMemConfig ChainwebTransaction)
     -> MVar (CutDb cas)
     -> PayloadDb cas
     -> Bool
@@ -108,8 +107,10 @@ withChainResourcesStandalone
       -- ^ reset database directory
     -> (ChainResources logger -> IO a)
     -> IO a
-withChainResourcesStandalone v cid rdb peer logger mempoolCfg cdbv payloadDb prune dbDir nodeid resetDb inner =
-    withBlockHeaderDb rdb v cid $ \cdb ->
+withChainResourcesStandalone v cid rdb peer logger mempoolCfg0 cdbv payloadDb prune dbDir nodeid resetDb inner =
+    withBlockHeaderDb rdb v cid $ \cdb -> do
+        pexMv <- newEmptyMVar
+        let mempoolCfg = mempoolCfg0 pexMv
         Mempool.withInMemoryMempool_ (setComponent "mempool" logger) mempoolCfg $ \mempool -> do
             -- placing mempool access shim here
             -- putting a default here for now.
@@ -144,6 +145,7 @@ withChainResourcesStandalone v cid rdb peer logger mempoolCfg cdbv payloadDb pru
 
                       -- replay pact
                       let pact = pes requestQ
+                      putMVar pexMv pact
 
                       -- run inner
                       inner ChainResources
@@ -167,15 +169,6 @@ withChainResourcesStandalone v cid rdb peer logger mempoolCfg cdbv payloadDb pru
         -- Testnet01 -> mkPactExecutionService' requestQ
         Testnet02 -> mkPactExecutionService' requestQ
 
-validatingMempoolConfig :: Mempool.InMemConfig ChainwebTransaction
-validatingMempoolConfig = Mempool.InMemConfig
-    Mempool.chainwebTransactionConfig
-    blockGasLimit
-    maxRecentLog
-  where
-    blockGasLimit = 100000
-    maxRecentLog = 2048
-
 withChainwebInternalStandalone
     :: Logger logger
     => ChainwebConfiguration
@@ -192,8 +185,10 @@ withChainwebInternalStandalone conf logger peer rocksDb dbDir nodeid resetDb inn
     cdbv <- newEmptyMVar
     concurrentWith
       -- initialize chains concurrently
-      (\cid -> withChainResourcesStandalone v cid rocksDb peer (chainLogger cid)
-                validatingMempoolConfig cdbv payloadDb prune dbDir nodeid resetDb)
+      (\cid -> do
+          let mcfg = validatingMempoolConfig cid cdbv
+          withChainResourcesStandalone v cid rocksDb peer (chainLogger cid)
+                mcfg cdbv payloadDb prune dbDir nodeid resetDb)
 
       -- initialize global resources after all chain resources are
       -- initialized


### PR DESCRIPTION
We're re-gossiping old transactions in the mempool -- this change eagerly checks them, at the expense of moving the checkpointer more often.