### PR TITLE
Miner: Treat Servant more Rigorously

### DIFF
--- a/src/Chainweb/Chainweb/MinerResources.hs
+++ b/src/Chainweb/Chainweb/MinerResources.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
@@ -38,7 +39,7 @@ import qualified System.Random.MWC as MWC
 
 -- internal modules
 
-import Chainweb.BlockHeader (_blockCreationTime, BlockCreationTime(..))
+import Chainweb.BlockHeader (BlockCreationTime(..), _blockCreationTime)
 import Chainweb.CutDB (CutDb)
 import Chainweb.Logger (Logger, logFunction)
 import Chainweb.Miner.Config (MinerConfig(..))


### PR DESCRIPTION
This PR makes `chainweb-miner` follow the precedent for dealing with servant bounds.