### PR TITLE
Header Stream

### DIFF
--- a/src/Chainweb/BlockHeaderDB/RestAPI.hs
+++ b/src/Chainweb/BlockHeaderDB/RestAPI.hs
@@ -67,6 +67,7 @@ module Chainweb.BlockHeaderDB.RestAPI
 
 -- * BlockHeader Event Stream
 , HeaderStream(..)
+, HeaderUpdate(..)
 , HeaderStreamApi
 , headerStreamApi
 , someHeaderStreamApi
@@ -381,6 +382,13 @@ someBlockHeaderDbApis v = mconcat . fmap (someBlockHeaderDbApi v)
 -- BlockHeader Event Stream
 
 newtype HeaderStream = HeaderStream Bool
+
+data HeaderUpdate = HeaderUpdate
+    { _huHeader :: !(ObjectEncoded BlockHeader)
+    , _huTxCount :: !Int }
+
+instance ToJSON HeaderUpdate where
+    toJSON o = object [ "header" .= _huHeader o, "txCount" .= _huTxCount o ]
 
 type HeaderStreamApi_ = "header" :> "updates" :> Raw
 

--- a/src/Chainweb/BlockHeaderDB/RestAPI.hs
+++ b/src/Chainweb/BlockHeaderDB/RestAPI.hs
@@ -359,6 +359,7 @@ blockHeaderDbApi = Proxy
 -- -------------------------------------------------------------------------- --
 -- Multi Chain API
 
+-- TODO Just use @case@ statements.
 someBlockHeaderDbApi :: ChainwebVersion -> ChainId -> SomeApi
 someBlockHeaderDbApi v c = runIdentity $ do
     SomeChainwebVersionT (_ :: Proxy v') <- return $ someChainwebVersionVal v

--- a/src/Chainweb/BlockHeaderDB/RestAPI.hs
+++ b/src/Chainweb/BlockHeaderDB/RestAPI.hs
@@ -65,6 +65,11 @@ module Chainweb.BlockHeaderDB.RestAPI
 , someBlockHeaderDbApi
 , someBlockHeaderDbApis
 
+-- * BlockHeader Event Stream
+, HeaderStreamApi
+, headerStreamApi
+, someHeaderStreamApi
+
 -- * Sub APIs
 , BranchHashesApi
 , branchHashesApi
@@ -103,6 +108,8 @@ import Chainweb.RestAPI.Utils
 import Chainweb.TreeDB
 import Chainweb.Utils.Paging hiding (properties)
 import Chainweb.Version
+
+import Data.Singletons
 
 -- -------------------------------------------------------------------------- --
 -- API types
@@ -368,3 +375,18 @@ someBlockHeaderDbApi v c = runIdentity $ do
 
 someBlockHeaderDbApis :: ChainwebVersion -> [ChainId] -> SomeApi
 someBlockHeaderDbApis v = mconcat . fmap (someBlockHeaderDbApi v)
+
+-- -------------------------------------------------------------------------- --
+-- BlockHeader Event Stream
+
+type HeaderStreamApi_ = "header" :> "updates" :> Raw
+
+-- | A stream of all new `BlockHeader`s that are accepted into the true `Cut`.
+--
+type HeaderStreamApi (v :: ChainwebVersionT) = 'ChainwebEndpoint v :> HeaderStreamApi_
+
+headerStreamApi :: forall (v :: ChainwebVersionT). Proxy (HeaderStreamApi v)
+headerStreamApi = Proxy
+
+someHeaderStreamApi :: ChainwebVersion -> SomeApi
+someHeaderStreamApi (FromSing (SChainwebVersion :: Sing v)) = SomeApi $ headerStreamApi @v

--- a/src/Chainweb/BlockHeaderDB/RestAPI.hs
+++ b/src/Chainweb/BlockHeaderDB/RestAPI.hs
@@ -66,6 +66,7 @@ module Chainweb.BlockHeaderDB.RestAPI
 , someBlockHeaderDbApis
 
 -- * BlockHeader Event Stream
+, HeaderStream(..)
 , HeaderStreamApi
 , headerStreamApi
 , someHeaderStreamApi
@@ -378,6 +379,8 @@ someBlockHeaderDbApis v = mconcat . fmap (someBlockHeaderDbApi v)
 
 -- -------------------------------------------------------------------------- --
 -- BlockHeader Event Stream
+
+newtype HeaderStream = HeaderStream Bool
 
 type HeaderStreamApi_ = "header" :> "updates" :> Raw
 

--- a/src/Chainweb/BlockHeaderDB/RestAPI/Server.hs
+++ b/src/Chainweb/BlockHeaderDB/RestAPI/Server.hs
@@ -315,7 +315,7 @@ headerStreamHandler :: forall cas. PayloadCas cas => CutDb cas -> Tagged Handler
 headerStreamHandler db = Tagged $ \req respond -> do
     chan <- newChan
     snd <$> concurrently
-        (void . SP.mapM_ (g >=> writeChan chan . f) . SP.concat $ blockDiffStream db)
+        (SP.mapM_ (g >=> writeChan chan . f) . SP.concat $ blockDiffStream db)
         (eventSourceAppChan chan req respond)
   where
     cas :: PayloadDb cas

--- a/src/Chainweb/Chainweb.hs
+++ b/src/Chainweb/Chainweb.hs
@@ -52,7 +52,7 @@ module Chainweb.Chainweb
 , configChainwebVersion
 , configMiner
 , configCoordinator
-, configBlockStream
+, configHeaderStream
 , configReintroTxs
 , configP2p
 , configTransactionIndex
@@ -190,7 +190,7 @@ data ChainwebConfiguration = ChainwebConfiguration
     , _configNodeId :: !NodeId
     , _configMiner :: !(EnableConfig MinerConfig)
     , _configCoordinator :: !Bool
-    , _configBlockStream :: !Bool
+    , _configHeaderStream :: !Bool
     , _configReintroTxs :: !Bool
     , _configP2p :: !P2pConfiguration
     , _configTransactionIndex :: !(EnableConfig TransactionIndexConfig)
@@ -217,7 +217,7 @@ defaultChainwebConfiguration v = ChainwebConfiguration
     , _configNodeId = NodeId 0 -- FIXME
     , _configMiner = defaultEnableConfig defaultMinerConfig
     , _configCoordinator = False
-    , _configBlockStream = False
+    , _configHeaderStream = False
     , _configReintroTxs = True
     , _configP2p = defaultP2pConfiguration
     , _configTransactionIndex = defaultEnableConfig defaultTransactionIndexConfig
@@ -233,7 +233,7 @@ instance ToJSON ChainwebConfiguration where
         , "nodeId" .= _configNodeId o
         , "miner" .= _configMiner o
         , "miningCoordination" .= _configCoordinator o
-        , "blockStream" .= _configBlockStream o
+        , "headerStream" .= _configHeaderStream o
         , "reintroTxs" .= _configReintroTxs o
         , "p2p" .= _configP2p o
         , "transactionIndex" .= _configTransactionIndex o
@@ -249,7 +249,7 @@ instance FromJSON (ChainwebConfiguration -> ChainwebConfiguration) where
         <*< configNodeId ..: "nodeId" % o
         <*< configMiner %.: "miner" % o
         <*< configCoordinator ..: "miningCoordination" % o
-        <*< configBlockStream ..: "blockStream" % o
+        <*< configHeaderStream ..: "headerStream" % o
         <*< configReintroTxs ..: "reintroTxs" % o
         <*< configP2p %.: "p2p" % o
         <*< configTransactionIndex %.: "transactionIndex" % o
@@ -272,8 +272,8 @@ pChainwebConfiguration = id
     <*< configCoordinator .:: boolOption_
         % long "mining-coordination"
         <> help "whether to enable external requests for mining work"
-    <*< configBlockStream .:: boolOption_
-        % long "block-stream"
+    <*< configHeaderStream .:: boolOption_
+        % long "header-stream"
         <> help "whether to enable an endpoint for streaming block updates"
     <*< configReintroTxs .:: enableDisableFlag
         % long "tx-reintro"
@@ -490,7 +490,7 @@ withChainwebInternal conf logger peer rocksDb dbDir nodeid resetDb inner = do
                             , _chainwebCutResources = cuts
                             , _chainwebMiner = m
                             , _chainwebCoordinator = mc
-                            , _chainwebHeaderStream = HeaderStream $ _configBlockStream conf
+                            , _chainwebHeaderStream = HeaderStream $ _configHeaderStream conf
                             , _chainwebLogger = logger
                             , _chainwebPeer = peer
                             , _chainwebPayloadDb = payloadDb

--- a/src/Chainweb/Chainweb.hs
+++ b/src/Chainweb/Chainweb.hs
@@ -126,6 +126,7 @@ import System.LogLevel
 
 import Chainweb.BlockHeader
 import Chainweb.BlockHeaderDB (BlockHeaderDb)
+import Chainweb.BlockHeaderDB.RestAPI (HeaderStream(..))
 import Chainweb.ChainId
 import Chainweb.Chainweb.ChainResources
 import Chainweb.Chainweb.CutResources
@@ -294,8 +295,6 @@ pChainwebConfiguration = id
 
 -- -------------------------------------------------------------------------- --
 -- Chainweb Resources
-
-newtype HeaderStream = HeaderStream Bool
 
 data Chainweb logger cas = Chainweb
     { _chainwebHostAddress :: !HostAddress
@@ -630,6 +629,7 @@ runChainweb cw = do
             , _chainwebServerPactDbs = pactDbsToServe
             }
         (_chainwebCoordinator cw)
+        (_chainwebHeaderStream cw)
 
     -- HTTP Request Logger
 

--- a/src/Chainweb/CutDB/RestAPI.hs
+++ b/src/Chainweb/CutDB/RestAPI.hs
@@ -23,10 +23,6 @@ module Chainweb.CutDB.RestAPI
 , CutApi
 , cutApi
 
--- * BlockHeader Event Stream
-, HeaderStreamApi
-, headerStreamApi
-
 -- * Some Cut API
 , someCutApi
 ) where
@@ -83,7 +79,6 @@ cutPutApi = Proxy
 type CutApi v
     = CutGetApi v
     :<|> CutPutApi v
-    :<|> HeaderStreamApi v
 
 cutApi :: forall (v :: ChainwebVersionT) . Proxy (CutApi v)
 cutApi = Proxy
@@ -93,15 +88,3 @@ cutApi = Proxy
 
 someCutApi :: ChainwebVersion -> SomeApi
 someCutApi (FromSing (SChainwebVersion :: Sing v)) = SomeApi $ cutApi @v
-
--- -------------------------------------------------------------------------- --
--- BlockHeader Event Stream
-
-type HeaderStreamApi_ = "header" :> "updates" :> Raw
-
--- | A stream of all new `BlockHeader`s that are accepted into the true `Cut`.
---
-type HeaderStreamApi (v :: ChainwebVersionT) = 'ChainwebEndpoint v :> HeaderStreamApi_
-
-headerStreamApi :: forall (v :: ChainwebVersionT). Proxy (HeaderStreamApi v)
-headerStreamApi = Proxy

--- a/src/Chainweb/CutDB/RestAPI.hs
+++ b/src/Chainweb/CutDB/RestAPI.hs
@@ -23,6 +23,10 @@ module Chainweb.CutDB.RestAPI
 , CutApi
 , cutApi
 
+-- * BlockHeader Event Stream
+, HeaderStreamApi
+, headerStreamApi
+
 -- * Some Cut API
 , someCutApi
 ) where
@@ -79,6 +83,7 @@ cutPutApi = Proxy
 type CutApi v
     = CutGetApi v
     :<|> CutPutApi v
+    :<|> HeaderStreamApi v
 
 cutApi :: forall (v :: ChainwebVersionT) . Proxy (CutApi v)
 cutApi = Proxy
@@ -89,3 +94,14 @@ cutApi = Proxy
 someCutApi :: ChainwebVersion -> SomeApi
 someCutApi (FromSing (SChainwebVersion :: Sing v)) = SomeApi $ cutApi @v
 
+-- -------------------------------------------------------------------------- --
+-- BlockHeader Event Stream
+
+type HeaderStreamApi_ = "header" :> "updates" :> Raw
+
+-- | A stream of all new `BlockHeader`s that are accepted into the true `Cut`.
+--
+type HeaderStreamApi (v :: ChainwebVersionT) = 'ChainwebEndpoint v :> HeaderStreamApi_
+
+headerStreamApi :: forall (v :: ChainwebVersionT). Proxy (HeaderStreamApi v)
+headerStreamApi = Proxy

--- a/src/Chainweb/CutDB/RestAPI/Server.hs
+++ b/src/Chainweb/CutDB/RestAPI/Server.hs
@@ -74,9 +74,7 @@ cutServer
     :: forall cas (v :: ChainwebVersionT)
     . CutDbT cas v
     -> Server (CutApi v)
-cutServer (CutDbT db) =
-    cutGetHandler db
-    :<|> cutPutHandler db
+cutServer (CutDbT db) = cutGetHandler db :<|> cutPutHandler db
 
 -- -------------------------------------------------------------------------- --
 -- Some Cut Server

--- a/src/Chainweb/CutDB/RestAPI/Server.hs
+++ b/src/Chainweb/CutDB/RestAPI/Server.hs
@@ -31,19 +31,26 @@ module Chainweb.CutDB.RestAPI.Server
 , serveCutOnPort
 ) where
 
+import Control.Concurrent.Chan (newChan, writeChan)
 import Control.Lens (view)
 import Control.Monad.Except
 
+import Data.Aeson (encode, toJSON)
+import Data.Binary.Builder (fromByteString, fromLazyByteString)
 import Data.Proxy
 import Data.Semigroup
 
+import Network.Wai.EventSource (ServerEvent(..), eventSourceAppChan)
 import Network.Wai.Handler.Warp hiding (Port)
 
 import Servant.API
 import Servant.Server
 
+import qualified Streaming.Prelude as SP
+
 -- internal modules
 
+import Chainweb.BlockHeader (BlockHeader(..), ObjectEncoded(..))
 import Chainweb.Cut
 import Chainweb.Cut.CutHashes
 import Chainweb.CutDB
@@ -67,6 +74,16 @@ cutGetHandler db (Just (MaxRank (Max mar))) = liftIO $ do
 cutPutHandler :: CutDb cas -> CutHashes -> Handler NoContent
 cutPutHandler db c = NoContent <$ liftIO (addCutHashes db c)
 
+headerStreamHandler :: CutDb cas -> Tagged Handler Application
+headerStreamHandler db = Tagged $ \req respond -> do
+    chan <- newChan
+    void . SP.mapM_ (writeChan chan . f) . SP.concat $ blockDiffStream db
+    eventSourceAppChan chan req respond
+  where
+    f :: BlockHeader -> ServerEvent
+    f bh = ServerEvent (Just $ fromByteString "BlockHeader") Nothing
+        [ fromLazyByteString . encode . toJSON $ ObjectEncoded bh ]
+
 -- -------------------------------------------------------------------------- --
 -- Cut API Server
 
@@ -74,7 +91,10 @@ cutServer
     :: forall cas (v :: ChainwebVersionT)
     . CutDbT cas v
     -> Server (CutApi v)
-cutServer (CutDbT db) = cutGetHandler db :<|> cutPutHandler db
+cutServer (CutDbT db) =
+    cutGetHandler db
+    :<|> cutPutHandler db
+    :<|> headerStreamHandler db
 
 -- -------------------------------------------------------------------------- --
 -- Some Cut Server

--- a/src/Chainweb/RestAPI.hs
+++ b/src/Chainweb/RestAPI.hs
@@ -213,8 +213,7 @@ someChainwebServer v dbs mr (HeaderStream hs) =
         <> someP2pServers v (_chainwebServerPeerDbs dbs)
         <> PactAPI.somePactServers v (_chainwebServerPactDbs dbs)
         <> maybe mempty (Mining.someMiningServer v) mr
-        <> maybe mempty (someHeaderStreamServer v)
-               (bool Nothing (Just ()) hs >> _chainwebServerCutDb dbs)
+        <> maybe mempty (someHeaderStreamServer v) (bool Nothing (_chainwebServerCutDb dbs) hs)
 
 chainwebApplication
     :: Show t

--- a/src/Chainweb/RestAPI.hs
+++ b/src/Chainweb/RestAPI.hs
@@ -146,6 +146,7 @@ someChainwebApi v cs = someSwaggerApi
     <> someP2pApis v cs
     <> PactAPI.somePactServiceApis v chains
     <> someMiningApi v
+    <> someHeaderStreamApi v
   where
     chains = selectChainIds cs
 
@@ -210,6 +211,7 @@ someChainwebServer v dbs mr =
         <> someP2pServers v (_chainwebServerPeerDbs dbs)
         <> PactAPI.somePactServers v (_chainwebServerPactDbs dbs)
         <> maybe mempty (Mining.someMiningServer v) mr
+        <> maybe mempty (someHeaderStreamServer v) (_chainwebServerCutDb dbs)
 
 chainwebApplication
     :: Show t

--- a/test/Chainweb/Test/Mempool/RestAPI.hs
+++ b/test/Chainweb/Test/Mempool/RestAPI.hs
@@ -16,6 +16,7 @@ import Test.Tasty
 
 -- internal modules
 
+import Chainweb.BlockHeaderDB.RestAPI (HeaderStream(..))
 import Chainweb.ChainId (ChainId)
 import Chainweb.Chainweb.MinerResources (MiningCoordination)
 import Chainweb.Graph
@@ -87,8 +88,10 @@ newTestServer = mask_ $ do
     chain = someChainId version
 
     mkApp :: MempoolBackend MockTx -> Application
-    mkApp mp = chainwebApplication version (serverMempools [(chain, mp)]) mr
+    mkApp mp = chainwebApplication version (serverMempools [(chain, mp)]) mr hs
       where
+        hs = HeaderStream False
+
         mr :: Maybe (MiningCoordination GenericLogger cas)
         mr = Nothing
 

--- a/test/Chainweb/Test/Utils.hs
+++ b/test/Chainweb/Test/Utils.hs
@@ -141,6 +141,7 @@ import Text.Printf (printf)
 
 -- internal modules
 
+import Chainweb.BlockHeaderDB.RestAPI (HeaderStream(..))
 import Chainweb.Chainweb.MinerResources (MiningCoordination)
 import Chainweb.Logger (Logger)
 import Chainweb.BlockHeader
@@ -418,7 +419,8 @@ starBlockHeaderDbs n genDbs = do
 -- | Spawn a server that acts as a peer node for the purpose of querying / syncing.
 --
 withChainServer
-    :: Show t
+    :: forall t cas logger a
+    .  Show t
     => ToJSON t
     => FromJSON t
     => PayloadCas cas
@@ -428,7 +430,10 @@ withChainServer
     -> IO a
 withChainServer dbs f = W.testWithApplication (pure app) work
   where
-    app = chainwebApplication (Test singletonChainGraph) dbs Nothing
+    app :: W.Application
+    app = chainwebApplication (Test singletonChainGraph) dbs Nothing (HeaderStream False)
+
+    work :: Int -> IO a
     work port = do
         mgr <- HTTP.newManager HTTP.defaultManagerSettings
         f $ mkClientEnv mgr (BaseUrl Http "localhost" port "")
@@ -565,7 +570,7 @@ clientEnvWithChainwebTestServer tls v dbsIO f =
     miningRes = Nothing
 
     mkApp :: IO W.Application
-    mkApp = chainwebApplication v <$> dbsIO <*> pure miningRes
+    mkApp = chainwebApplication v <$> dbsIO <*> pure miningRes <*> pure (HeaderStream False)
 
     mkEnv :: Int -> IO (TestClientEnv t cas)
     mkEnv port = do

--- a/tools/standalone/Standalone/Chainweb.hs
+++ b/tools/standalone/Standalone/Chainweb.hs
@@ -253,7 +253,7 @@ withChainwebInternalStandalone conf logger peer rocksDb dbDir nodeid resetDb inn
                                       , _chainwebMiner = m
                                       , _chainwebCoordinator = mc
                                       , _chainwebHeaderStream =
-                                          HeaderStream $ _configBlockStream conf
+                                          HeaderStream $ _configHeaderStream conf
                                       , _chainwebLogger = logger
                                       , _chainwebPeer = peer
                                       , _chainwebPayloadDb = payloadDb

--- a/tools/standalone/Standalone/Chainweb.hs
+++ b/tools/standalone/Standalone/Chainweb.hs
@@ -36,6 +36,7 @@ import System.LogLevel
 
 import Chainweb.BlockHeader
 import Chainweb.BlockHeaderDB
+import Chainweb.BlockHeaderDB.RestAPI (HeaderStream(..))
 import Chainweb.Chainweb
 import Chainweb.Chainweb.ChainResources
 import Chainweb.Chainweb.CutResources
@@ -251,6 +252,8 @@ withChainwebInternalStandalone conf logger peer rocksDb dbDir nodeid resetDb inn
                                       , _chainwebCutResources = cuts
                                       , _chainwebMiner = m
                                       , _chainwebCoordinator = mc
+                                      , _chainwebHeaderStream =
+                                          HeaderStream $ _configBlockStream conf
                                       , _chainwebLogger = logger
                                       , _chainwebPeer = peer
                                       , _chainwebPayloadDb = payloadDb


### PR DESCRIPTION
This PR adds an endpoint that sends a stream of `BlockHeader`s as Server-Sent Events for consumption by our block explorer.

Can be tested with:
```
chainweb-node --chainweb-version=development --port=8082 --log-level=warn --header-stream

curl -k -v https://localhost:8082/chainweb/0.0/development/header/updates
```