### PR TITLE
Avoid rewind when input to LookupPactTxs is empty

### DIFF
--- a/src/Chainweb/Chainweb.hs
+++ b/src/Chainweb/Chainweb.hs
@@ -366,10 +366,11 @@ validatingMempoolConfig
     -> MVar PactExecutionService
     -> Mempool.InMemConfig ChainwebTransaction
 validatingMempoolConfig cid cutmv mv = Mempool.InMemConfig
-    txcfg
-    blockGasLimit
-    maxRecentLog
-    preInsertCheck
+    { Mempool._inmemTxCfg = txcfg
+    , Mempool._inmemTxBlockSizeLimit = blockGasLimit
+    , Mempool._inmemMaxRecentItems = maxRecentLog
+    , Mempool._inmemPreInsertCheck = preInsertCheck
+    }
   where
     txcfg = Mempool.chainwebTransactionConfig
     blockGasLimit = 100000

--- a/src/Chainweb/Pact/PactService.hs
+++ b/src/Chainweb/Pact/PactService.hs
@@ -694,7 +694,7 @@ rewindTo mb = do
             Just x -> return x
             Nothing -> do
                 logInfo $ "exception during rewind to "
-                    <> sshow (newH, parentHash) <> ". Failed to look last hash "
+                    <> sshow (newH, parentHash) <> ". Failed to look up last hash "
                     <> sshow (height, hash) <> " in block header db. Continuing with parent."
                 liftIO (_cpGetBlockParent cp (height, hash)) >>= \case
                     Nothing -> throwM $ BlockValidationFailure
@@ -830,11 +830,13 @@ execLookupPactTxs
     => T2 BlockHeight BlockHash
     -> Vector P.PactHash
     -> PactServiceM cas (Vector (Maybe (T2 BlockHeight BlockHash)))
-execLookupPactTxs (T2 leafHeight leafHash) txs =
-    withCheckpointerRewind (Just (leafHeight + 1, leafHash))
-                           "lookupPactTxs" $ \_pdbenv -> do
-        cp <- getCheckpointer
-        fmap Discard $ liftIO $ V.mapM (_cpLookupProcessedTx cp) txs
+execLookupPactTxs (T2 leafHeight leafHash) txs
+    | null txs = return mempty
+    | otherwise
+        = withCheckpointerRewind (Just (leafHeight + 1, leafHash)) "lookupPactTxs"
+            $ \_pdbenv -> do
+                cp <- getCheckpointer
+                fmap Discard $ liftIO $ V.mapM (_cpLookupProcessedTx cp) txs
 
 getCheckpointer :: PactServiceM cas Checkpointer
 getCheckpointer = view (psCheckpointEnv . cpeCheckpointer)


### PR DESCRIPTION
<img width="810" alt="image" src="https://user-images.githubusercontent.com/1369810/65649785-df04f300-dfbc-11e9-8f90-ffc55679285e.png">

This PR was deployed on `us1.tn1.chainweb.com` at 00:32. The node caught up ~10,000 blocks and joined consensus with the network within eight minutes.