### PR TITLE
Reject Payloads by Version Incompat

### DIFF
--- a/src/Chainweb/Pact/RestAPI/Server.hs
+++ b/src/Chainweb/Pact/RestAPI/Server.hs
@@ -63,6 +63,7 @@ import System.LogLevel
 
 -- internal modules
 
+import Chainweb.Pact.TransactionExec (networkIdOf)
 import Pact.Types.API
 import qualified Pact.Types.ChainId as Pact
 import Pact.Types.Command
@@ -181,7 +182,7 @@ sendHandler
     -> Handler RequestKeys
 sendHandler logger v mempool (SubmitBatch cmds) = Handler $ do
     liftIO $ logg Info (PactCmdLogSend cmds)
-    case traverse (validateCommand v) cmds of  -- TODO
+    case traverse (validateCommand v) cmds of
       Right enriched -> do
         let txs = V.fromList $ NEL.toList enriched
         -- if any of the txs in the batch fail validation, we punt on the whole
@@ -440,4 +441,4 @@ validateCommand v cmdText = case verifyCommand cmdBS of
     cmdBS = encodeUtf8 <$> cmdText
 
     payloadVer :: Command (Payload m c) -> Maybe ChainwebVersion
-    payloadVer = (>>= fromText . Pact._networkId) . _pNetworkId . _cmdPayload
+    payloadVer = networkIdOf >=> fromText . Pact._networkId

--- a/src/Chainweb/Pact/RestAPI/Server.hs
+++ b/src/Chainweb/Pact/RestAPI/Server.hs
@@ -61,6 +61,8 @@ import Servant
 
 import System.LogLevel
 
+import Text.Printf (printf)
+
 -- internal modules
 
 import Chainweb.Pact.TransactionExec (networkIdOf)
@@ -432,9 +434,12 @@ toPactTx (Transaction b) = decodeStrict' b
 validateCommand :: ChainwebVersion -> Command Text -> Either String ChainwebTransaction
 validateCommand v cmdText = case verifyCommand cmdBS of
     ProcSucc cmd
-        | length (_cmdSigs cmd) > 100 -> Left "More than 100 signatures given."
-        | payloadVer cmd /= Just v -> Left "Incompatible ChainwebVersion given."
-        | otherwise -> Right (mkPayloadWithText <$> cmd)
+        | length (_cmdSigs cmd) > 100 ->
+            Left "More than 100 signatures given."
+        | payloadVer cmd /= Just v ->
+            Left $ printf "Incompatible Network. Given: %s, Expected: %s " (show $ networkIdOf cmd) (show v)
+        | otherwise ->
+            Right (mkPayloadWithText <$> cmd)
     ProcFail err -> Left err
   where
     cmdBS :: Command ByteString


### PR DESCRIPTION
This PR prevents Payloads that report the wrong `ChainwebVersion` to be rejected before even reaching the mempool.