### PR TITLE
Use sane retry logic in pact remote tests

### DIFF
--- a/chainweb.cabal
+++ b/chainweb.cabal
@@ -456,6 +456,7 @@ test-suite chainweb-tests
         , reflection >= 2.1
         , resource-pool >= 0.2
         , resourcet >= 1.2
+        , retry >= 0.7
         , scheduler >= 1.4
         , servant >= 0.14
         , servant-client >= 0.14

--- a/test/Chainweb/Test/Pact/RemotePactTest.hs
+++ b/test/Chainweb/Test/Pact/RemotePactTest.hs
@@ -1,17 +1,11 @@
 {-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MultiWayIf #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TypeOperators #-}
-{-# LANGUAGE AllowAmbiguousTypes #-}
-{-# LANGUAGE DataKinds #-}
-{-# LANGUAGE KindSignatures #-}
-{-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE QuasiQuotes #-}
-{-# LANGUAGE LambdaCase #-}
-{-# LANGUAGE GADTs #-}
-{-# LANGUAGE CPP #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 
 -- |
 -- Module: Chainweb.Test.RemotePactTest

--- a/test/Chainweb/Test/Pact/RemotePactTest.hs
+++ b/test/Chainweb/Test/Pact/RemotePactTest.hs
@@ -340,7 +340,7 @@ polling api cenv rks =
         Right r@(PollResponses mp) ->
           if all (go mp) (toList rs)
           then return r
-          else fail "polling check failed"
+          else throwM $ PollingFailure "polling check failed"
   where
     rs = _rkRequestKeys rks
 

--- a/test/Chainweb/Test/Pact/RemotePactTest.hs
+++ b/test/Chainweb/Test/Pact/RemotePactTest.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE BangPatterns #-}
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE MultiWayIf #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
@@ -95,9 +94,6 @@ import Chainweb.NodeId
 import Chainweb.Pact.RestAPI
 import Chainweb.Pact.RestAPI.Client
 import Chainweb.Pact.Service.Types
-#if ! MIN_VERSION_servant(0,16,0)
-import Chainweb.RestAPI.Utils
-#endif
 import Chainweb.Test.P2P.Peer.BootstrapConfig
 import Chainweb.Test.Pact.Utils
 import Chainweb.Test.Utils

--- a/test/Chainweb/Test/Pact/Utils.hs
+++ b/test/Chainweb/Test/Pact/Utils.hs
@@ -141,6 +141,7 @@ data PactTestFailure
     = PollingFailure String
     | SendFailure String
     | LocalFailure String
+    | SpvFailure String
     deriving Show
 
 instance Exception PactTestFailure

--- a/test/Chainweb/Test/Pact/Utils.hs
+++ b/test/Chainweb/Test/Pact/Utils.hs
@@ -16,8 +16,10 @@
 --
 -- Unit test for Pact execution via (inprocess) API  in Chainweb
 module Chainweb.Test.Pact.Utils
-( -- * test data
-  someED25519Pair
+( -- * Exceptions
+  PactTestFailure(..)
+  -- * test data
+, someED25519Pair
 , testPactFilesDir
 , testKeyPairs
 , adminData
@@ -130,6 +132,21 @@ import qualified Chainweb.Version as Version
 import Chainweb.WebBlockHeaderDB.Types
 import Chainweb.WebPactExecutionService
 import Chainweb.Test.Utils
+
+
+-- ----------------------------------------------------------------------- --
+-- Test Exceptions
+
+data PactTestFailure
+    = PollingFailure String
+    | SendFailure String
+    | LocalFailure String
+    deriving Show
+
+instance Exception PactTestFailure
+
+-- ----------------------------------------------------------------------- --
+-- Keys
 
 testKeyPairs :: IO [SomeKeyPairCaps]
 testKeyPairs = do


### PR DESCRIPTION
This fixes some nondeterminism problems we've been seeing in tests and obliterates our use of `sleep` when retrying!