### PR TITLE
Mempool Validation: Detect Empty Vectors

### DIFF
--- a/src/Chainweb/Mempool/InMem.hs
+++ b/src/Chainweb/Mempool/InMem.hs
@@ -219,7 +219,9 @@ insertCheckInMem
     -> MVar (InMemoryMempoolData t)  -- ^ in-memory state
     -> Vector t  -- ^ new transactions
     -> IO (Either (T2 TransactionHash InsertError) ())
-insertCheckInMem cfg lock txs = do
+insertCheckInMem cfg lock txs
+  | V.null txs = pure $ Right ()
+  | otherwise = do
     now <- getCurrentTimeIntegral
     badmap <- withMVarMasked lock $ readIORef . _inmemBadMap
 
@@ -280,7 +282,9 @@ insertCheckInMem'
     -> MVar (InMemoryMempoolData t)  -- ^ in-memory state
     -> Vector t  -- ^ new transactions
     -> IO (Vector (T2 TransactionHash t))
-insertCheckInMem' cfg lock txs = do
+insertCheckInMem' cfg lock txs
+  | V.null txs = pure V.empty
+  | otherwise = do
     now <- getCurrentTimeIntegral
     badmap <- withMVarMasked lock $ readIORef . _inmemBadMap
 


### PR DESCRIPTION
This PR detects empty Vectors entering the validation logic and exits before redundant checks involving IO are performed. This better suits the low/no TX volume case.