### PR TITLE
Rename two types

### DIFF
--- a/src/Chainweb/Chainweb/ChainResources.hs
+++ b/src/Chainweb/Chainweb/ChainResources.hs
@@ -87,7 +87,7 @@ data ChainResources logger = ChainResources
     { _chainResPeer :: !(PeerResources logger)
     , _chainResBlockHeaderDb :: !BlockHeaderDb
     , _chainResLogger :: !logger
-    , _chainResMempool :: !(MempoolBackend ChainwebTransaction)
+    , _chainResMempool :: !(MempoolBackend ChainwebTX)
     , _chainResPact :: PactExecutionService
     }
 
@@ -115,7 +115,7 @@ withChainResources
     -> RocksDb
     -> PeerResources logger
     -> logger
-    -> (MVar PactExecutionService -> Mempool.InMemConfig ChainwebTransaction)
+    -> (MVar PactExecutionService -> Mempool.InMemConfig ChainwebTX)
     -> MVar (CutDb cas)
     -> PayloadDb cas
     -> Bool

--- a/src/Chainweb/Mempool/Consensus.hs
+++ b/src/Chainweb/Mempool/Consensus.hs
@@ -57,7 +57,7 @@ data MempoolConsensus t = MempoolConsensus
     , mpcProcessFork
           :: LogFunction
           -> BlockHeader
-          -> IO (Vector ChainwebTransaction, Vector ChainwebTransaction)
+          -> IO (Vector ChainwebTX, Vector ChainwebTX)
     }
 
 data ReintroducedTxsLog = ReintroducedTxsLog
@@ -100,7 +100,7 @@ processFork
     -> IORef (Maybe BlockHeader)
     -> LogFunction
     -> BlockHeader
-    -> IO (Vector ChainwebTransaction, Vector ChainwebTransaction)
+    -> IO (Vector ChainwebTX, Vector ChainwebTX)
 processFork blockHeaderDb payloadStore lastHeaderRef logFun newHeader = do
     lastHeader <- readIORef lastHeaderRef
     (a, b) <- processFork' logFun blockHeaderDb newHeader lastHeader

--- a/src/Chainweb/Mempool/InMemTypes.hs
+++ b/src/Chainweb/Mempool/InMemTypes.hs
@@ -39,7 +39,7 @@ import Chainweb.Mempool.Mempool
 import Chainweb.Time (Micros(..), Time(..))
 
 ------------------------------------------------------------------------------
-type PendingMap = HashMap TransactionHash SB.ShortByteString
+type PendingMap = HashMap TXHash SB.ShortByteString
 
 ------------------------------------------------------------------------------
 -- | Configuration for in-memory mempool.
@@ -49,8 +49,8 @@ data InMemConfig t = InMemConfig {
   , _inmemMaxRecentItems :: {-# UNPACK #-} !Int
   , _inmemPreInsertPureChecks :: t -> Either InsertError t
   , _inmemPreInsertBatchChecks
-        :: V.Vector (T2 TransactionHash t)
-        -> IO (V.Vector (Either (T2 TransactionHash InsertError) (T2 TransactionHash t)))
+        :: V.Vector (T2 TXHash t)
+        -> IO (V.Vector (Either (T2 TXHash InsertError) (T2 TXHash t)))
 }
 
 ------------------------------------------------------------------------------
@@ -62,7 +62,7 @@ data InMemoryMempool t = InMemoryMempool {
 
 
 ------------------------------------------------------------------------------
-type BadMap = HashMap TransactionHash (Time Micros)
+type BadMap = HashMap TXHash (Time Micros)
 
 ------------------------------------------------------------------------------
 data InMemoryMempoolData t = InMemoryMempoolData {
@@ -73,7 +73,7 @@ data InMemoryMempoolData t = InMemoryMempoolData {
 }
 
 ------------------------------------------------------------------------------
-type RecentItem = T2 MempoolTxId TransactionHash
+type RecentItem = T2 MempoolTxId TXHash
 data RecentLog = RecentLog {
     _rlNext :: {-# UNPACK #-} !MempoolTxId
   , _rlRecent :: !(V.Vector RecentItem)

--- a/src/Chainweb/Mempool/RestAPI.hs
+++ b/src/Chainweb/Mempool/RestAPI.hs
@@ -72,7 +72,7 @@ someMempoolVal v cid m =
 ------------------------------------------------------------------------------
 -- pending transactions
 data PendingTransactions = PendingTransactions
-    { _pendingTransationsHashes :: ![TransactionHash]
+    { _pendingTransationsHashes :: ![TXHash]
     , _pendingTransactionsHighwaterMark :: !HighwaterMark
     }
     deriving (Show, Eq, Ord, Generic)
@@ -103,10 +103,10 @@ type MempoolInsertApi v c =
     ReqBody '[JSON] [Text] :> Put '[JSON] NoContent
 type MempoolMemberApi v c =
     'ChainwebEndpoint v :> MempoolEndpoint c :> "member" :>
-    ReqBody '[JSON] [TransactionHash] :> Post '[JSON] [Bool]
+    ReqBody '[JSON] [TXHash] :> Post '[JSON] [Bool]
 type MempoolLookupApi v c =
     'ChainwebEndpoint v :> MempoolEndpoint c :> "lookup" :>
-    ReqBody '[JSON] [TransactionHash] :> Post '[JSON] [LookupResult Text]
+    ReqBody '[JSON] [TXHash] :> Post '[JSON] [LookupResult Text]
 type MempoolGetPendingApi v c =
     'ChainwebEndpoint v :> MempoolEndpoint c :> "getPending" :>
     QueryParam "nonce" ServerNonce :>

--- a/src/Chainweb/Mempool/RestAPI/Client.hs
+++ b/src/Chainweb/Mempool/RestAPI/Client.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
-{-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
@@ -108,14 +107,14 @@ insertClient txcfg v c k0 = runIdentity $ do
 memberClient_
     :: forall (v :: ChainwebVersionT) (c :: ChainIdT)
     . (KnownChainwebVersionSymbol v, KnownChainIdSymbol c)
-    => [TransactionHash]
+    => [TXHash]
     -> ClientM [Bool]
 memberClient_ = client (mempoolMemberApi @v @c)
 
 memberClient
   :: ChainwebVersion
   -> ChainId
-  -> [TransactionHash]
+  -> [TXHash]
   -> ClientM [Bool]
 memberClient v c txs = runIdentity $ do
     SomeChainwebVersionT (_ :: Proxy v) <- return $ someChainwebVersionVal v
@@ -127,7 +126,7 @@ memberClient v c txs = runIdentity $ do
 lookupClient_
     :: forall (v :: ChainwebVersionT) (c :: ChainIdT)
     . (KnownChainwebVersionSymbol v, KnownChainIdSymbol c)
-    => [TransactionHash]
+    => [TXHash]
     -> ClientM [LookupResult T.Text]
 lookupClient_ = client (mempoolLookupApi @v @c)
 
@@ -135,7 +134,7 @@ lookupClient
   :: TransactionConfig t
   -> ChainwebVersion
   -> ChainId
-  -> [TransactionHash]
+  -> [TXHash]
   -> ClientM [LookupResult t]
 lookupClient txcfg v c txs = do
     SomeChainwebVersionT (_ :: Proxy v) <- return $ someChainwebVersionVal v

--- a/src/Chainweb/Mempool/RestAPI/Server.hs
+++ b/src/Chainweb/Mempool/RestAPI/Server.hs
@@ -48,7 +48,7 @@ insertHandler mempool txsT = handleErrs (NoContent <$ begin)
         liftIO $ mempoolInsert mempool CheckedInsert txV
 
 
-memberHandler :: Show t => MempoolBackend t -> [TransactionHash] -> Handler [Bool]
+memberHandler :: Show t => MempoolBackend t -> [TXHash] -> Handler [Bool]
 memberHandler mempool txs = handleErrs (liftIO mem)
   where
     txV = V.fromList txs
@@ -58,7 +58,7 @@ memberHandler mempool txs = handleErrs (liftIO mem)
 lookupHandler
     :: Show t
     => MempoolBackend t
-    -> [TransactionHash]
+    -> [TXHash]
     -> Handler [LookupResult T.Text]
 lookupHandler mempool txs = handleErrs (liftIO look)
   where

--- a/src/Chainweb/Pact/Backend/Types.hs
+++ b/src/Chainweb/Pact/Backend/Types.hs
@@ -118,12 +118,11 @@ import Pact.Parse (ParsedDecimal(..))
 import Pact.Persist.SQLite (Pragma(..), SQLiteConfig(..))
 import Pact.PersistPactDb (DbEnv(..))
 import Pact.Types.ChainMeta (PublicData(..))
+import Pact.Types.Gas (GasModel)
 import qualified Pact.Types.Hash as P
 import Pact.Types.Logger (Logger(..), Logging(..))
 import Pact.Types.Runtime
-    (ExecutionMode(..), PactDb(..), TableName(..), TxId(..),
-    TxLog(..))
-import Pact.Types.Gas (GasModel)
+    (ExecutionMode(..), PactDb(..), TableName(..), TxId(..), TxLog(..))
 import Pact.Types.SPV
 
 -- internal modules
@@ -328,11 +327,11 @@ type PactServiceM cas = ReaderT (PactServiceEnv cas) (StateT PactServiceState IO
 -- TODO: get rid of this shim, it's probably not necessary
 data MemPoolAccess = MemPoolAccess
   { mpaGetBlock
-        :: MempoolPreBlockCheck ChainwebTransaction
+        :: MempoolPreBlockCheck ChainwebTX
         -> BlockHeight
         -> BlockHash
         -> BlockHeader
-        -> IO (Vector ChainwebTransaction)
+        -> IO (Vector ChainwebTX)
   , mpaSetLastHeader :: BlockHeader -> IO ()
   , mpaProcessFork :: BlockHeader -> IO ()
   }

--- a/src/Chainweb/Pact/RestAPI/Server.hs
+++ b/src/Chainweb/Pact/RestAPI/Server.hs
@@ -78,7 +78,7 @@ import Chainweb.Cut
 import qualified Chainweb.CutDB as CutDB
 import Chainweb.Logger
 import Chainweb.Mempool.Mempool
-    (InsertError, InsertType(..), MempoolBackend(..), TransactionHash(..))
+    (InsertError, InsertType(..), MempoolBackend(..), TXHash(..))
 import Chainweb.Pact.RestAPI
 import Chainweb.Pact.Service.Types
 import Chainweb.Pact.SPV
@@ -88,7 +88,7 @@ import Chainweb.RestAPI.Orphans ()
 import Chainweb.RestAPI.Utils
 import Chainweb.SPV (SpvException(..))
 import Chainweb.SPV.CreateProof
-import Chainweb.Transaction (ChainwebTransaction, mkPayloadWithText)
+import Chainweb.Transaction (ChainwebTX, mkPayloadWithText)
 import qualified Chainweb.TreeDB as TreeDB
 import Chainweb.Utils
 import Chainweb.Version
@@ -174,7 +174,7 @@ data PactCmdLog
 sendHandler
     :: Logger logger
     => logger
-    -> MempoolBackend ChainwebTransaction
+    -> MempoolBackend ChainwebTX
     -> SubmitBatch
     -> Handler RequestKeys
 sendHandler logger mempool (SubmitBatch cmds) = Handler $ do
@@ -193,10 +193,10 @@ sendHandler logger mempool (SubmitBatch cmds) = Handler $ do
 
     logg = logFunctionJson (setComponent "send-handler" logger)
 
-    toPactHash :: TransactionHash -> Pact.TypedHash h
-    toPactHash (TransactionHash h) = Pact.TypedHash $ SB.fromShort h
+    toPactHash :: TXHash -> Pact.TypedHash h
+    toPactHash (TXHash h) = Pact.TypedHash $ SB.fromShort h
 
-    checkResult :: Either (T2 TransactionHash InsertError) () -> ExceptT ServerError IO ()
+    checkResult :: Either (T2 TXHash InsertError) () -> ExceptT ServerError IO ()
     checkResult (Right _) = pure ()
     checkResult (Left (T2 hash insErr)) =
         failWith $ concat [ "Validation failed for hash "
@@ -427,7 +427,7 @@ internalPoll cutR cid chain cut requestKeys0 = do
 toPactTx :: Transaction -> Maybe (Command Text)
 toPactTx (Transaction b) = decodeStrict' b
 
-validateCommand :: Command Text -> Either String ChainwebTransaction
+validateCommand :: Command Text -> Either String ChainwebTX
 validateCommand cmdText = case verifyCommand cmdBS of
     ProcSucc cmd -> Right (mkPayloadWithText <$> cmd)
     ProcFail err -> Left err

--- a/src/Chainweb/Pact/Service/BlockValidation.hs
+++ b/src/Chainweb/Pact/Service/BlockValidation.hs
@@ -61,7 +61,7 @@ validateBlock bHeader plData reqQ = do
     addRequest reqQ msg
     return resultVar
 
-local :: ChainwebTransaction -> PactQueue -> IO (MVar (Either PactException HashCommandResult))
+local :: ChainwebTX -> PactQueue -> IO (MVar (Either PactException HashCommandResult))
 local ct reqQ = do
     !resultVar <- newEmptyMVar
     let !msg = LocalMsg LocalReq

--- a/src/Chainweb/Pact/Service/PactInProcApi.hs
+++ b/src/Chainweb/Pact/Service/PactInProcApi.hs
@@ -59,7 +59,7 @@ withPactService
     => ChainwebVersion
     -> ChainId
     -> logger
-    -> MempoolConsensus ChainwebTransaction
+    -> MempoolConsensus ChainwebTX
     -> MVar (CutDb cas)
     -> BlockHeaderDb
     -> PayloadDb cas
@@ -114,7 +114,7 @@ pactQueueSize = 2000
 
 pactMemPoolAccess
     :: Logger logger
-    => MempoolConsensus ChainwebTransaction
+    => MempoolConsensus ChainwebTX
     -> logger
     -> MemPoolAccess
 pactMemPoolAccess mpc logger = MemPoolAccess
@@ -125,13 +125,13 @@ pactMemPoolAccess mpc logger = MemPoolAccess
 
 pactMemPoolGetBlock
     :: Logger logger
-    => MempoolConsensus ChainwebTransaction
+    => MempoolConsensus ChainwebTX
     -> logger
-    -> (MempoolPreBlockCheck ChainwebTransaction
+    -> (MempoolPreBlockCheck ChainwebTX
             -> BlockHeight
             -> BlockHash
             -> BlockHeader
-            -> IO (Vector ChainwebTransaction))
+            -> IO (Vector ChainwebTX))
 pactMemPoolGetBlock mpc theLogger validate height hash _bHeader = do
     logFn theLogger Info $! "pactMemPoolAccess - getting new block of transactions for "
         <> "height = " <> sshow height <> ", hash = " <> sshow hash
@@ -143,7 +143,7 @@ pactMemPoolGetBlock mpc theLogger validate height hash _bHeader = do
 
 pactProcessFork
     :: Logger logger
-    => MempoolConsensus ChainwebTransaction
+    => MempoolConsensus ChainwebTX
     -> logger
     -> (BlockHeader -> IO ())
 pactProcessFork mpc theLogger bHeader = do
@@ -166,10 +166,9 @@ pactProcessFork mpc theLogger bHeader = do
 
 pactMempoolSetLastHeader
     :: Logger logger
-    => MempoolConsensus ChainwebTransaction
+    => MempoolConsensus ChainwebTX
     -> logger
     -> (BlockHeader -> IO ())
 pactMempoolSetLastHeader mpc _theLogger bHeader = do
     let headerRef = mpcLastNewBlockParent mpc
     atomicWriteIORef headerRef (Just bHeader)
-

--- a/src/Chainweb/Pact/Service/Types.hs
+++ b/src/Chainweb/Pact/Service/Types.hs
@@ -85,7 +85,7 @@ data ValidateBlockReq = ValidateBlockReq
 instance Show ValidateBlockReq where show ValidateBlockReq{..} = show (_valBlockHeader, _valPayloadData)
 
 data LocalReq = LocalReq
-    { _localRequest :: ChainwebTransaction
+    { _localRequest :: ChainwebTX
     , _localResultVar :: PactExMVar HashCommandResult
     }
 instance Show LocalReq where show LocalReq{..} = show (_localRequest)

--- a/src/Chainweb/Transaction.hs
+++ b/src/Chainweb/Transaction.hs
@@ -8,7 +8,7 @@
 {-# LANGUAGE TemplateHaskell #-}
 
 module Chainweb.Transaction
-  ( ChainwebTransaction
+  ( ChainwebTX
   , HashableTrans(..)
   , PayloadWithText
   , payloadBytes
@@ -70,9 +70,9 @@ modifyPayloadWithText f pwt = mkPayloadWithText newPayload
     oldPayload = payloadObj pwt
     newPayload = f oldPayload
 
-type ChainwebTransaction = Command PayloadWithText
+type ChainwebTX = Command PayloadWithText
 
--- | Hashable newtype of ChainwebTransaction
+-- | Hashable newtype of ChainwebTX
 newtype HashableTrans a = HashableTrans { unHashable :: Command a }
     deriving (Eq, Functor, Ord)
 

--- a/src/Chainweb/WebPactExecutionService/Types.hs
+++ b/src/Chainweb/WebPactExecutionService/Types.hs
@@ -21,7 +21,7 @@ import Chainweb.Transaction
 data PactExecutionService = PactExecutionService
   { _pactValidateBlock :: BlockHeader -> PayloadData -> IO PayloadWithOutputs
   , _pactNewBlock :: Miner -> BlockHeader -> BlockCreationTime -> IO PayloadWithOutputs
-  , _pactLocal :: ChainwebTransaction -> IO (Either PactException HashCommandResult)
+  , _pactLocal :: ChainwebTX -> IO (Either PactException HashCommandResult)
   , _pactLookup
         :: Either ChainId BlockHeader    -- restore point. Left cid means we
                                          -- don't care about the restore point.

--- a/test/Chainweb/Test/Mempool.hs
+++ b/test/Chainweb/Test/Mempool.hs
@@ -119,9 +119,8 @@ instance Arbitrary MockTx where
       zero = Time.Time (Time.TimeSpan (Time.Micros 0))
 
 type BatchCheck =
-    Vector (T2 TransactionHash MockTx)
-    -> IO (V.Vector (Either (T2 TransactionHash InsertError)
-                            (T2 TransactionHash MockTx)))
+    Vector (T2 TXHash MockTx)
+    -> IO (V.Vector (Either (T2 TXHash InsertError) (T2 TXHash MockTx)))
 
 -- | We use an `MVar` so that tests can override/modify the instance's insert
 -- check for tests. To make quickcheck testing not take forever for remote, we
@@ -238,9 +237,8 @@ propPreInsert (txs, badTxs) gossipMV mempool =
         | otherwise = Right tx
 
     checkNotBad
-        :: Vector (T2 TransactionHash MockTx)
-        -> IO (V.Vector (Either (T2 TransactionHash InsertError)
-                                (T2 TransactionHash MockTx)))
+        :: Vector (T2 TXHash MockTx)
+        -> IO (V.Vector (Either (T2 TXHash InsertError) (T2 TXHash MockTx)))
     checkNotBad = pure . V.map (\(T2 h tx) -> bimap (T2 h) (T2 h) $ checkOne tx)
 
 

--- a/test/Chainweb/Test/Pact/ChainData.hs
+++ b/test/Chainweb/Test/Pact/ChainData.hs
@@ -98,10 +98,10 @@ chainDataTest t time =
 getTestBlock
     :: T.Text
     -> Time Integer
-    -> MempoolPreBlockCheck ChainwebTransaction
+    -> MempoolPreBlockCheck ChainwebTX
     -> BlockHeight
     -> BlockHash
-    -> IO (V.Vector ChainwebTransaction)
+    -> IO (V.Vector ChainwebTX)
 getTestBlock t txOrigTime _validate _bh _hash = do
     akp0 <- stockKey "sender00"
     kp0 <- mkKeyPairs [akp0]

--- a/test/Chainweb/Test/Pact/PactInProcApi.hs
+++ b/test/Chainweb/Test/Pact/PactInProcApi.hs
@@ -151,7 +151,7 @@ testEmptyMemPool = MemPoolAccess
     , mpaProcessFork = \_ -> return ()
     }
 
-_testLocal :: IO ChainwebTransaction
+_testLocal :: IO ChainwebTX
 _testLocal = do
     d <- adminData
     fmap (head . V.toList)

--- a/test/Chainweb/Test/Pact/SPV.hs
+++ b/test/Chainweb/Test/Pact/SPV.hs
@@ -262,7 +262,7 @@ type TransactionGenerator
     -> BlockHeight
     -> BlockHash
     -> BlockHeader
-    -> IO (Vector ChainwebTransaction)
+    -> IO (Vector ChainwebTX)
 
 type BurnGenerator
     = Time Integer -> MVar PactId -> Chainweb.ChainId -> Chainweb.ChainId -> IO TransactionGenerator

--- a/tools/standalone/Standalone/Chainweb.hs
+++ b/tools/standalone/Standalone/Chainweb.hs
@@ -96,7 +96,7 @@ withChainResourcesStandalone
     -> RocksDb
     -> PeerResources logger
     -> logger
-    -> (MVar PactExecutionService -> Mempool.InMemConfig ChainwebTransaction)
+    -> (MVar PactExecutionService -> Mempool.InMemConfig ChainwebTX)
     -> MVar (CutDb cas)
     -> PayloadDb cas
     -> Bool

--- a/tools/standalone/Standalone/Utils.hs
+++ b/tools/standalone/Standalone/Utils.hs
@@ -1,7 +1,6 @@
-{-# LANGUAGE BangPatterns #-}
-{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TypeApplications #-}
 
@@ -11,9 +10,9 @@
 module Standalone.Utils where
 
 import Control.Concurrent.STM
+import Control.Lens hiding ((.=))
 import Control.Monad
 import Control.Monad.Catch
-import Control.Lens hiding ((.=))
 
 import Data.Aeson
 import Data.ByteString (ByteString)
@@ -90,7 +89,7 @@ onlyCoinTransferMemPoolAccess cid blocksize = MemPoolAccess
     }
 
 defaultMemPoolAccess :: ChainId -> Int -> MemPoolAccess
-defaultMemPoolAccess cid blocksize  = MemPoolAccess
+defaultMemPoolAccess cid blocksize = MemPoolAccess
     { mpaGetBlock = \_preblockcheck height _hash _prevBlock ->
         makeBlock height cid blocksize ("(+ 1 2)", Nothing)
     , mpaSetLastHeader = const $ return ()
@@ -102,7 +101,7 @@ defaultMemPoolAccess cid blocksize  = MemPoolAccess
         -> ChainId
         -> Int
         -> (Text, Maybe Value)
-        -> IO (Vector.Vector ChainwebTransaction)
+        -> IO (Vector.Vector ChainwebTX)
     makeBlock height cidd n = Vector.replicateM n . go
         where
           go (c, d) = do
@@ -162,7 +161,7 @@ getTestBlock
     -- ^ chain id
     -> Int
     -- ^ number of transactions in a block
-    -> IO (Vector.Vector ChainwebTransaction)
+    -> IO (Vector.Vector ChainwebTX)
 getTestBlock cid blocksize = do
     let gen = do
           (sendera, senderb) <- distinctSenders
@@ -206,7 +205,7 @@ mkExecTransactions
       -- ^ time in seconds until creation (from offset)
     -> Vector.Vector (Text, PactTransaction)
       -- ^ the pact transactions with data to run
-    -> IO (Vector.Vector ChainwebTransaction)
+    -> IO (Vector.Vector ChainwebTX)
 mkExecTransactions cid ks nonce0 gas gasrate ttl ct txs = do
     nref <- newIORef (0 :: Int)
     traverse (go nref) txs


### PR DESCRIPTION
This PR does a simple find-and-replace on `ChainwebTransaction` and `TransactionHash` to combat some line length issues.