### PR TITLE
Revert "Fix handshake failures by pinning tls to 1.5.2 (#532)"

### DIFF
--- a/chainweb.cabal
+++ b/chainweb.cabal
@@ -354,7 +354,7 @@ library
         , text >= 1.2
         , these >= 1 && < 1.1
         , time >= 1.8
-        , tls >=1.5.2
+        , tls >=1.5
         , token-bucket >= 0.1
         , transformers >= 0.5
         , unordered-containers >= 0.2

--- a/overrides.nix
+++ b/overrides.nix
@@ -105,8 +105,8 @@ let # Working on getting this function upstreamed into nixpkgs, but
 
       tls = callHackageDirect {
         pkg = "tls";
-        ver = "1.5.2";
-        sha256 = "00bps2bmp3ahlfw6wf7ifnni8kn306bbzapqcgsallnpgzx62gp1";
+        ver = "1.5.1";
+        sha256 = "0rh7302v2swbbfkjp15mgvs5xhbzqd0id30rqpjhmawszr1hnnd1";
       };
 
       warp-tls = callHackageDirect {

--- a/stack.yaml
+++ b/stack.yaml
@@ -24,7 +24,7 @@ extra-deps:
 
   # --- Forced Upgrades --- #
   - generic-lens-1.2.0.0  # For generic newtype unwrapping
-  - tls-1.5.2
+  - tls-1.5.1
   - warp-tls-3.2.8        # To match `tls-1.5`
 
   # --- Custom Pins --- #


### PR DESCRIPTION
This reverts commit 719f993a875855401d9ecdff7515dc3667fec139.