### PR TITLE
Avoid `succ`

### DIFF
--- a/src/Chainweb/Miner/Core.hs
+++ b/src/Chainweb/Miner/Core.hs
@@ -126,7 +126,7 @@ mine _ orig@(Nonce o) (TargetBytes tbytes) (HeaderBytes hbytes) = do
                       -- check whether the nonce meets the target
                       fastCheckTarget trgPtr (castPtr pow) >>= \case
                           True -> writeIORef nonces (nv - o)
-                          False -> go (succ n)
+                          False -> go (Nonce $ nv + 1)
 
               -- Start inner mining loop
               go orig


### PR DESCRIPTION
This PR avoids `succ` in the core mining loop. `succ` is implemented as follows for `Word`:
```haskell
instance Enum Word where
    succ x
        | x /= maxBound = x + 1
        | otherwise     = succError "Word"
```
Our core mining loop doesn't care if the `Word` overflows, so all these `maxBound` comparisons are wasteful. 