### PR TITLE
Fix busted module caching in buyGas

### DIFF
--- a/src/Chainweb/Pact/TransactionExec.hs
+++ b/src/Chainweb/Pact/TransactionExec.hs
@@ -479,9 +479,8 @@ buyGas env cmd (Miner mid mks) supply mcache = go
     sender = view (cmdPayload . pMeta . pmSender) cmd
     initState = setModuleCache mcache $ initCapabilities [magic_GAS]
     interp = Interpreter $ \start end withRollback input ->
-      withRollback $ start (run input) >>= end
+      withRollback (put initState >> start (run input) >>= end)
     run input = do
-      put initState
       findPayer >>= \r -> case r of
         Nothing -> input
         Just withPayerCap -> withPayerCap input


### PR DESCRIPTION
Most likely reason for massive slowdown with transfer cmds