### PR TITLE
Correct reported Hash Rates

### DIFF
--- a/miner/Miner.hs
+++ b/miner/Miner.hs
@@ -336,7 +336,7 @@ cpu cpue tbytes hbytes = do
             n <- Nonce <$> MWC.uniform (envGen e)
             new <- usePowHash (version $ envArgs e) (\p -> mine p n tbytes) hbytes
             terminateWith sch new
-    writeIORef (envStats e) ns
+    writeIORef (envStats e) $ ns * fromIntegral (cores cpue)
     pure new
   where
     comp :: Comp


### PR DESCRIPTION
Much better. This is with 3 cores:
```
2019-10-21 09:44:07.874889: [info] Starting Miner.
2019-10-21 09:44:57.432390: [info] Chain 3: Mined block at Height 5619. (2.61 MH/s)
2019-10-21 09:45:55.567942: [info] Chain 3: Mined block at Height 5619. (3.08 MH/s)
2019-10-21 09:46:39.591234: [info] Chain 1: Mined block at Height 5620. (3.14 MH/s)
```
