### PR TITLE
Forward compatiblity with servant master

### DIFF
--- a/src/Chainweb/BlockHeaderDB/RestAPI.hs
+++ b/src/Chainweb/BlockHeaderDB/RestAPI.hs
@@ -334,7 +334,7 @@ headerApi = Proxy
 type HeaderPutApi_
     = "header"
     :> ReqBody '[JSON, JsonBlockHeaderObject, OctetStream] BlockHeader
-    :> PutNoContent '[JSON] NoContent
+    :> Verb 'PUT 204 '[JSON] NoContent
 
 -- | @PUT \/chainweb\/\<ApiVersion\>\/\<InstanceId\>\/chain\/\<ChainId\>\/header@
 --

--- a/src/Chainweb/CutDB/RestAPI.hs
+++ b/src/Chainweb/CutDB/RestAPI.hs
@@ -63,7 +63,7 @@ cutGetApi = Proxy
 
 type CutPutApi_
     = ReqBody '[JSON] CutHashes
-    :> PutNoContent '[JSON] NoContent
+    :> Verb 'PUT 204 '[JSON] NoContent
 
 type CutPutApi (v :: ChainwebVersionT)
     = 'ChainwebEndpoint v :> 'NetworkEndpoint 'CutNetworkT :> Reassoc CutPutApi_

--- a/src/P2P/Node/RestAPI.hs
+++ b/src/P2P/Node/RestAPI.hs
@@ -73,7 +73,7 @@ peerGetApi = Proxy
 type PeerPutApi_
     = "peer"
     :> ReqBody '[JSON] PeerInfo
-    :> PutNoContent '[JSON] NoContent
+    :> Verb 'PUT 204 '[JSON] NoContent
 
 type PeerPutApi (v :: ChainwebVersionT) (n :: NetworkIdT)
     = 'ChainwebEndpoint v :> 'NetworkEndpoint n :> Reassoc PeerPutApi_


### PR DESCRIPTION
With this change chainweb builds both with the released servant-0.16 versions *and* the current head of the `master` branch of servant.