### PR TITLE
[mempool] don't reintroduce old transactions

### DIFF
--- a/src/Chainweb/Mempool/InMem.hs
+++ b/src/Chainweb/Mempool/InMem.hs
@@ -17,6 +17,8 @@ module Chainweb.Mempool.InMem
     -- * Low-level create/destroy functions
   , makeInMemPool
   , newInMemMempoolData
+
+  , validateOne
   ) where
 
 ------------------------------------------------------------------------------

--- a/src/Chainweb/Pact/Service/PactInProcApi.hs
+++ b/src/Chainweb/Pact/Service/PactInProcApi.hs
@@ -59,7 +59,7 @@ withPactService
     => ChainwebVersion
     -> ChainId
     -> logger
-    -> MempoolConsensus ChainwebTransaction
+    -> MempoolConsensus
     -> MVar (CutDb cas)
     -> BlockHeaderDb
     -> PayloadDb cas
@@ -114,7 +114,7 @@ pactQueueSize = 2000
 
 pactMemPoolAccess
     :: Logger logger
-    => MempoolConsensus ChainwebTransaction
+    => MempoolConsensus
     -> logger
     -> MemPoolAccess
 pactMemPoolAccess mpc logger = MemPoolAccess
@@ -125,7 +125,7 @@ pactMemPoolAccess mpc logger = MemPoolAccess
 
 pactMemPoolGetBlock
     :: Logger logger
-    => MempoolConsensus ChainwebTransaction
+    => MempoolConsensus
     -> logger
     -> (MempoolPreBlockCheck ChainwebTransaction
             -> BlockHeight
@@ -143,7 +143,7 @@ pactMemPoolGetBlock mpc theLogger validate height hash _bHeader = do
 
 pactProcessFork
     :: Logger logger
-    => MempoolConsensus ChainwebTransaction
+    => MempoolConsensus
     -> logger
     -> (BlockHeader -> IO ())
 pactProcessFork mpc theLogger bHeader = do
@@ -166,7 +166,7 @@ pactProcessFork mpc theLogger bHeader = do
 
 pactMempoolSetLastHeader
     :: Logger logger
-    => MempoolConsensus ChainwebTransaction
+    => MempoolConsensus
     -> logger
     -> (BlockHeader -> IO ())
 pactMempoolSetLastHeader mpc _theLogger bHeader = do

--- a/test/Chainweb/Test/Mempool/Consensus.hs
+++ b/test/Chainweb/Test/Mempool/Consensus.hs
@@ -11,6 +11,7 @@ import Control.Monad.IO.Class
 
 import qualified Data.ByteString.Short as SB
 import Data.CAS.RocksDB
+import Data.Foldable (toList)
 import Data.Hashable
 import Data.HashMap.Strict (HashMap)
 import qualified Data.HashMap.Strict as HM
@@ -50,10 +51,12 @@ import Data.LogMessage
 tests :: BlockHeaderDb -> BlockHeader -> ScheduledTest
 tests db h0 = testGroupSch "mempool-consensus-quickcheck-tests"
     [ testProperty "valid-transactions-source" (prop_validTxSource db h0)
-    , testProperty "no-orphaned-txs" (prop_noOrphanedTxs db h0) ]
+    , testProperty "no-orphaned-txs" (prop_noOrphanedTxs db h0)
+    , testProperty "test-processfork-filter" (prop_noOldCrap db h0)
+    ]
 
 ----------------------------------------------------------------------------------------------------
--- | Poperty: All transactions returned by processFork (for re-introduction to the mempool) come from
+-- | Property: All transactions returned by processFork (for re-introduction to the mempool) come from
 --   the old fork and are not represented in the new fork blocks
 prop_validTxSource
     :: BlockHeaderDb
@@ -107,6 +110,27 @@ prop_noOrphanedTxs db genBlock = monadicIO $ do
     let expectedTrans = fiOldForkTrans `HS.difference` fiNewForkTrans
 
     assert $ expectedTrans `isSubsetOf` reIntroTrans
+
+
+----------------------------------------------------------------------------------------------------
+-- Tests filtering within processFork'.
+prop_noOldCrap
+    :: BlockHeaderDb
+    -> BlockHeader
+    -> Property
+prop_noOldCrap db genBlock = monadicIO $ do
+    -- tests filtering, in theory on age
+    mapRef <- liftIO $ newIORef (HM.empty :: HashMap BlockHeader (HashSet TransactionHash))
+    ForkInfo{..} <- genFork db mapRef genBlock
+    pre (length fiOldForkTrans > 0)
+    let badtx = head $ toList fiOldForkTrans
+    let badFilter = (/= badtx)
+    (reIntroTransV, _) <- run $ processFork' (alogFunction aNoLog) fiBlockHeaderDb
+                                    fiNewHeader (Just fiOldHeader) (lookupFunc mapRef)
+                                    badFilter
+    let reIntroTrans = HS.fromList $ V.toList reIntroTransV
+    assert $ not $ HS.member badtx reIntroTrans
+
 
 ----------------------------------------------------------------------------------------------------
 data ForkInfo = ForkInfo

--- a/test/Chainweb/Test/Mempool/Consensus.hs
+++ b/test/Chainweb/Test/Mempool/Consensus.hs
@@ -65,6 +65,7 @@ prop_validTxSource db genBlock = monadicIO $ do
 
     (reIntroTransV, _) <- run $ processFork' (alogFunction aNoLog) fiBlockHeaderDb
                                     fiNewHeader (Just fiOldHeader) (lookupFunc mapRef)
+                                    (const True)
     let reIntroTrans = HS.fromList $ V.toList reIntroTransV
 
     assert $ (reIntroTrans `isSubsetOf` fiOldForkTrans)
@@ -101,6 +102,7 @@ prop_noOrphanedTxs db genBlock = monadicIO $ do
 
     (reIntroTransV, _) <- run $ processFork' (alogFunction aNoLog) fiBlockHeaderDb
                                     fiNewHeader (Just fiOldHeader) (lookupFunc mapRef)
+                                    (const True)
     let reIntroTrans = HS.fromList $ V.toList reIntroTransV
     let expectedTrans = fiOldForkTrans `HS.difference` fiNewForkTrans
 


### PR DESCRIPTION
When resolving a fork, there's no reason to reintroduce transactions to the mempool that would already be expired if they were played now.