### PR TITLE
Output Keys as JSON

### DIFF
--- a/chainweb.cabal
+++ b/chainweb.cabal
@@ -654,6 +654,7 @@ executable chainweb-miner
           chainweb
 
         -- external
+        , aeson-pretty >= 0.8
         , base >= 4.11 && < 5
         , bytestring >= 0.10
         , connection >= 0.2

--- a/miner/Miner.hs
+++ b/miner/Miner.hs
@@ -62,6 +62,7 @@ module Main ( main ) where
 
 import Control.Retry
 import Control.Scheduler (Comp(..), replicateWork, terminateWith, withScheduler)
+import Data.Aeson.Encode.Pretty (encodePretty)
 import Data.Generics.Product.Fields (field)
 import qualified Data.List.NonEmpty as NEL
 import Data.Time.Clock.POSIX (POSIXTime, getPOSIXTime)
@@ -77,6 +78,7 @@ import RIO
 import qualified RIO.ByteString as B
 import qualified RIO.ByteString.Lazy as BL
 import RIO.List.Partial (head)
+import qualified RIO.Map as M
 import qualified RIO.Text as T
 import Servant.Client
 import qualified Streaming.Prelude as SP
@@ -259,8 +261,9 @@ scheme env = case envCmd env of
 genKeys :: IO ()
 genKeys = do
     kp <- genKeyPair defaultScheme
-    printf "public:  %s\n" (T.unpack . toB16Text $ getPublic kp)
-    printf "private: %s\n" (T.unpack . toB16Text $ getPrivate kp)
+    let publ = toB16Text $ getPublic kp
+        priv = toB16Text $ getPrivate kp
+    BL.putStrLn . encodePretty $ M.fromList [("public" :: Text, publ), ("private", priv)]
 
 -- | Attempt to get new work while obeying a sane retry policy.
 --

--- a/tools/ea/Ea.hs
+++ b/tools/ea/Ea.hs
@@ -122,7 +122,7 @@ main = do
         genPayloadModule v (tag <> "0") txs
 
     goM cid cs = for_ cs $ \(v, tag, txs) -> do
-        printf ("Generate Mainnet Genesis Payload for %s on Chain " <> T.unpack cid <> "...\n") $ show v
+        printf ("Generating Genesis Payload for %s on Chain " <> T.unpack cid <> "...\n") $ show v
         genPayloadModule v (tag <> cid) txs
 
     goN cs = for_ cs $ \(v, tag, txs) -> do


### PR DESCRIPTION
This formats the output of `chainweb-miner keys` as pretty-printed JSON for easy piping.
```
{
    "private": "3b6a1cce54d75d97b7615a7eac9299734d05d3efc2a1dc3ca2fbd8a60e7d1ebb",
    "public": "ec84dd34bf7aa1670df2f8cbbaf69f754c8456e6fb5c9ed8d8988d64043e9339"
}
```