### PR TITLE
Add chainweb miner as a nixos service

### DIFF
--- a/project.nix
+++ b/project.nix
@@ -27,7 +27,7 @@ in {
     overrides = import ./overrides.nix pactSrc pkgs hackGet;
 
     packages = {
-      chainweb = gitignoreSource [ ".gitlab-ci.yml" "*.md" "**/*.md" ] ./.;
+      chainweb = gitignoreSource [ ".gitlab-ci.yml" "*.md" "**/*.md" "*.nix" "**/.nix" ] ./.;
     };
 
     shellToolOverrides = ghc: super: {

--- a/project.nix
+++ b/project.nix
@@ -14,22 +14,20 @@ in
   (import pactProj {}).rp.project ({ pkgs, hackGet, ... }:
 let
 
-gitignoreSrc = pkgs.fetchFromGitHub {
-  owner = "hercules-ci";
-  repo = "gitignore";
-  rev = "f9e996052b5af4032fe6150bba4a6fe4f7b9d698";
-  sha256 = "0jrh5ghisaqdd0vldbywags20m2cxpkbbk5jjjmwaw0gr8nhsafv";
-};
-inherit (import gitignoreSrc { inherit (pkgs) lib; }) gitignoreSource;
+gitignoreSrc = pkgs.callPackage (pkgs.fetchFromGitHub {
+  owner = "Fresheyeball";
+  repo = "nix-gitignore";
+  rev = "d27bfb07dc63e36d5ea53f375f023f9ae49aea1d";
+  sha256 = "19j47sjxj2fm36y50gfx3kvyxwbiscja45gmbkb01vnqck80rlq6";
+}) {};
+inherit (gitignoreSrc) gitignoreSource;
 
 in {
     name = "chainweb";
     overrides = import ./overrides.nix pactSrc pkgs hackGet;
 
     packages = {
-      chainweb = gitignoreSource ./.;
-      #chainweb = gitignoreFilter
-      #  [ ".git" ".gitlab-ci.yml" "CHANGELOG.md" "README.md" "future-work.md" ] ./.;
+      chainweb = gitignoreSource [ ".gitlab-ci.yml" "*.md" "**/*.md" ] ./.;
     };
 
     shellToolOverrides = ghc: super: {

--- a/service.nix
+++ b/service.nix
@@ -1,0 +1,64 @@
+{ config, lib, pkgs, ...}: with lib;
+let cfg = config.services.chainweb-miner;
+    chainweb-miner = import ./.;
+in
+{
+  options = {
+    services.chainweb-miner = {
+      enable = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          Chainweb-miner, our dedicated Mining Client.
+          Work requests are sent to known Nodes, which construct blocks for the client.
+          Once solved, the client returns the block to the Node for submission to the wider network.
+          This client boasts much higher mining performance and a much simpler setup,
+          since a chainweb-miner has no database connections and thus no storage footprint.
+        '';
+      };
+      nodeHostname = mkOption {
+        type = types.string;
+        description = ''
+          Host name for the trusted node https://github.com/kadena-io/chainweb-node/wiki
+        '';
+      };
+      nodePort = mkOption {
+        type = types.port;
+        default = 443;
+        description = ''
+          Port number for the trused node https://github.com/kadena-io/chainweb-node/wiki
+        '';
+      };
+      account = mkOption {
+        type = types.string;
+        description = ''
+          Your miner account. This must be unowned, or already claimed by you!
+        '';
+      };
+      key = mkOption {
+        type = types.string;
+        description = ''
+          Your miner public key. https://github.com/kadena-io/chainweb-node/blob/master/miner/README.org#obtaining-a-key-pair
+        '';
+      };
+    };
+  };
+
+  config = {
+
+    systemd.services.chainweb-miner = mkIf cfg.enable {
+
+      serviceConfig = {
+        ExecStart = pkgs.writeShellScriptBin "chainweb-miner.sh" ''
+          ${chainweb-miner}/bin/chainweb-miner cpu --node=${cfg.nodeHostname}:${toString cfg.nodePort} --miner-account=${cfg.account} --miner-key=${cfg.key}
+        '' + "/bin/chainweb-miner.sh";
+      };
+
+      wantedBy = [ "multi-user.target" ];
+
+      after = [ "network.target" ];
+
+    };
+  };
+
+}

--- a/service.nix
+++ b/service.nix
@@ -35,6 +35,14 @@ in
           Your miner account. This must be unowned, or already claimed by you!
         '';
       };
+      chain = mkOption {
+        type = types.nullOr types.int;
+        default = null;
+        description = ''
+          Chain in focus https://github.com/kadena-io/chainweb-node/blob/master/miner/README.org#chain-focusing
+        '';
+
+      };
       key = mkOption {
         type = types.string;
         description = ''
@@ -50,7 +58,7 @@ in
 
       serviceConfig = {
         ExecStart = pkgs.writeShellScriptBin "chainweb-miner.sh" ''
-          ${chainweb-miner}/bin/chainweb-miner cpu --node=${cfg.nodeHostname}:${toString cfg.nodePort} --miner-account=${cfg.account} --miner-key=${cfg.key}
+          ${chainweb-miner}/bin/chainweb-miner cpu --node=${cfg.nodeHostname}:${toString cfg.nodePort} --miner-account=${cfg.account} --miner-key=${cfg.key} ${if cfg.chain == null then "" else "--chain=${cfg.chain}"}
         '' + "/bin/chainweb-miner.sh";
       };
 


### PR DESCRIPTION
I wanted to run the miner on my NixOS machine. Naturally that wasn't going to fly with `chainweb-miner --flags &`. It needs to be a systemd service. 

I added `service.nix` to the root of the project to serve as the provider for chain web components as systemd services. Currently I supported a naive implementation of `chainweb-miner` only. You can use this service like so.

```nix
let 
  chainweb-miner = builtins.fetchTarball { url = "https://github.com/Fresheyeball/chainweb-node/archive/master.tar.gz"; } + "/service.nix";
in {
  imports = [ chainweb-miner ];
  services.chainweb-miner = {
    enable = true;
    account = "<my account>";
    nodeHostname = "<my node>";
    key = "<my key>";
  };
}
```

---

Additionally you where using the hercules-ci fork of gitignore at root. This introduces unclean nix hash calculation in 2 ways.

1. The hash depends on the directory name in which the project is cloned
2. The hash depends on local user development environment including their home directory

This means your `nix-build` is not deterministic between computers. I moved you to my fork of gitignore in which both of these problems are resolved. Additionally you where no ignoring markdown or nix files, I addressed this as well.