### PR TITLE
Initial cut height limit and private flag

### DIFF
--- a/src/Chainweb/Chainweb.hs
+++ b/src/Chainweb/Chainweb.hs
@@ -270,6 +270,7 @@ data ChainwebConfiguration = ChainwebConfiguration
     , _configPruneChainDatabase :: !Bool
     , _configBlockGasLimit :: !Mempool.GasLimit
     , _configCutFetchTimeout :: !Int
+    , _configInitialCutHeightLimit :: !(Maybe BlockHeight)
     } deriving (Show, Eq, Generic)
 
 makeLenses ''ChainwebConfiguration
@@ -302,6 +303,7 @@ defaultChainwebConfiguration v = ChainwebConfiguration
     , _configPruneChainDatabase = True
     , _configBlockGasLimit = 100000
     , _configCutFetchTimeout = 3000000
+    , _configInitialCutHeightLimit = Nothing
     }
 
 instance ToJSON ChainwebConfiguration where
@@ -320,6 +322,7 @@ instance ToJSON ChainwebConfiguration where
         , "pruneChainDatabase" .= _configPruneChainDatabase o
         , "blockGasLimit" .= _configBlockGasLimit o
         , "cutFetchTimeout" .= _configCutFetchTimeout o
+        , "initialCutHeightLimit" .= _configInitialCutHeightLimit o
         ]
 
 instance FromJSON (ChainwebConfiguration -> ChainwebConfiguration) where
@@ -338,6 +341,7 @@ instance FromJSON (ChainwebConfiguration -> ChainwebConfiguration) where
         <*< configPruneChainDatabase ..: "pruneChainDatabase" % o
         <*< configBlockGasLimit ..: "blockGasLimit" % o
         <*< configCutFetchTimeout ..: "cutFetchTimeout" % o
+        <*< configInitialCutHeightLimit ..: "initialCutHeightLimit" % o
 
 pChainwebConfiguration :: MParser ChainwebConfiguration
 pChainwebConfiguration = id
@@ -376,6 +380,9 @@ pChainwebConfiguration = id
     <*< configCutFetchTimeout .:: option auto
         % long "cut-fetch-timeout"
         <> help "After this many microseconds, give up trying to sync a particular Cut"
+    <*< configInitialCutHeightLimit .:: fmap (Just . BlockHeight) % option auto
+        % long "initial-cut-height-limit"
+        <> help "The maximum size of the initial cut. We'll chose the largest available cut that is small than this number"
 
 -- -------------------------------------------------------------------------- --
 -- Chainweb Resources
@@ -644,6 +651,7 @@ withChainwebInternal conf logger peer rocksDb dbDir nodeid resetDb inner = do
         { _cutDbConfigLogLevel = Info
         , _cutDbConfigTelemetryLevel = Info
         , _cutDbConfigUseOrigin = _configIncludeOrigin conf
+        , _cutDbConfigInitialHeightLimit = _configInitialCutHeightLimit conf
         }
 
     synchronizePactDb :: HM.HashMap ChainId (ChainResources logger) -> CutDb cas -> IO ()

--- a/src/Chainweb/Cut.hs
+++ b/src/Chainweb/Cut.hs
@@ -42,6 +42,7 @@ module Chainweb.Cut
 , lookupCutM
 , forkDepth
 , limitCut
+, limitCutHeaders
 
 -- * Exceptions
 , CutException(..)
@@ -245,6 +246,18 @@ limitCut wdb h c
         fromJuste <$> seekAncestor db bh (min (int $ _blockHeight bh) (int ch))
         -- this is safe because it's guaranteed that the requested rank is
         -- smaller then the block height of the argument
+
+limitCutHeaders
+    :: HasCallStack
+    => WebBlockHeaderDb
+    -> BlockHeight
+        -- upper bound for the cut height. This is not a tight bound.
+    -> HM.HashMap ChainId BlockHeader
+    -> IO (HM.HashMap ChainId BlockHeader)
+limitCutHeaders whdb h ch = _cutHeaders <$> limitCut whdb h Cut
+    { _cutHeaders = ch
+    , _cutChainwebVersion = _chainwebVersion whdb
+    }
 
 -- -------------------------------------------------------------------------- --
 -- Genesis Cut

--- a/src/Chainweb/Cut.hs
+++ b/src/Chainweb/Cut.hs
@@ -251,7 +251,7 @@ limitCutHeaders
     :: HasCallStack
     => WebBlockHeaderDb
     -> BlockHeight
-        -- upper bound for the cut height. This is not a tight bound.
+        -- ^ upper bound for the cut height. This is not a tight bound.
     -> HM.HashMap ChainId BlockHeader
     -> IO (HM.HashMap ChainId BlockHeader)
 limitCutHeaders whdb h ch = _cutHeaders <$> limitCut whdb h Cut

--- a/src/Chainweb/CutDB.hs
+++ b/src/Chainweb/CutDB.hs
@@ -481,7 +481,7 @@ processCuts conf logFun headerStore payloadStore cutHashesStore queue cutVar = q
             <> ", got: " <> sshow (_cutHashesHeight x)
         return r
 
-    -- This could be problematic if there is a very lighweight fork that is far
+    -- This could be problematic if there is a very lightweight fork that is far
     -- ahead
     --
     isVeryOld x = do

--- a/src/Chainweb/CutDB.hs
+++ b/src/Chainweb/CutDB.hs
@@ -33,6 +33,7 @@ module Chainweb.CutDB
 , cutDbConfigLogLevel
 , cutDbConfigTelemetryLevel
 , cutDbConfigUseOrigin
+, cutDbConfigInitialHeightLimit
 , cutDbFetchTimeout
 , defaultCutDbConfig
 , farAheadThreshold
@@ -147,6 +148,7 @@ data CutDbConfig = CutDbConfig
     , _cutDbConfigTelemetryLevel :: !LogLevel
     , _cutDbConfigUseOrigin :: !Bool
     , _cutDbFetchTimeout :: !Int
+    , _cutDbConfigInitialHeightLimit :: !(Maybe BlockHeight)
     }
     deriving (Show, Eq, Ord, Generic)
 
@@ -161,6 +163,7 @@ defaultCutDbConfig v ft = CutDbConfig
     , _cutDbConfigTelemetryLevel = Warn
     , _cutDbConfigUseOrigin = True
     , _cutDbFetchTimeout = ft
+    , _cutDbConfigInitialHeightLimit = Nothing
     }
   where
     g = _chainGraph v
@@ -381,10 +384,13 @@ startCutDb config logfun headerStore payloadStore cutHashesStore = mask_ $ do
                     go it
                 Left e -> throwM e
                 Right hm -> do
-                    logg Debug $ "joining intial cut from cut db configuration with cut that was loaded from the database " <> sshow hm
+                    hm' <- case _cutDbConfigInitialHeightLimit config of
+                        Nothing -> return hm
+                        Just h -> limitCutHeaders wbhdb h hm
+                    logg Debug $ "joining intial cut from cut db configuration with cut that was loaded from the database " <> sshow hm'
                     joinIntoHeavier_
                         (_webBlockHeaderStoreCas headerStore)
-                        hm
+                        hm'
                         (_cutMap $ _cutDbConfigInitialCut config)
 
 -- | Stop the cut validation pipeline.
@@ -475,12 +481,17 @@ processCuts conf logFun headerStore payloadStore cutHashesStore queue cutVar = q
             <> ", got: " <> sshow (_cutHashesHeight x)
         return r
 
+    -- This could be problematic if there is a very lighweight fork that is far
+    -- ahead
+    --
     isVeryOld x = do
         !h <- _cutHeight <$> readTVarIO cutVar
         let r = int (_cutHashesHeight x) <= (int h - threshold)
         when r $ loggc Debug x "skip very old cut"
         return r
 
+    -- This should be based on weight
+    --
     isOld x = do
         curHashes <- cutToCutHashes Nothing <$> readTVarIO cutVar
         let r = all (>= (0 :: Int)) $ (HM.unionWith (-) `on` (fmap (int . fst) . _cutHashes)) curHashes x

--- a/src/P2P/Node.hs
+++ b/src/P2P/Node.hs
@@ -553,6 +553,7 @@ newSession conf node = do
     peerDb = _p2pNodePeerDb node
 
     syncFromPeer_ pinfo
+        | _p2pConfigPrivate conf = return True
         | _p2pNodeDoPeerSync node = syncFromPeer node pinfo
         | otherwise = return True
 
@@ -644,7 +645,9 @@ startPeerDb nids conf = do
     case _p2pConfigPeerDbFilePath conf of
         Just dbFilePath -> loadIntoPeerDb dbFilePath peerDb
         Nothing -> return ()
-    return peerDb
+    return $ if _p2pConfigPrivate conf
+        then makePeerDbPrivate peerDb
+        else peerDb
 
 -- | Stop a 'PeerDb', possibly persisting the db to a file.
 --

--- a/src/P2P/Node/Configuration.hs
+++ b/src/P2P/Node/Configuration.hs
@@ -85,7 +85,7 @@ data P2pConfiguration = P2pConfiguration
 
     , _p2pConfigPrivate :: !Bool
         -- ^ make this node private, so that it only communicates with the
-        -- initially configured know peers. Use this option with care, because
+        -- initially configured known peers. Use this option with care, because
         -- it may result in networks that are not well connected with the
         -- overall consensus.
     }
@@ -174,7 +174,7 @@ pP2pConfiguration networkId = id
         <> help ("when enabled the hard-coded bootstrap nodes for network are ignored")
     <*< p2pConfigPrivate .:: enableDisableFlag
         % prefixLong net "private"
-        <> help ("when enabled this node private and communicates only with the initially configured known peers")
+        <> help ("when enabled this node becomes private and communicates only with the initially configured known peers")
   where
     net = T.unpack . networkIdToText <$> networkId
 

--- a/src/P2P/Node/Configuration.hs
+++ b/src/P2P/Node/Configuration.hs
@@ -81,6 +81,13 @@ data P2pConfiguration = P2pConfiguration
         -- ^ the path where the peer database is persisted
 
     , _p2pConfigIgnoreBootstrapNodes :: !Bool
+        -- ^ ignore builtin bootstrap nodes.
+
+    , _p2pConfigPrivate :: !Bool
+        -- ^ make this node private, so that it only communicates with the
+        -- initially configured know peers. Use this option with care, because
+        -- it may result in networks that are not well connected with the
+        -- overall consensus.
     }
     deriving (Show, Eq, Generic)
 
@@ -90,7 +97,7 @@ instance Arbitrary P2pConfiguration where
     arbitrary = P2pConfiguration
         <$> arbitrary <*> arbitrary <*> arbitrary
         <*> arbitrary <*> arbitrary <*> arbitrary
-        <*> arbitrary
+        <*> arbitrary <*> arbitrary
 
 -- | These are acceptable values for both test and production chainwebs.
 --
@@ -108,6 +115,7 @@ defaultP2pConfiguration = P2pConfiguration
 
     , _p2pConfigPeerDbFilePath = Nothing
     , _p2pConfigIgnoreBootstrapNodes = False
+    , _p2pConfigPrivate = False
     }
 
 instance ToJSON P2pConfiguration where
@@ -119,6 +127,7 @@ instance ToJSON P2pConfiguration where
         , "peers" .= _p2pConfigKnownPeers o
         , "peerDbFilePath" .= _p2pConfigPeerDbFilePath o
         , "ignoreBootstrapNodes" .= _p2pConfigIgnoreBootstrapNodes o
+        , "private" .= _p2pConfigPrivate o
         ]
 
 instance FromJSON (P2pConfiguration -> P2pConfiguration) where
@@ -130,6 +139,7 @@ instance FromJSON (P2pConfiguration -> P2pConfiguration) where
         <*< p2pConfigKnownPeers . from leftMonoidalUpdate %.: "peers" % o
         <*< p2pConfigPeerDbFilePath ..: "peerDbFilePath" % o
         <*< p2pConfigIgnoreBootstrapNodes ..: "ignoreBootstrapNodes" % o
+        <*< p2pConfigPrivate ..: "private" % o
 
 instance FromJSON P2pConfiguration where
     parseJSON = withObject "P2pExampleConfig" $ \o -> P2pConfiguration
@@ -140,6 +150,7 @@ instance FromJSON P2pConfiguration where
         <*> o .: "peers"
         <*> o .: "peerDbFilePath"
         <*> o .: "ignoreBootstrapNodes"
+        <*> o .: "private"
 
 pP2pConfiguration :: Maybe NetworkId -> MParser P2pConfiguration
 pP2pConfiguration networkId = id
@@ -161,6 +172,9 @@ pP2pConfiguration networkId = id
     <*< p2pConfigIgnoreBootstrapNodes .:: enableDisableFlag
         % prefixLong net "ignore-bootstrap-nodes"
         <> help ("when enabled the hard-coded bootstrap nodes for network are ignored")
+    <*< p2pConfigPrivate .:: enableDisableFlag
+        % prefixLong net "private"
+        <> help ("when enabled this node private and communicates only with the initially configured known peers")
   where
     net = T.unpack . networkIdToText <$> networkId
 

--- a/src/P2P/Node/PeerDB.hs
+++ b/src/P2P/Node/PeerDB.hs
@@ -53,6 +53,7 @@ module P2P.Node.PeerDB
 , peerDbInsertSet
 , peerDbDelete
 , newEmptyPeerDb
+, makePeerDbPrivate
 , fromPeerEntryList
 , fromPeerInfoList
 
@@ -308,23 +309,23 @@ insertPeerEntryList l m = foldl' (flip addPeerEntry) m l
 -- -------------------------------------------------------------------------- --
 -- Peer Database
 
-data PeerDb = PeerDb (MVar ()) (TVar PeerSet)
+data PeerDb = PeerDb !Bool !(MVar ()) !(TVar PeerSet)
     deriving (Eq, Generic)
 
 peerDbSnapshot :: PeerDb -> IO PeerSet
-peerDbSnapshot (PeerDb _ var) = readTVarIO var
+peerDbSnapshot (PeerDb _ _ var) = readTVarIO var
 {-# INLINE peerDbSnapshot #-}
 
 peerDbSnapshotSTM :: PeerDb -> STM PeerSet
-peerDbSnapshotSTM (PeerDb _ var) = readTVar var
+peerDbSnapshotSTM (PeerDb _ _ var) = readTVar var
 {-# INLINE peerDbSnapshotSTM #-}
 
 peerDbSize :: PeerDb -> IO Natural
-peerDbSize (PeerDb _ var) = int . size <$!> readTVarIO var
+peerDbSize (PeerDb _ _ var) = int . size <$!> readTVarIO var
 {-# INLINE peerDbSize #-}
 
 peerDbSizeSTM :: PeerDb -> STM Natural
-peerDbSizeSTM (PeerDb _ var) = int . size <$!> readTVar var
+peerDbSizeSTM (PeerDb _ _ var) = int . size <$!> readTVar var
 {-# INLINE peerDbSizeSTM #-}
 
 -- | Adds new 'PeerInfo' values for a given chain id.
@@ -334,7 +335,8 @@ peerDbSizeSTM (PeerDb _ var) = int . size <$!> readTVar var
 -- contention.
 --
 peerDbInsert :: PeerDb -> NetworkId -> PeerInfo -> IO ()
-peerDbInsert (PeerDb lock var) nid i = withMVar lock
+peerDbInsert (PeerDb True _ _) _ _ = return ()
+peerDbInsert (PeerDb _ lock var) nid i = withMVar lock
     . const
     . atomically
     . modifyTVar' var
@@ -344,7 +346,7 @@ peerDbInsert (PeerDb lock var) nid i = withMVar lock
 -- | Delete a peer, identified by its host address, from the peer database.
 --
 peerDbDelete :: PeerDb -> PeerInfo -> IO ()
-peerDbDelete (PeerDb lock var) i = withMVar lock
+peerDbDelete (PeerDb _ lock var) i = withMVar lock
     . const
     . atomically
     . modifyTVar' var
@@ -352,7 +354,7 @@ peerDbDelete (PeerDb lock var) i = withMVar lock
 {-# INLINE peerDbDelete #-}
 
 fromPeerEntryList :: [PeerEntry] -> IO PeerDb
-fromPeerEntryList peers = PeerDb
+fromPeerEntryList peers = PeerDb False
     <$> newMVar ()
     <*> newTVarIO (fromList peers)
 
@@ -360,7 +362,8 @@ fromPeerInfoList :: NetworkId -> [PeerInfo] -> IO PeerDb
 fromPeerInfoList nid peers = fromPeerEntryList $ newPeerEntry nid <$> peers
 
 peerDbInsertList :: [PeerEntry] -> PeerDb -> IO ()
-peerDbInsertList peers (PeerDb lock var) =
+peerDbInsertList _ (PeerDb True _ _) = return ()
+peerDbInsertList peers (PeerDb _ lock var) =
     withMVar lock
         . const
         . atomically
@@ -368,19 +371,25 @@ peerDbInsertList peers (PeerDb lock var) =
         $ insertPeerEntryList peers
 
 peerDbInsertPeerInfoList :: NetworkId -> [PeerInfo] -> PeerDb -> IO ()
-peerDbInsertPeerInfoList nid ps = peerDbInsertList (newPeerEntry nid <$> ps)
+peerDbInsertPeerInfoList _ _ (PeerDb True _ _) = return ()
+peerDbInsertPeerInfoList nid ps db = peerDbInsertList (newPeerEntry nid <$> ps) db
 
 peerDbInsertPeerInfoList_ :: Bool -> NetworkId -> [PeerInfo] -> PeerDb -> IO ()
-peerDbInsertPeerInfoList_ sticky nid ps = peerDbInsertList (newPeerEntry_ sticky nid <$> ps)
+peerDbInsertPeerInfoList_ _ _ _ (PeerDb True _ _) = return ()
+peerDbInsertPeerInfoList_ sticky nid ps db = peerDbInsertList (newPeerEntry_ sticky nid <$> ps) db
 
 peerDbInsertSet :: S.Set PeerEntry -> PeerDb -> IO ()
-peerDbInsertSet = peerDbInsertList . F.toList
+peerDbInsertSet _ (PeerDb True _ _) = return ()
+peerDbInsertSet s db = peerDbInsertList (F.toList s) db
 
 newEmptyPeerDb :: IO PeerDb
-newEmptyPeerDb = PeerDb <$> newMVar () <*> newTVarIO mempty
+newEmptyPeerDb = PeerDb False <$> newMVar () <*> newTVarIO mempty
+
+makePeerDbPrivate :: PeerDb -> PeerDb
+makePeerDbPrivate (PeerDb _ lock var) = PeerDb True lock var
 
 updatePeerDb :: PeerDb -> HostAddress -> (PeerEntry -> PeerEntry) -> IO ()
-updatePeerDb (PeerDb lock var) a f
+updatePeerDb (PeerDb _ lock var) a f
     = withMVar lock . const . atomically . modifyTVar' var $ \s ->
         case getOne $ getEQ a s of
             Nothing -> s
@@ -421,7 +430,7 @@ storePeerDb f db = withOutputFile f $ \h ->
     peerDbSnapshot db >>= \sn -> BL.hPutStr h (encode $ toPeerSet sn)
 
 loadPeerDb :: FilePath -> IO PeerDb
-loadPeerDb f = PeerDb
+loadPeerDb f = PeerDb False
     <$> newMVar ()
     <*> (newTVarIO . fromPeerSet =<< decodeFileStrictOrThrow' f)
 

--- a/src/P2P/Node/PeerDB.hs
+++ b/src/P2P/Node/PeerDB.hs
@@ -309,7 +309,11 @@ insertPeerEntryList l m = foldl' (flip addPeerEntry) m l
 -- -------------------------------------------------------------------------- --
 -- Peer Database
 
-data PeerDb = PeerDb !Bool !(MVar ()) !(TVar PeerSet)
+data PeerDb = PeerDb
+    { _peerDbIsPrivate :: !Bool
+    , _peerDbLock :: !(MVar ())
+    , _peerDbPeerSet :: !(TVar PeerSet)
+    }
     deriving (Eq, Generic)
 
 peerDbSnapshot :: PeerDb -> IO PeerSet

--- a/tools/genconf/GenConf.hs
+++ b/tools/genconf/GenConf.hs
@@ -1,0 +1,142 @@
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TypeApplications #-}
+
+module GenConf where
+
+import Control.Lens
+
+import Data.Maybe
+import Data.Text (Text)
+import qualified Data.Text as T
+import qualified Data.Text.IO as T
+import qualified Data.Yaml as Y
+
+import System.Exit
+import System.IO
+import System.Directory
+import System.Process
+
+-- chainweb imports
+import Chainweb.Chainweb
+import Chainweb.HostAddress
+import Chainweb.Mempool.P2pConfig
+import Chainweb.Miner.Config
+import Chainweb.NodeId
+import Chainweb.Utils
+import Chainweb.Version
+
+import P2P.Node.Configuration
+import P2P.Peer
+
+-- three items to ask the user
+-- 1) ask for their hostname (or public ip address)
+-- 2) ask for a usable port number (test to see if this is actually open)
+-- 3) ask if they want mining coordination turned (the default for this value is yes)
+
+getUserInput ::
+     Show b
+  => String
+  -> Maybe b
+  -> (Text -> IO (Maybe b))
+  -> Maybe (b -> Either String b)
+  -> IO b
+getUserInput prompt defaultVal parse safetyCheck = do
+    putStr (prompt <> " ")
+    hFlush stdout
+    input' <- T.getLine
+    if T.null input' && isJust defaultVal
+      then return $ fromJust defaultVal
+      else do
+       p <- parse input'
+       case p of
+         Nothing -> do
+           putStrLn "Invalid Input, try again"
+           hFlush stdout
+           getUserInput prompt defaultVal parse safetyCheck
+         Just y -> case safetyCheck of
+           Nothing -> return y
+           Just f -> case f y of
+             Left err -> do
+               putStrLn err
+               hFlush stdout
+               getUserInput prompt defaultVal parse safetyCheck
+             Right y' -> return y'
+
+validate :: (a -> Bool) -> String -> Maybe (a -> Either String a)
+validate f msg = Just $ \a -> if f a then Right a else Left msg
+
+getConf :: IO ChainwebConfiguration
+getConf = do
+    ip <- getIP
+    hostname <- hostnameFromText ip
+    host <- getUserInput (hostMsg ip) (Just hostname) (const $ return Nothing) Nothing
+    port <- getUserInput portMsg (Just 443) (return . portFromText) Nothing
+    miningCord <- getUserInput mineCoordMsg (Just True) (return . yesorno2Bool) Nothing
+    return ChainwebConfiguration
+      { _configChainwebVersion = Mainnet01
+      , _configNodeId = NodeId 0 -- FIXME
+      , _configMiner = EnableConfig False defaultMinerConfig
+      , _configCoordinator = miningCord
+      , _configHeaderStream = False
+      , _configReintroTxs = True
+      , _configP2p = defaultP2pConfiguration
+                     & p2pConfigPeer . peerConfigAddr
+                     .~ HostAddress host port
+      , _configTransactionIndex = defaultEnableConfig defaultTransactionIndexConfig
+      , _configIncludeOrigin = True
+      , _configThrottling = defaultThrottlingConfig
+      , _configMempoolP2p = defaultEnableConfig defaultMempoolP2pConfig
+      , _configPruneChainDatabase = True
+      , _configBlockGasLimit = 100000
+      , _configCutFetchTimeout = 3000000
+      , _configInitialCutHeightLimit = Nothing
+      }
+  where
+    hostMsg ip = "What is your publicly reachable domain name / IP address (default: " <> T.unpack ip <> ")?"
+    portMsg = "Which port would you like to use (default: 443)?"
+    mineCoordMsg = "Would you like to turn mining coordination (default: yes)?"
+
+-- This was not exported by the Chainweb.Chainweb module
+defaultThrottlingConfig :: ThrottlingConfig
+defaultThrottlingConfig = ThrottlingConfig
+  { _throttlingRate = 50 -- per second
+  , _throttlingMiningRate = 2  -- per second
+  , _throttlingPeerRate = 11  -- per second, on for each p2p network
+  , _throttlingLocalRate = 0.1 -- per 10 seconds
+  }
+
+main :: IO ()
+main = do
+    conf <- getConf
+    exist <- doesFileExist defaultfile
+    case exist of
+      True ->
+        getUserInput msg (Just True) (return . yesorno2Bool) Nothing >>= \case
+          True -> writeStuff conf
+          False -> putStrLn "Not writing configuration file"
+      False -> writeStuff conf
+    exitSuccess
+  where
+    msg = "Would you like to write the configuration to " <> defaultfile <> "?"
+    defaultfile = "mainnet.yaml"
+    writeStuff c = do
+        Y.encodeFile defaultfile c
+        putStrLn ("Writing (possibly overwriting) configuration to file " <> defaultfile)
+
+yesorno2Bool :: Text -> Maybe Bool
+yesorno2Bool text =
+  case T.toLower text of
+    "yes" -> Just True
+    "no" -> Just False
+    _ -> Nothing
+
+checkIP :: Text -> IO (Maybe Hostname)
+checkIP ip = do
+    value <- getIP
+    if value == ip
+      then return $ hostnameFromText ip
+      else return Nothing
+
+getIP :: IO Text
+getIP = T.pack . (read @String) <$> readProcess "dig" (words "TXT +short o-o.myaddr.l.google.com @ns1.google.com") ""


### PR DESCRIPTION
* `private: true`: prevents the addition of any new peers to the PeerDb. The only peers that a private node connects to are the configured known peers. With this PR other nodes can still push cuts to a private node. PR #681 prevents unknown peers from pushing cuts.

* `initialCutHeightLimit`: When switching between forks, long rewinds are very expensive. Another issue is that a node that switches from fork `A` to `B` will go to `B` at a height larger than the current height an `A`. If the fork point is deep down it will attempt to do this in a single step, which might cause timeouts during rewind or pact replay (which doesn't cache intermediate states).

    This PR allows the user to provide an estimate of the fork point or any lower bound (0 is always a safe, but inefficient choice), to cause he node to start cut processing at a block height blow the fork point.

    Another benefit of this option is, that it allows a node to re-validate the history of the block chain from some point onwards. This verifies the consistency of the database and the chain.