### PR TITLE
Only allow small rewinds on new block

### DIFF
--- a/src/Chainweb/Pact/PactService.hs
+++ b/src/Chainweb/Pact/PactService.hs
@@ -898,11 +898,18 @@ rewindTo
 rewindTo mb = maybe rewindGenesis doRewind mb
   where
     rewindGenesis = return ()
-    doRewind (_, parentHash) = do
+    doRewind (reqHeight, parentHash) = do
         payloadDb <- asks _psPdb
         lastHeader <- findLatestValidBlock >>= maybe failNonGenesisOnEmptyDb return
+        failOnTooLowRequestedHeight lastHeader reqHeight
         bhDb <- asks _psBlockHeaderDb
         playFork bhDb payloadDb parentHash lastHeader
+
+    rewindLimit = 20
+
+    failOnTooLowRequestedHeight lastHeader reqHeight
+      | _blockHeight lastHeader - reqHeight > rewindLimit =
+
 
     failNonGenesisOnEmptyDb = fail "impossible: playing non-genesis block to empty DB"
 

--- a/src/Chainweb/Pact/PactService.hs
+++ b/src/Chainweb/Pact/PactService.hs
@@ -496,7 +496,7 @@ withCheckpointerRewind
     -> (PactDbEnv' -> PactServiceM cas (WithCheckpointerResult a))
     -> PactServiceM cas a
 withCheckpointerRewind target caller act = do
-    rewindTo target
+    rewindTo Nothing target
     withCheckpointer target caller act
 
 finalizeCheckpointer :: (Checkpointer -> IO ()) -> PactServiceM cas ()
@@ -693,11 +693,16 @@ execNewBlock mpAccess parentHeader miner creationTime =
   do
     updateMempool
     withDiscardedBatch $ do
-      rewindTo target
+      rewindTo newblockRewindLimit target
       newTrans <- withCheckpointer target "preBlock" doPreBlock
       withCheckpointer target "execNewBlock" (doNewBlock newTrans)
 
   where
+
+    -- This is intended to mitigate mining attempts during replay.
+    -- In theory we shouldn't need to rewind much ever, but values
+    -- less than this are failing in PactReplay test.
+    newblockRewindLimit = Just 8
 
     doPreBlock pdbenv = do
       cp <- getCheckpointer
@@ -889,26 +894,31 @@ playOneBlock currHeader plData pdbenv = do
 --
 rewindTo
     :: forall cas . PayloadCas cas
-    => Maybe (BlockHeight, ParentHash)
+    => Maybe BlockHeight
+        -- ^ if set, limit rewinds to this delta
+    -> Maybe (BlockHeight, ParentHash)
         -- ^ The block height @height@ to which to restore and the parent header
         -- @parentHeader@.
         --
         -- It holds that @(_blockHeight parentHeader == pred height)@
     -> PactServiceM cas ()
-rewindTo mb = maybe rewindGenesis doRewind mb
+rewindTo rewindLimit mb = maybe rewindGenesis doRewind mb
   where
     rewindGenesis = return ()
     doRewind (reqHeight, parentHash) = do
         payloadDb <- asks _psPdb
         lastHeader <- findLatestValidBlock >>= maybe failNonGenesisOnEmptyDb return
-        failOnTooLowRequestedHeight lastHeader reqHeight
+        failOnTooLowRequestedHeight rewindLimit lastHeader reqHeight
         bhDb <- asks _psBlockHeaderDb
         playFork bhDb payloadDb parentHash lastHeader
 
-    rewindLimit = 20
-
-    failOnTooLowRequestedHeight lastHeader reqHeight
-      | _blockHeight lastHeader - reqHeight > rewindLimit =
+    failOnTooLowRequestedHeight (Just limit) lastHeader reqHeight
+      | reqHeight + limit < lastHeight = -- need to stick with addition because Word64
+        throwM $ RewindLimitExceeded
+        ("Requested rewind exceeds limit (" <> sshow limit <> ")")
+        reqHeight lastHeight
+        where lastHeight = _blockHeight lastHeader
+    failOnTooLowRequestedHeight _ _ _ = return ()
 
 
     failNonGenesisOnEmptyDb = fail "impossible: playing non-genesis block to empty DB"

--- a/src/Chainweb/Pact/RestAPI/Server.hs
+++ b/src/Chainweb/Pact/RestAPI/Server.hs
@@ -338,6 +338,11 @@ spvHandler l cutR cid chainR (SpvRequest rk (Pact.ChainId ptid)) = do
     cut <- liftIO $! CutDB._cut cdb
     bh <- liftIO $! lookupCutM cid cut
 
+    -- TODO get rid of (Right bh) below, rewinding checkpointer for
+    -- this could cause much problems. Conversely, we could set the
+    -- max rewind limit for this case in PactService. But in any case
+    -- it would seem this is the wrong way to check for transaction
+    -- existence at a particular depth.
     T2 bhe _bha <- liftIO (_pactLookup pe (Right bh) (pure ph)) >>= \case
       Left e ->
         toErr $ "Internal error: transaction hash lookup failed: " <> sshow e

--- a/src/Chainweb/Pact/Service/Types.hs
+++ b/src/Chainweb/Pact/Service/Types.hs
@@ -49,6 +49,7 @@ data PactException
   | TransactionValidationException [(PactHash, Text)]
   | PactDuplicateTableError Text
   | TransactionDecodeFailure Text
+  | RewindLimitExceeded Text BlockHeight BlockHeight
   -- The only argument Text is the duplicate table name.
   deriving (Eq,Generic)
 


### PR DESCRIPTION
This limits rewinds on new block to a difference of 8 blockheight from checkpointer head. It also notes that the SPV use of checkpointer rewind needs to go away soon.