### PR TITLE
Allow Insecure TLS Connections

### DIFF
--- a/chainweb.cabal
+++ b/chainweb.cabal
@@ -66,6 +66,12 @@ flag debug
     default: False
     manual:True
 
+flag ghc-flags
+    description:
+        Generate .ghc.flags files during compilation
+    default: False
+    manual: True
+
 common debugging-flags
     if flag(debug)
         ghc-options:
@@ -394,6 +400,9 @@ library
     if flag(use_systemd) && os(linux)
         build-depends: systemd >= 1.2
         cpp-options: -DWITH_SYSTEMD=1
+    if flag(ghc-flags)
+        ghc-options: -fplugin GhcFlags.Plugin
+        build-depends: ghcflags
 
 -- -------------------------------------------------------------------------- --
 -- Chainweb Test suite

--- a/src/Chainweb/RestAPI.hs
+++ b/src/Chainweb/RestAPI.hs
@@ -68,7 +68,7 @@ import GHC.Generics (Generic)
 import Network.Socket
 import Network.Wai (Middleware, mapResponseHeaders)
 import Network.Wai.Handler.Warp hiding (Port)
-import Network.Wai.Handler.WarpTLS (TLSSettings, runTLSSocket)
+import Network.Wai.Handler.WarpTLS (TLSSettings, runTLSSocket, OnInsecure (..), onInsecure)
 import Network.Wai.Middleware.Cors
 
 import Servant.API
@@ -306,7 +306,7 @@ serveChainwebSocketTls settings certChain key sock v dbs mr hs m =
     runTLSSocket tlsSettings settings sock $ m app
   where
     tlsSettings :: TLSSettings
-    tlsSettings = tlsServerChainSettings certChain key
+    tlsSettings = (tlsServerChainSettings certChain key) { onInsecure = AllowInsecure }
 
     app :: Application
     app = chainwebApplication v dbs mr hs


### PR DESCRIPTION
From what we've seen, TLS connections and the current way we're doing fingerprint validation is broken. This is a quick fix to turn _on_ accepting invalid certificates so nodes can talk to each other. 