### PR TITLE
Configurable Work Request Limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,48 @@
 # Changelog
 
-## [Unreleased]
+## 1.0.4 (2019 Nov ??)
 
+- **Improved mining configuration.** Mining configuration has been consolidated
+  into a single section:
+
+```yaml
+mining:
+  coordination:
+    enabled: false
+    mode: private
+    limit: 1200
+    miners: []
+  nodeMining:
+    miner:
+      account: ''
+      predicate: keys-all
+      public-keys: []
+    enabled: false
+```
+
+While your old config files will still work, you are encouraged to refresh them
+via:
+
+```
+# Generate the refreshed config.
+chainweb-node --config-file=config.yaml --print-config > new-config.yaml
+
+# See what changed.
+diff --color -u config.yaml new-config.yaml
+
+# Confirm the changes.
+mv new-config.yaml config.yaml
+```
+
+You will notice, for instance, that the `miningCoordination` field has been
+moved.
+
+- **Private mining.** When `enabled: true` and `mode: private`, you must provide
+  a list of account names into the `miners` field. Only remote clients that
+  declare they are mining to these blessed accounts will be able to receive
+  work - all others will be rejected. You can use this to protect your node from
+  unwanted visitors.
+
+- **Configurable work request limits.** The `limit` field can be set to restrict
+  the number of mining work requests that occur over a 5 minute period. Requests
+  over this limit are rejected with a `503` error code.

--- a/src/Chainweb/Chainweb/MinerResources.hs
+++ b/src/Chainweb/Chainweb/MinerResources.hs
@@ -88,7 +88,7 @@ withMiningCoordination logger conf cutDb inner
             { _coordLogger = logger
             , _coordCutDb = cutDb
             , _coordState = t
-            , _coordLimit = 1200
+            , _coordLimit = _coordinationReqLimit conf
             , _coord503s = c
             , _coordConf = conf }
   where

--- a/src/Chainweb/Miner/Config.hs
+++ b/src/Chainweb/Miner/Config.hs
@@ -57,6 +57,8 @@ import Chainweb.Miner.Pact (Miner(..), MinerId, MinerKeys(..), minerId)
 
 ---
 
+-- | Strictly for testing.
+--
 newtype MinerCount = MinerCount { _minerCount :: Natural }
     deriving stock (Eq, Ord, Show)
     deriving newtype (FromJSON)
@@ -68,6 +70,8 @@ validateMinerConfig c =
   where
     nmc = _miningInNode c
 
+-- | Full configuration for Mining.
+--
 data MiningConfig = MiningConfig
     { _miningCoordination :: !CoordinationConfig
     , _miningInNode :: !NodeMiningConfig }
@@ -94,12 +98,21 @@ defaultMining = MiningConfig
     { _miningCoordination = defaultCoordination
     , _miningInNode = defaultNodeMining }
 
+-- | Configuration for Mining Coordination.
 data CoordinationConfig = CoordinationConfig
     { _coordinationEnabled :: !Bool
+      -- ^ Is mining coordination enabled? If not, the @/mining/@ won't even be
+      -- present on the node.
     , _coordinationMode :: !CoordinationMode
+      -- ^ `Public` or `Private`.
     , _coordinationMiners :: !(HS.HashSet MinerId)
-    , _coordinationReqLimit :: !Int }
-    deriving stock (Eq, Show, Generic)
+      -- ^ When the mode is set to `Private`, this field must contain at least
+      -- one `MinerId` (i.e. account name) in order for work requests to be
+      -- made.
+    , _coordinationReqLimit :: !Int
+      -- ^ The number of @/mining/work/@ requests that can be made to this node
+      -- in a 5 minute period.
+    } deriving stock (Eq, Show, Generic)
 
 coordinationEnabled :: Lens' CoordinationConfig Bool
 coordinationEnabled = lens _coordinationEnabled (\m c -> m { _coordinationEnabled = c })
@@ -134,6 +147,8 @@ defaultCoordination = CoordinationConfig
     , _coordinationMiners = mempty
     , _coordinationReqLimit = 1200 }
 
+-- | When `Public`, anyone can make Mining work requests to this node.
+-- When `Private`, only designated Miners can do so.
 data CoordinationMode = Public | Private
     deriving stock (Eq, Show)
 
@@ -148,9 +163,14 @@ instance FromJSON CoordinationMode where
 
 data NodeMiningConfig = NodeMiningConfig
     { _nodeMiningEnabled :: !Bool
+      -- ^ If enabled, this node will mine with a single CPU along with its
+      -- other responsibilities.
     , _nodeMiner :: !Miner
-    , _nodeTestMiners :: !MinerCount }
-    deriving stock (Eq, Show, Generic)
+      -- ^ If enabled, a `Miner` identity must be supplied in order to assign
+      -- mining rewards.
+    , _nodeTestMiners :: !MinerCount
+      -- ^ Strictly for testing.
+    } deriving stock (Eq, Show, Generic)
 
 nodeMiningEnabled :: Lens' NodeMiningConfig Bool
 nodeMiningEnabled = lens _nodeMiningEnabled (\m c -> m { _nodeMiningEnabled = c })

--- a/src/Chainweb/Miner/Config.hs
+++ b/src/Chainweb/Miner/Config.hs
@@ -97,11 +97,15 @@ defaultMining = MiningConfig
 data CoordinationConfig = CoordinationConfig
     { _coordinationEnabled :: !Bool
     , _coordinationMode :: !CoordinationMode
-    , _coordinationMiners :: !(HS.HashSet MinerId) }
+    , _coordinationMiners :: !(HS.HashSet MinerId)
+    , _coordinationReqLimit :: !Int }
     deriving stock (Eq, Show, Generic)
 
 coordinationEnabled :: Lens' CoordinationConfig Bool
 coordinationEnabled = lens _coordinationEnabled (\m c -> m { _coordinationEnabled = c })
+
+coordinationLimit :: Lens' CoordinationConfig Int
+coordinationLimit = lens _coordinationReqLimit (\m c -> m { _coordinationReqLimit = c })
 
 coordinationMode :: Lens' CoordinationConfig CoordinationMode
 coordinationMode = lens _coordinationMode (\m c -> m { _coordinationMode = c })
@@ -112,12 +116,14 @@ coordinationMiners = lens _coordinationMiners (\m c -> m { _coordinationMiners =
 instance ToJSON CoordinationConfig where
     toJSON o = object
         [ "enabled" .= _coordinationEnabled o
+        , "limit" .= _coordinationReqLimit o
         , "mode" .= _coordinationMode o
         , "miners" .= _coordinationMiners o ]
 
 instance FromJSON (CoordinationConfig -> CoordinationConfig) where
     parseJSON = withObject "CoordinationConfig" $ \o -> id
         <$< coordinationEnabled ..: "enabled" % o
+        <*< coordinationLimit ..: "limit" % o
         <*< coordinationMode ..: "mode" % o
         <*< coordinationMiners ..: "miners" % o
 
@@ -125,7 +131,8 @@ defaultCoordination :: CoordinationConfig
 defaultCoordination = CoordinationConfig
     { _coordinationEnabled = False
     , _coordinationMode = Private
-    , _coordinationMiners = mempty }
+    , _coordinationMiners = mempty
+    , _coordinationReqLimit = 1200 }
 
 data CoordinationMode = Public | Private
     deriving stock (Eq, Show)


### PR DESCRIPTION
The `coordination` config section now looks like:
```yaml
  mining:
    coordination:
      enabled: false
      mode: private
      limit: 1200  # New field. The number of work requests allowed over a 5 minute period.
      miners: []
```