### PR TITLE
Make stderr echo, when external miner err capture is disabled

### DIFF
--- a/src/Chainweb/Miner/Core.hs
+++ b/src/Chainweb/Miner/Core.hs
@@ -264,13 +264,11 @@ callExternalMiner minerPath0 minerArgs saveStderr target blockBytes = do
                 return $ MiningResult nonceBytes numHashes rate errbytes
     go _ _ _ _ = fail "impossible: process is opened with CreatePipe in/out/err"
 
-    slurp h = act
-      where
-        act = do
+    slurp h = do
             b <- B.hGet h 4000
             if B.null b 
               then return "See prior logs for error message" 
-              else B.hPutStr stderr b >> act
+              else B.hPutStr stderr b >> slurp h
 
     errThread = if saveStderr
                   then B.hGetContents

--- a/src/Chainweb/Miner/Core.hs
+++ b/src/Chainweb/Miner/Core.hs
@@ -52,7 +52,7 @@ import Foreign.Storable (peekElemOff, poke)
 import Servant.API
 
 import System.Exit
-import System.IO (hClose)
+import System.IO (hClose, stderr)
 import System.Path
 import qualified System.Process as P
 
@@ -268,7 +268,9 @@ callExternalMiner minerPath0 minerArgs saveStderr target blockBytes = do
       where
         act = do
             b <- B.hGet h 4000
-            if B.null b then return "stderr not saved" else act
+            if B.null b 
+              then return "See prior logs for error message" 
+              else B.hPutStr stderr b >> act
 
     errThread = if saveStderr
                   then B.hGetContents


### PR DESCRIPTION
If there's a different way which you'd prefer I do this, let me know!

Sample output:

```
jbarber@home-dev ~/projects/bigolchungus $> chainweb-miner gpu --node tsundere.waifuwars.org:35090 --miner-key <lol> --miner-account JayKobe6k --log-level debug --miner-path ./bigolchungus --miner-args "-p 0 -k chungusfail"
2019-11-13 02:10:08.789517: [info] Starting Miner.
2019-11-13 02:10:08.789646: [debug] Attempting to fetch new work from the remote Node
Creating program
OpenCL call failed with error -30
2019-11-13 02:10:09.052752: [error] Error running GPU miner: Got error from miner. Stderr was: See prior logs for error message
chainweb-miner: Control.Exception.Safe.throwString called with:

Got error from miner. Stderr was: See prior logs for error message
Called from:
  throwString (miner/Miner.hs:417:11 in main:Main)
```