### PR TITLE
Seed Initial Module Cache in Pact Service at Genesis

### DIFF
--- a/src/Chainweb/Pact/Backend/Types.hs
+++ b/src/Chainweb/Pact/Backend/Types.hs
@@ -81,6 +81,7 @@ module Chainweb.Pact.Backend.Types
     , runPactServiceM
 
     , PactServiceException(..)
+    , ModuleCache
 
       -- * optics
     , psMempoolAccess
@@ -92,6 +93,7 @@ module Chainweb.Pact.Backend.Types
     , psBlockHeaderDb
     , psMinerRewards
     , psGasModel
+    , psInitCache
     ) where
 
 import Control.Exception
@@ -125,8 +127,6 @@ import Pact.Types.ChainMeta (PublicData(..))
 import qualified Pact.Types.Hash as P
 import Pact.Types.Logger (Logger(..), Logging(..))
 import Pact.Types.Runtime
-    (ExecutionMode(..), PactDb(..), TableName(..), TxId(..),
-    TxLog(..))
 import Pact.Types.Gas (GasModel)
 import Pact.Types.SPV
 
@@ -328,8 +328,11 @@ data PactServiceEnv cas = PactServiceEnv
     , _psMinerRewards :: !MinerRewards
     }
 
-newtype PactServiceState = PactServiceState
+type ModuleCache = HashMap ModuleName (ModuleData Ref, Bool)
+
+data PactServiceState = PactServiceState
     { _psStateValidated :: Maybe BlockHeader
+    , _psInitCache :: ! ModuleCache
     }
 
 type PactServiceM cas = ReaderT (PactServiceEnv cas) (StateT PactServiceState IO)

--- a/src/Chainweb/Pact/Backend/Types.hs
+++ b/src/Chainweb/Pact/Backend/Types.hs
@@ -332,7 +332,7 @@ type ModuleCache = HashMap ModuleName (ModuleData Ref, Bool)
 
 data PactServiceState = PactServiceState
     { _psStateValidated :: Maybe BlockHeader
-    , _psInitCache :: ! ModuleCache
+    , _psInitCache :: !ModuleCache
     }
 
 type PactServiceM cas = ReaderT (PactServiceEnv cas) (StateT PactServiceState IO)

--- a/src/Chainweb/Pact/PactService.hs
+++ b/src/Chainweb/Pact/PactService.hs
@@ -53,6 +53,8 @@ import Data.Bool (bool)
 import qualified Data.ByteString.Short as SB
 import Data.Decimal
 import Data.Default (def)
+import Data.DList (DList(..))
+import qualified Data.DList as DL
 import Data.Either
 import Data.Foldable (foldl', toList)
 import qualified Data.HashMap.Strict as HM
@@ -198,7 +200,7 @@ initPactService' ver cid chainwebLogger spv bhDb pdb dbDir nodeid
           gasModel = tableGasModelNoSize defaultGasConfig -- TODO get sizing working
       let !pse = PactServiceEnv Nothing checkpointEnv spv def pdb
                                 bhDb gasModel rs
-      evalStateT (runReaderT act pse) (PactServiceState Nothing)
+      evalStateT (runReaderT act pse) (PactServiceState Nothing mempty)
   where
     loggers = pactLoggers chainwebLogger
     logger = P.newLogger loggers $ P.LogName ("PactService" <> show cid)
@@ -988,14 +990,15 @@ execTransactions
     -> PactDbEnv'
     -> PactServiceM cas Transactions
 execTransactions nonGenesisParentHash miner ctxs enfCBFail (PactDbEnv' pactdbenv) = do
-    T2 coinOut mc <- runCoinbase nonGenesisParentHash pactdbenv miner enfCBFail
+    mc <- use psInitCache
+    coinOut <- runCoinbase nonGenesisParentHash pactdbenv miner enfCBFail mc
     txOuts <- applyPactCmds isGenesis pactdbenv ctxs miner mc
     return $! Transactions (paired txOuts) coinOut
   where
     !isGenesis = isNothing nonGenesisParentHash
     cmdBSToTx = toTransactionBytes
       . fmap (T.decodeUtf8 . SB.fromShort . payloadBytes)
-    paired = V.zipWith (curry $ first cmdBSToTx) ctxs
+    paired outs = V.zipWith (curry $ first cmdBSToTx) ctxs outs
 
 
 runCoinbase
@@ -1003,9 +1006,10 @@ runCoinbase
     -> P.PactDbEnv p
     -> Miner
     -> EnforceCoinbaseFailure
-    -> PactServiceM cas (T2 HashCommandResult ModuleCache)
-runCoinbase Nothing _ _ _ = return $ T2 noCoinbase mempty
-runCoinbase (Just parentHash) dbEnv miner enfCBFail = do
+    -> ModuleCache
+    -> PactServiceM cas HashCommandResult
+runCoinbase Nothing _ _ _ _ = return noCoinbase
+runCoinbase (Just parentHash) dbEnv miner enfCBFail mc = do
     psEnv <- ask
 
     let !pd = _psPublicData psEnv
@@ -1014,8 +1018,8 @@ runCoinbase (Just parentHash) dbEnv miner enfCBFail = do
         !rs = _psMinerRewards psEnv
 
     reward <- liftIO $! minerReward rs bh
-    T2 cr mc <- liftIO $! applyCoinbase logger dbEnv miner reward pd parentHash enfCBFail
-    return $! T2 (toHashCommandResult cr) mc
+    cr <- liftIO $! applyCoinbase logger dbEnv miner reward pd parentHash enfCBFail mc
+    return $! toHashCommandResult cr
 
 -- | Apply multiple Pact commands, incrementing the transaction Id for each.
 -- The output vector is in the same order as the input (i.e. you can zip it
@@ -1028,7 +1032,7 @@ applyPactCmds
     -> ModuleCache
     -> PactServiceM cas (Vector HashCommandResult)
 applyPactCmds isGenesis env cmds miner mc =
-    V.fromList . ($ []) . sfst <$> V.foldM f (T2 id mc) cmds
+    V.fromList . toList . sfst <$> V.foldM f (T2 mempty mc) cmds
   where
     f  (T2 dl mcache) cmd = applyPactCmd isGenesis env cmd miner mcache dl
 
@@ -1039,8 +1043,8 @@ applyPactCmd
     -> ChainwebTransaction
     -> Miner
     -> ModuleCache
-    -> ([HashCommandResult] -> [HashCommandResult])  -- ^ difference list
-    -> PactServiceM cas (T2 ([HashCommandResult] -> [HashCommandResult]) ModuleCache)
+    -> DList HashCommandResult
+    -> PactServiceM cas (T2 (DList HashCommandResult) ModuleCache)
 applyPactCmd isGenesis dbEnv cmdIn miner mcache dl = do
     psEnv <- ask
     let !logger   = _cpeLogger . _psCheckpointEnv $ psEnv
@@ -1048,15 +1052,19 @@ applyPactCmd isGenesis dbEnv cmdIn miner mcache dl = do
         !spv      = _psSpvSupport psEnv
         pactHash  = view P.cmdHash cmdIn
 
-    T2 !result mcache' <- liftIO $ if isGenesis
+    T2 result mcache' <- liftIO $ if isGenesis
         then applyGenesisCmd logger dbEnv pd spv (payloadObj <$> cmdIn)
         else applyCmd logger dbEnv miner (_psGasModel psEnv) pd spv cmdIn mcache
+
+    -- on genesis, seed initial service state with loaded modules
+    when isGenesis $
+      psInitCache .= mcache'
 
     cp <- getCheckpointer
     -- mark the tx as processed at the checkpointer.
     liftIO $ _cpRegisterProcessedTx cp pactHash
     let !res = toHashCommandResult result
-    pure $! T2 (dl . (res :)) mcache'
+    pure $! T2 (DL.snoc dl res) mcache'
 
 toHashCommandResult :: P.CommandResult [P.TxLog A.Value] -> HashCommandResult
 toHashCommandResult = over (P.crLogs . _Just) $ P.pactHash . encodeToByteString

--- a/src/Chainweb/Pact/Types.hs
+++ b/src/Chainweb/Pact/Types.hs
@@ -28,7 +28,6 @@ module Chainweb.Pact.Types
   , Rewind(..)
     -- * types
   , TransactionM
-  , ModuleCache
   , HashCommandResult
     -- * optics
   , pdbspRestoreFile
@@ -45,7 +44,6 @@ import Control.Monad.Catch
 import Control.Monad.Reader
 
 import Data.Aeson
-import Data.HashMap.Strict
 import Data.Vector (Vector)
 
 -- internal pact modules
@@ -55,9 +53,8 @@ import Pact.Types.Command
 import Pact.Types.Exp
 import qualified Pact.Types.Hash as H
 import Pact.Types.PactValue
-import Pact.Types.Runtime (ModuleData)
 import Pact.Types.Server (CommandEnv)
-import Pact.Types.Term (ModuleName, PactId(..), Ref)
+import Pact.Types.Term (PactId(..))
 
 -- internal chainweb modules
 
@@ -70,8 +67,6 @@ import Chainweb.Version
 
 
 type HashCommandResult = CommandResult H.Hash
-
-type ModuleCache = HashMap ModuleName (ModuleData Ref, Bool)
 
 data Transactions = Transactions
     { _transactionPairs :: !(Vector (Transaction, HashCommandResult))

--- a/test/Chainweb/Test/Pact/Utils.hs
+++ b/test/Chainweb/Test/Pact/Utils.hs
@@ -399,7 +399,7 @@ testPactCtx v cid cdbv bhdb pdb = do
     cpe <- initInMemoryCheckpointEnv loggers logger
     let rs = readRewards v
     ctx <- TestPactCtx
-        <$> newMVar (PactServiceState Nothing)
+        <$> newMVar (PactServiceState Nothing mempty)
         <*> pure (PactServiceEnv Nothing cpe spv pd pdb bhdb (constGasModel 0) rs)
     evalPactServiceM ctx (initialPayloadState v cid)
     return ctx
@@ -422,7 +422,7 @@ testPactCtxSQLite v cid cdbv bhdb pdb sqlenv = do
     cpe <- initRelationalCheckpointer initBlockState sqlenv logger
     let rs = readRewards v
     ctx <- TestPactCtx
-      <$> newMVar (PactServiceState Nothing)
+      <$> newMVar (PactServiceState Nothing mempty)
       <*> pure (PactServiceEnv Nothing cpe spv pd pdb bhdb (constGasModel 0) rs)
     evalPactServiceM ctx (initialPayloadState v cid)
     return ctx
@@ -553,7 +553,7 @@ withPactCtxSQLite v cutDB bhdbIO pdbIO f =
       (dbSt, cpe) <- initRelationalCheckpointer' initBlockState s logger
       let rs = readRewards v
       !ctx <- TestPactCtx
-        <$!> newMVar (PactServiceState Nothing)
+        <$!> newMVar (PactServiceState Nothing mempty)
         <*> pure (PactServiceEnv Nothing cpe spv pd pdb bhdb (constGasModel 0) rs)
       evalPactServiceM ctx (initialPayloadState v cid)
       return (ctx, dbSt)


### PR DESCRIPTION
This seeds every module cache with the modules/interfaces loaded at genesis, keeping it in Pact Service state in perpetuity.