### PR TITLE
Logging of Orphans

### DIFF
--- a/node/ChainwebNode.hs
+++ b/node/ChainwebNode.hs
@@ -365,6 +365,8 @@ withNodeLogger logConfig v f = runManaged $ do
         $ mkTelemetryLogger @PactCmdLog mgr teleLogConfig
     newBlockBackend <- managed
         $ mkTelemetryLogger @NewMinedBlock mgr teleLogConfig
+    orphanedBlockBackend <- managed
+        $ mkTelemetryLogger @OrphanedBlock mgr teleLogConfig
     miningStatsBackend <- managed
         $ mkTelemetryLogger @MiningStats mgr teleLogConfig
     requestLogBackend <- managed
@@ -390,6 +392,7 @@ withNodeLogger logConfig v f = runManaged $ do
             , logHandler newBlockAmberdataBackend
             , logHandler endpointBackend
             , logHandler newBlockBackend
+            , logHandler orphanedBlockBackend
             , logHandler miningStatsBackend
             , logHandler requestLogBackend
             , logHandler queueStatsBackend

--- a/src/Chainweb/Logging/Miner.hs
+++ b/src/Chainweb/Logging/Miner.hs
@@ -16,6 +16,7 @@
 --
 module Chainweb.Logging.Miner
 ( NewMinedBlock(..)
+, OrphanedBlock(..)
 ) where
 
 import Control.DeepSeq
@@ -40,5 +41,12 @@ data NewMinedBlock = NewMinedBlock
     , _minedBlockMiner :: !Text
     , _minedBlockDiscoveredAt :: !(Time Micros)
     }
-    deriving (Eq, Show, Generic)
+    deriving stock (Eq, Show, Generic)
+    deriving anyclass (ToJSON, NFData)
+
+data OrphanedBlock = OrphanedBlock
+    { _orphanedHeader :: !(ObjectEncoded BlockHeader)
+    , _orphanedMiner :: !Text
+    , _orphanedReason :: Text }
+    deriving stock (Eq, Show, Generic)
     deriving anyclass (ToJSON, NFData)


### PR DESCRIPTION
This moves logging of errors related to orphans into its own index for easier debugging.