### PR TITLE
improve cut db member ship queries

### DIFF
--- a/src/Chainweb/SPV/VerifyProof.hs
+++ b/src/Chainweb/SPV/VerifyProof.hs
@@ -53,8 +53,8 @@ runTransactionProof (TransactionProof _ p)
     = BlockHash $ MerkleLogHash $ runMerkleProof p
 
 -- | Verifies the proof against the current state of consensus. The result
--- confirms that the subject of the proof is included in the history of the
--- winning fork of target chain.
+-- confirms that the subject of the proof occurs in the history of the winning
+-- fork of the target chain.
 --
 verifyTransactionProof
     :: CutDb cas
@@ -67,9 +67,9 @@ verifyTransactionProof cutDb proof@(TransactionProof cid p) = do
   where
     h = runTransactionProof proof
 
--- | Verifies the proof against for the given block hash. The result confirms
--- that the subject of the proof is included in the history of the target chain
--- of the proof before the given block hash.
+-- | Verifies the proof for the given block hash. The result confirms that the
+-- subject of the proof occurs in the history of the target chain before the
+-- given block hash.
 --
 -- Throws 'TreeDbKeyNotFound' if the given block hash doesn't exist on target
 -- chain.
@@ -97,8 +97,8 @@ runTransactionOutputProof (TransactionOutputProof _ p)
     = BlockHash $ MerkleLogHash $ runMerkleProof p
 
 -- | Verifies the proof against the current state of consensus. The result
--- confirms that the subject of the proof is included in the history of the
--- winning fork of target chain.
+-- confirms that the subject of the proof occurs in the history of the winning
+-- fork of the target chain.
 --
 verifyTransactionOutputProof
     :: CutDb cas
@@ -111,9 +111,9 @@ verifyTransactionOutputProof cutDb proof@(TransactionOutputProof cid p) = do
   where
     h = runTransactionOutputProof proof
 
--- | Verifies the proof against for the given block hash. The result confirms
--- that the subject of the proof is included in the history of the target chain
--- of the proof before the given block hash.
+-- | Verifies the proof for the given block hash. The result confirms that the
+-- subject of the proof occurs in the history of the target chain before the
+-- given block hash.
 --
 -- Throws 'TreeDbKeyNotFound' if the given block hash doesn't exist on target
 -- chain.

--- a/src/Chainweb/SPV/VerifyProof.hs
+++ b/src/Chainweb/SPV/VerifyProof.hs
@@ -20,6 +20,7 @@ module Chainweb.SPV.VerifyProof
 -- * Transaction Output Proofs
 , runTransactionOutputProof
 , verifyTransactionOutputProof
+, verifyTransactionOutputProofAt
 ) where
 
 import Control.Monad.Catch
@@ -77,6 +78,18 @@ verifyTransactionOutputProof
     -> IO TransactionOutput
 verifyTransactionOutputProof cutDb proof@(TransactionOutputProof cid p) = do
     unlessM (member cutDb cid h) $ throwM
+        $ SpvExceptionVerificationFailed "target header is not in the chain"
+    proofSubject p
+  where
+    h = runTransactionOutputProof proof
+
+verifyTransactionOutputProofAt
+    :: CutDb cas
+    -> TransactionOutputProof SHA512t_256
+    -> BlockHash
+    -> IO TransactionOutput
+verifyTransactionOutputProofAt cutDb proof@(TransactionOutputProof cid p) ctx = do
+    unlessM (memberOfM cutDb cid h ctx) $ throwM
         $ SpvExceptionVerificationFailed "target header is not in the chain"
     proofSubject p
   where


### PR DESCRIPTION
* [x] Cut db member ship for a given context/branch
* [x] Make cut db membership queries expected `O(1)`
* [x] add verifyTransactionOutputProofAt that uses an oracle for the given branch