### PR TITLE
Introduce "pre-compiled" terms for buy gas, coinbase

### DIFF
--- a/chainweb.cabal
+++ b/chainweb.cabal
@@ -273,6 +273,7 @@ library
         , Chainweb.Pact.Service.PactInProcApi
         , Chainweb.Pact.Service.PactQueue
         , Chainweb.Pact.Service.Types
+        , Chainweb.Pact.Templates
         , Chainweb.Pact.TransactionExec
         , Chainweb.Pact.Types
         , Chainweb.Pact.Utils

--- a/src/Chainweb/Pact/Templates.hs
+++ b/src/Chainweb/Pact/Templates.hs
@@ -1,0 +1,107 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TupleSections #-}
+{-# LANGUAGE TypeApplications #-}
+
+-- |
+-- Module      :  Chainweb.Pact.Templates
+-- Copyright   :  Copyright © 2010 Kadena LLC.
+-- License     :  (see the file LICENSE)
+-- Maintainer  :  Stuart Popejoy
+-- Stability   :  experimental
+--
+-- Prebuilt Term templates for automated operations (coinbase, gas buy)
+--
+module Chainweb.Pact.Templates
+  ( mkBuyGasTerm
+  , mkCoinbaseTerm
+  ) where
+
+
+import Control.Lens
+import Data.Aeson hiding ((.=))
+import qualified Data.Aeson as A
+import Data.Default (def)
+import Data.Text (Text)
+
+import Pact.Parse
+import Pact.Types.Command
+import Pact.Types.RPC
+import Pact.Types.Runtime
+
+import Chainweb.Miner.Pact
+import Chainweb.Pact.Types
+
+app :: Name -> [Term Name] -> Term Name
+app f as = TApp (App (TVar f def) as def) def
+
+qn :: ModuleName -> Text -> Name
+qn mn d = QName $ QualifiedName mn d def
+
+bn :: Text -> Name
+bn n = Name $ BareName n def
+
+strLit :: Text -> Term Name
+strLit s = TLiteral (LString s) def
+
+strArgSetter :: Int -> ASetter' (Term Name) Text
+strArgSetter idx = tApp . appArgs . ix idx . tLiteral . _LString
+
+buyGasTemplate :: (Term Name,ASetter' (Term Name) Text,ASetter' (Term Name) Text)
+buyGasTemplate =
+  (app (qn "coin" "fund-tx")
+   [strLit "sender"
+   ,strLit "mid"
+   ,app (bn "read-keyset") [strLit "miner-keyset"]
+   ,app (bn "read-decimal") [strLit "total"]
+   ]
+  ,strArgSetter 0
+  ,strArgSetter 1
+  )
+
+
+dummyParsedCode :: ParsedCode
+dummyParsedCode = ParsedCode "1" [ELiteral $ LiteralExp (LInteger 1) def]
+
+mkBuyGasTerm
+  :: MinerId   -- ^ Id of the miner to fund
+  -> MinerKeys -- ^ Miner keyset
+  -> Text      -- ^ Address of the sender from the command
+  -> GasSupply -- ^ The gas limit total * price
+  -> (Term Name,ExecMsg ParsedCode)
+mkBuyGasTerm (MinerId mid) (MinerKeys ks) sender total = (populatedTerm,execMsg)
+  where (term,senderS,minerS) = buyGasTemplate
+        populatedTerm = set senderS sender $ set minerS mid term
+        execMsg = ExecMsg dummyParsedCode buyGasData
+        buyGasData = object
+          [ "miner-keyset" A..= ks
+          , "total" A..= total
+          ]
+{-# INLINABLE mkBuyGasTerm #-}
+
+
+coinbaseTemplate :: (Term Name,ASetter' (Term Name) Text)
+coinbaseTemplate =
+  (app (qn "coin" "coinbase")
+   [strLit "mid"
+   ,app (bn "read-keyset") [strLit "miner-keyset"]
+   ,app (bn "read-decimal") [strLit "reward"]]
+  ,strArgSetter 0)
+
+mkCoinbaseTerm :: MinerId -> MinerKeys -> ParsedDecimal -> (Term Name,ExecMsg ParsedCode)
+mkCoinbaseTerm (MinerId mid) (MinerKeys ks) reward = (populatedTerm,execMsg)
+  where
+    (term,minerS) = coinbaseTemplate
+    populatedTerm = set minerS mid term
+    execMsg = ExecMsg dummyParsedCode coinbaseData
+    coinbaseData = object
+      [ "miner-keyset" A..= ks
+      , "reward" A..= reward
+      ]
+{-# INLINABLE mkCoinbaseTerm #-}

--- a/src/Chainweb/Pact/Templates.hs
+++ b/src/Chainweb/Pact/Templates.hs
@@ -40,15 +40,19 @@ import Chainweb.Pact.Types
 
 app :: Name -> [Term Name] -> Term Name
 app f as = TApp (App (TVar f def) as def) def
+{-# INLINE app #-}
 
 qn :: ModuleName -> Text -> Name
 qn mn d = QName $ QualifiedName mn d def
+{-# INLINE qn #-}
 
 bn :: Text -> Name
 bn n = Name $ BareName n def
+{-# INLINE bn #-}
 
 strLit :: Text -> Term Name
 strLit s = TLiteral (LString s) def
+{-# INLINE strLit #-}
 
 strArgSetter :: Int -> ASetter' (Term Name) Text
 strArgSetter idx = tApp . appArgs . ix idx . tLiteral . _LString
@@ -64,10 +68,13 @@ buyGasTemplate =
   ,strArgSetter 0
   ,strArgSetter 1
   )
+{-# NOINLINE buyGasTemplate #-}
 
 
 dummyParsedCode :: ParsedCode
 dummyParsedCode = ParsedCode "1" [ELiteral $ LiteralExp (LInteger 1) def]
+{-# NOINLINE dummyParsedCode #-}
+
 
 mkBuyGasTerm
   :: MinerId   -- ^ Id of the miner to fund
@@ -93,6 +100,8 @@ coinbaseTemplate =
    ,app (bn "read-keyset") [strLit "miner-keyset"]
    ,app (bn "read-decimal") [strLit "reward"]]
   ,strArgSetter 0)
+{-# NOINLINE coinbaseTemplate #-}
+
 
 mkCoinbaseTerm :: MinerId -> MinerKeys -> ParsedDecimal -> (Term Name,ExecMsg ParsedCode)
 mkCoinbaseTerm (MinerId mid) (MinerKeys ks) reward = (populatedTerm,execMsg)

--- a/src/Chainweb/Pact/TransactionExec.hs
+++ b/src/Chainweb/Pact/TransactionExec.hs
@@ -31,11 +31,9 @@ module Chainweb.Pact.TransactionExec
 
   -- * Gas Execution
 , buyGas
-, mkBuyGasCmd
 
   -- * Coinbase Execution
 , applyCoinbase
-, mkCoinbaseCmd
 , EnforceCoinbaseFailure(..)
 
   -- * Command Helpers
@@ -72,7 +70,7 @@ import Data.Tuple.Strict (T2(..))
 
 -- internal Pact modules
 
-import Pact.Eval (liftTerm, lookupModule)
+import Pact.Eval (liftTerm, lookupModule, eval)
 import Pact.Gas (freeGasEnv)
 import Pact.Gas.Table
 import Pact.Interpreter
@@ -96,6 +94,7 @@ import Pact.Types.SPV
 import Chainweb.BlockHash
 import Chainweb.Miner.Pact
 import Chainweb.Pact.Service.Types (internalError)
+import Chainweb.Pact.Templates
 import Chainweb.Pact.Types
 import Chainweb.Transaction
 import Chainweb.Utils (sshow)
@@ -118,6 +117,7 @@ magic_GAS = mkMagicCapSlot "GAS"
 --
 magic_GENESIS :: CapSlot UserCapability
 magic_GENESIS = mkMagicCapSlot "GENESIS"
+
 
 -- | The main entry point to executing transactions. From here,
 -- 'applyCmd' assembles the command environment for a command and
@@ -238,13 +238,16 @@ applyCoinbase logger dbEnv (Miner mid mks) reward@(ParsedDecimal d) pd ph
   where
     tenv = TransactionEnv Transactional dbEnv logger pd noSPVSupport
            Nothing 0.0 rk 0 restrictiveExecutionConfig
-    txst =TransactionState mc mempty 0 Nothing (_geGasModel freeGasEnv)
-    interp = initStateInterpreter $ initCapabilities [magic_COINBASE]
+    txst = TransactionState mc mempty 0 Nothing (_geGasModel freeGasEnv)
+    initState = initCapabilities [magic_COINBASE]
     chash = Pact.Hash (sshow ph)
     rk = RequestKey chash
 
     go = do
-      cexec <- liftIO $ mkCoinbaseCmd mid mks reward
+      let (cterm,cexec) = mkCoinbaseTerm mid mks reward
+          interp = Interpreter $ \_input -> do
+            put initState
+            pure <$> eval cterm
       cr <- catchesPactError $!
         applyExec' interp cexec mempty chash managedNamespacePolicy
 
@@ -453,8 +456,7 @@ buyGas cmd (Miner mid mks) = go
   where
     sender = view (cmdPayload . pMeta . pmSender) cmd
     initState mc = setModuleCache mc $ initCapabilities [magic_GAS]
-    interp mc = Interpreter $ \input ->
-      put (initState mc) >> run input
+
     run input = do
       findPayer >>= \r -> case r of
         Nothing -> input
@@ -467,7 +469,9 @@ buyGas cmd (Miner mid mks) = go
       mcache <- use txCache
       supply <- gasSupplyOf <$> view txGasLimit <*> view txGasPrice
 
-      buyGasCmd <- liftIO $! mkBuyGasCmd mid mks sender supply
+      let (buyGasTerm,buyGasCmd) = mkBuyGasTerm mid mks sender supply
+          interp mc = Interpreter $ \_input ->
+            put (initState mc) >> run (pure <$> eval buyGasTerm)
 
       result <- applyExec' (interp mcache) buyGasCmd
         (_pSigners $ _cmdPayload cmd) bgHash managedNamespacePolicy
@@ -475,6 +479,8 @@ buyGas cmd (Miner mid mks) = go
       case _erExec result of
         Nothing -> fatal "buyGas: Internal error - empty continuation"
         Just pe -> void $! txGasId .= (Just $ GasId (_pePactId pe))
+
+
 
 findPayer :: Eval e (Maybe (Eval e [Term Name] -> Eval e [Term Name]))
 findPayer = runMaybeT $ do
@@ -535,43 +541,6 @@ redeemGas cmd = do
     redeemGasCmd fee (GasId pid) =
       ContMsg pid 1 False (object [ "fee" A..= fee ]) Nothing
 
--- | Build the 'coin-contract.buygas' command
---
-mkBuyGasCmd
-    :: MinerId   -- ^ Id of the miner to fund
-    -> MinerKeys -- ^ Miner keyset
-    -> Text      -- ^ Address of the sender from the command
-    -> GasSupply -- ^ The gas limit total * price
-    -> IO (ExecMsg ParsedCode)
-mkBuyGasCmd (MinerId mid) (MinerKeys ks) sender total =
-    buildExecParsedCode buyGasData $ mconcat
-      [ "(coin.fund-tx"
-      , " \"" <> sender <> "\""
-      , " \"" <> mid <> "\""
-      , " (read-keyset \"miner-keyset\")"
-      , " (read-decimal \"total\"))"
-      ]
-  where
-    buyGasData = Just $ object
-      [ "miner-keyset" A..= ks
-      , "total" A..= total
-      ]
-{-# INLINABLE mkBuyGasCmd #-}
-
-mkCoinbaseCmd :: MinerId -> MinerKeys -> ParsedDecimal -> IO (ExecMsg ParsedCode)
-mkCoinbaseCmd (MinerId mid) (MinerKeys ks) reward =
-    buildExecParsedCode coinbaseData $ mconcat
-      [ "(coin.coinbase"
-      , " \"" <> mid <> "\""
-      , " (read-keyset \"miner-keyset\")"
-      , " (read-decimal \"reward\"))"
-      ]
-  where
-    coinbaseData = Just $ object
-      [ "miner-keyset" A..= ks
-      , "reward" A..= reward
-      ]
-{-# INLINABLE mkCoinbaseCmd #-}
 
 -- ---------------------------------------------------------------------------- --
 -- Utilities
@@ -702,7 +671,6 @@ buildExecParsedCode value code = maybe (go Null) go value
       -- if we can't construct coin contract calls, this should
       -- fail fast
       Left err -> internalError $ "buildExecParsedCode: parse failed: " <> T.pack err
-
 
 -- | Retrieve public metadata from a command
 --

--- a/test/Chainweb/Test/CoinContract.hs
+++ b/test/Chainweb/Test/CoinContract.hs
@@ -31,17 +31,13 @@ import Pact.Types.Runtime
 
 
 -- internal chainweb modules
-
-import Chainweb.Miner.Pact
 import Chainweb.Pact.TransactionExec
 
 
 tests :: TestTree
 tests = testGroup "Chainweb.Test.CoinContract"
   [ testGroup "Pact Command Parsing"
-    [ testCase "Buy Gas" buyGas'
-    , testCase "Coinbase" coinbase'
-    , testCase "Build Exec with Data" buildExecWithData
+    [ testCase "Build Exec with Data" buildExecWithData
     , testCase "Build Exec without Data" buildExecWithoutData
     ]
   , testGroup "Pact Code Unit Tests"
@@ -50,12 +46,6 @@ tests = testGroup "Chainweb.Test.CoinContract"
     , testCase "Payer Repl Tests" (ccReplTests "pact/gas-payer/gas-payer-v1.repl")
     ]
   ]
-
-buyGas' :: Assertion
-buyGas' = void $ mkBuyGasCmd minerId0 minerKeys0 sender0 1.0
-
-coinbase' :: Assertion
-coinbase' = void $ mkCoinbaseCmd minerId0 minerKeys0 1.0
 
 buildExecWithData :: Assertion
 buildExecWithData = void $ buildExecParsedCode
@@ -76,18 +66,3 @@ ccReplTests ccFile = do
         traverse_ (uncurry failCC) $ trFailure tr
 
     failCC i e = assertFailure $ renderInfo (_faInfo i) <> ": " <> unpack e
-
-------------------------------------------------------------------------------
--- Test Data
-------------------------------------------------------------------------------
-
-sender0 :: Text
-sender0 = "sender"
-
-minerKeys0 :: MinerKeys
-minerKeys0 = MinerKeys $ mkKeySet
-  ["f880a433d6e2a13a32b6169030f56245efdd8c1b8a5027e9ce98a88e886bef27"]
-  "default"
-
-minerId0 :: MinerId
-minerId0 = MinerId "default miner"


### PR DESCRIPTION
Gets a ~1ms savings per tx, and ~3ms per block

Before:
```
benchmarking PactService/block-new-valid[1]
time                 264.2 ms   (262.9 ms .. 265.3 ms)
                     
benchmarking PactService/block-new-valid[10]
time                 309.0 ms   (296.8 ms .. 325.9 ms)
                     
benchmarking PactService/block-new-valid[50]
time                 506.9 ms   (497.7 ms .. 514.7 ms)
                     
benchmarking PactService/block-new-valid[100]
time                 742.6 ms   (705.6 ms .. 778.2 ms)
                     
benchmarking PactService/block-new[1]
time                 134.1 ms   (132.9 ms .. 135.8 ms)
                     
benchmarking PactService/block-new[10]
time                 158.8 ms   (156.8 ms .. 163.9 ms)
                     
benchmarking PactService/block-new[50]
time                 247.4 ms   (242.8 ms .. 251.0 ms)
                     
benchmarking PactService/block-new[100]
time                 370.4 ms   (359.7 ms .. 388.2 ms)
```

After:
```
benchmarking PactService/block-new-valid[1]
time                 248.6 ms   (233.6 ms .. 269.9 ms)
                      
benchmarking PactService/block-new-valid[10]
time                 288.6 ms   (267.9 ms .. 308.2 ms)
                      
benchmarking PactService/block-new-valid[50]
time                 483.7 ms   (455.1 ms .. 550.2 ms)
                      
benchmarking PactService/block-new-valid[100]
time                 678.7 ms   (605.1 ms .. 763.6 ms)
                      
benchmarking PactService/block-new[1]
time                 117.7 ms   (113.3 ms .. 125.8 ms)
                      
benchmarking PactService/block-new[10]
time                 135.4 ms   (133.3 ms .. 139.7 ms)
                      
benchmarking PactService/block-new[50]
time                 246.8 ms   (230.6 ms .. 265.7 ms)
                      
benchmarking PactService/block-new[100]
time                 378.9 ms   (352.1 ms .. 438.9 ms)
```

