### PR TITLE
[Bugfix] Reward Miner For Failed Payloads

### DIFF
--- a/src/Chainweb/Pact/PactService.hs
+++ b/src/Chainweb/Pact/PactService.hs
@@ -138,7 +138,7 @@ pactLoggers logger = P.Loggers $ P.mkLogger (error "ignored") fun def
     fun :: P.LoggerLogFun
     fun _ (P.LogName n) cat msg = do
         let namedLogger = addLabel ("logger", T.pack n) logger
-        logFunctionText namedLogger (pactLogLevel cat) $ T.pack ("wat: " <> msg)
+        logFunctionText namedLogger (pactLogLevel cat) $ T.pack msg
 
 initPactService
     :: Logger logger

--- a/src/Chainweb/Pact/PactService.hs
+++ b/src/Chainweb/Pact/PactService.hs
@@ -138,7 +138,7 @@ pactLoggers logger = P.Loggers $ P.mkLogger (error "ignored") fun def
     fun :: P.LoggerLogFun
     fun _ (P.LogName n) cat msg = do
         let namedLogger = addLabel ("logger", T.pack n) logger
-        logFunctionText namedLogger (pactLogLevel cat) $ T.pack msg
+        logFunctionText namedLogger (pactLogLevel cat) $ T.pack ("wat: " <> msg)
 
 initPactService
     :: Logger logger

--- a/src/Chainweb/Pact/TransactionExec.hs
+++ b/src/Chainweb/Pact/TransactionExec.hs
@@ -305,8 +305,7 @@ applyLocal logger dbEnv pd spv cmdIn mc =
         applyExec interp em signers chash managedNamespacePolicy
 
       case cr of
-        Left e -> do
-          jsonErrorResult e "applyLocal"
+        Left e -> jsonErrorResult e "applyLocal"
         Right r -> return $! r { _crMetaData = Just (toJSON pd') }
 
     go = do

--- a/src/Chainweb/Pact/TransactionExec.hs
+++ b/src/Chainweb/Pact/TransactionExec.hs
@@ -171,7 +171,9 @@ applyCmd logger pdbenv miner gasModel pd spv cmdIn mcache0 ecMod =
 
       cr <- catchesPactError $! runPayload cmd managedNamespacePolicy
       case cr of
-        Left e -> jsonErrorResult e "tx failure for request key when running cmd"
+        Left e -> do
+          r <- jsonErrorResult e "tx failure for request key when running cmd"
+          applyRedeem r
         Right r -> applyRedeem r
 
     applyRedeem cr = do

--- a/src/Chainweb/Pact/TransactionExec.hs
+++ b/src/Chainweb/Pact/TransactionExec.hs
@@ -44,7 +44,6 @@ module Chainweb.Pact.TransactionExec
 
   -- * Utilities
 , buildExecParsedCode
-, jsonErrorResult
 , mkMagicCapSlot
 
 ) where
@@ -159,11 +158,14 @@ applyCmd logger pdbenv miner gasModel pd spv cmdIn mcache0 ecMod =
     gasLimit = gasLimitOf cmd
     initialGas = initialGasOf (_cmdPayload cmdIn)
     nid = networkIdOf cmd
+    redeemAllGas r = do
+      txGasUsed .= fromIntegral gasLimit
+      applyRedeem r
 
     applyBuyGas =
       catchesPactError (buyGas cmd miner) >>= \case
         Left e -> fatal $ "tx failure for requestKey when buying gas: " <> sshow e
-        Right _ -> checkTooBigTx initialGas gasLimit applyPayload
+        Right _ -> checkTooBigTx initialGas gasLimit applyPayload redeemAllGas
 
     applyPayload = do
       txGasModel .= gasModel
@@ -173,7 +175,7 @@ applyCmd logger pdbenv miner gasModel pd spv cmdIn mcache0 ecMod =
       case cr of
         Left e -> do
           r <- jsonErrorResult e "tx failure for request key when running cmd"
-          applyRedeem r
+          redeemAllGas r
         Right r -> applyRedeem r
 
     applyRedeem cr = do
@@ -181,7 +183,8 @@ applyCmd logger pdbenv miner gasModel pd spv cmdIn mcache0 ecMod =
 
       r <- catchesPactError $! redeemGas cmd
       case r of
-        Left e -> jsonErrorResult e "tx failure for request key while redeeming gas"
+        -- redeem gas failure is fatal (block-failing) so miner doesn't lose coins
+        Left e -> fatal $ "tx failure for request key while redeeming gas: " <> sshow e
         Right _ -> do
           logs <- use txLogs
           return $! set crLogs (Just logs) cr
@@ -310,7 +313,7 @@ applyLocal logger dbEnv pd spv cmdIn mc =
         Exec !pm -> return pm
         _ -> throwCmdEx "local continuations not supported"
 
-      checkTooBigTx gas0 gasLimit (applyPayload em)
+      checkTooBigTx gas0 gasLimit (applyPayload em) return
 
 jsonErrorResult
     :: PactError
@@ -318,10 +321,9 @@ jsonErrorResult
     -> TransactionM p (CommandResult [TxLog Value])
 jsonErrorResult err msg = do
     logs <- use txLogs
-    gas <- use txGasUsed
+    gas <- view txGasLimit -- error means all gas was charged
     rk <- view txRequestKey
     l <- view txLogger
-
     liftIO
       $! logLog l "ERROR"
       $! T.unpack msg
@@ -563,8 +565,9 @@ checkTooBigTx
     :: Gas
     -> GasLimit
     -> TransactionM p (CommandResult [TxLog Value])
+    -> (CommandResult [TxLog Value] -> TransactionM p (CommandResult [TxLog Value]))
     -> TransactionM p (CommandResult [TxLog Value])
-checkTooBigTx initialGas gasLimit next
+checkTooBigTx initialGas gasLimit next onFail
   | initialGas >= (fromIntegral gasLimit) = do
       txGasUsed .= (fromIntegral gasLimit) -- all gas is consumed
 
@@ -572,7 +575,9 @@ checkTooBigTx initialGas gasLimit next
             $ "Tx too big (" <> pretty initialGas <> "), limit "
             <> pretty gasLimit
 
-      jsonErrorResult pe "Tx too big"
+      r <- jsonErrorResult pe "Tx too big"
+      onFail r
+
   | otherwise = next
 
 gasInterpreter :: Gas -> TransactionM db (Interpreter p)

--- a/src/Chainweb/Pact/TransactionExec.hs
+++ b/src/Chainweb/Pact/TransactionExec.hs
@@ -174,7 +174,6 @@ applyCmd logger pdbenv miner gasModel pd spv cmdIn mcache0 ecMod =
       cr <- catchesPactError $! runPayload cmd managedNamespacePolicy
       case cr of
         Left e -> do
-          txGasUsed .= gasLimit
           r <- jsonErrorResult e "tx failure for request key when running cmd"
           redeemAllGas r
         Right r -> applyRedeem r
@@ -307,7 +306,6 @@ applyLocal logger dbEnv pd spv cmdIn mc =
 
       case cr of
         Left e -> do
-          txGasUsed .= gasLImit
           jsonErrorResult e "applyLocal"
         Right r -> return $! r { _crMetaData = Just (toJSON pd') }
 

--- a/src/Chainweb/Transaction.hs
+++ b/src/Chainweb/Transaction.hs
@@ -19,7 +19,6 @@ module Chainweb.Transaction
   , timeToLiveOf
   , creationTimeOf
   , mkPayloadWithText
-  , modifyPayloadWithText
   , payloadBytes
   , payloadObj
   ) where
@@ -71,14 +70,6 @@ mkPayloadWithText p = PayloadWithText {
     , _payloadObj = p
     }
 
-modifyPayloadWithText
-    :: (Payload PublicMeta ParsedCode -> Payload PublicMeta ParsedCode)
-    -> PayloadWithText
-    -> PayloadWithText
-modifyPayloadWithText f pwt = mkPayloadWithText newPayload
-  where
-    oldPayload = _payloadObj pwt
-    newPayload = f oldPayload
 
 type ChainwebTransaction = Command PayloadWithText
 

--- a/test/Chainweb/Test/Pact/PactExec.hs
+++ b/test/Chainweb/Test/Pact/PactExec.hs
@@ -70,7 +70,7 @@ tests = ScheduledTest label $
         withResource newPayloadDb killPdb $ \pdb ->
         withRocksResource $ \rocksIO ->
         testGroup label
-    [ withPactCtxSQLite testVersion (bhdbIO rocksIO) pdb $
+    [ withPactCtxSQLite testVersion (bhdbIO rocksIO) pdb Nothing $
         \ctx -> testGroup "single transactions" $ schedule Sequential
             [ execTest ctx testReq2
             , execTest ctx testReq3
@@ -79,13 +79,15 @@ tests = ScheduledTest label $
             , execTxsTest ctx "testTfrGas" testTfrGas
             , execTxsTest ctx "testGasPayer" testGasPayer
             ]
-    , withPactCtxSQLite testVersion (bhdbIO rocksIO) pdb $
+    , withPactCtxSQLite testVersion (bhdbIO rocksIO) pdb Nothing $
       \ctx2 -> _schTest $ execTest ctx2 testReq6
       -- failures mess up cp state so run alone
-    , withPactCtxSQLite testVersion (bhdbIO rocksIO) pdb $
+    , withPactCtxSQLite testVersion (bhdbIO rocksIO) pdb Nothing $
       \ctx -> _schTest $ execTxsTest ctx "testTfrNoGasFails" testTfrNoGasFails
-    , withPactCtxSQLite testVersion (bhdbIO rocksIO) pdb $
+    , withPactCtxSQLite testVersion (bhdbIO rocksIO) pdb Nothing $
       \ctx -> _schTest $ execTxsTest ctx "testBadSenderFails" testBadSenderFails
+    , withPactCtxSQLite testVersion (bhdbIO rocksIO) pdb Nothing $
+      \ctx -> _schTest $ execTxsTest ctx "testFailureRedeem" testFailureRedeem
 
     ]
   where
@@ -190,6 +192,10 @@ checkPactResultSuccess :: HasCallStack => String -> PactResult -> (PactValue -> 
 checkPactResultSuccess _ (PactResult (Right pv)) test = test pv
 checkPactResultSuccess msg (PactResult (Left e)) _ = assertFailure $ msg ++ ": expected tx success, got " ++ show e
 
+checkPactResultFailure :: HasCallStack => String -> PactResult -> String -> Assertion
+checkPactResultFailure msg (PactResult (Right pv)) _ = assertFailure $ msg ++ ": expected tx failure, got " ++ show pv
+checkPactResultFailure msg (PactResult (Left e)) expectErr = assertSatisfies msg e ((isInfixOf expectErr).show)
+
 testTfrNoGasFails :: TxsTest
 testTfrNoGasFails = (txs,assertResultFail "Expected missing (GAS) failure" "Keyset failure")
   where
@@ -270,6 +276,32 @@ testGasPayer = (txs,checkResultSuccess test)
       checkPactResultSuccess "setupUser" setupUser $ assertEqual "setupUser" (pString "Write succeeded")
       checkPactResultSuccess "fundGasAcct" fundGasAcct $ assertEqual "fundGasAcct" (pString "Write succeeded")
       checkPactResultSuccess "paidTx" paidTx $ assertEqual "paidTx" (pDecimal 3)
+    test r = assertFailure $ "Expected 5 results, got: " ++ show r
+
+testFailureRedeem :: TxsTest
+testFailureRedeem = (txs,checkResultSuccess test)
+  where
+    txs = ks >>= \ks' ->
+      mkTestExecTransactions "sender00" "0" ks' "testFailureRedeem" 1000 0.01 1000000 0 $
+        V.fromList exps
+    ks = testKeyPairs sender00KeyPair Nothing
+    exps = map (`PactTransaction` Nothing)
+      ["(coin.get-balance \"sender00\")"
+      ,"(coin.get-balance \"miner\")"
+      ,"(enforce false \"forced error\")"
+      ,"(coin.get-balance \"sender00\")"
+      ,"(coin.get-balance \"miner\")"]
+    test [sbal0,mbal0,ferror,sbal1,mbal1] = do
+      -- sender 00 first is 100000000 - full gas debit during tx (10)
+      checkPactResultSuccess "sender bal 0" sbal0 $ assertEqual "sender bal 0" (pDecimal 99999990)
+      -- miner first is reward + epsilon tx size gas for [0]
+      checkPactResultSuccess "miner bal 0" mbal0 $ assertEqual "miner bal 0" (pDecimal 2.344523)
+      -- this should reward 10 more to miner
+      checkPactResultFailure "forced error" ferror "forced error"
+      -- sender 00 second is down epsilon size costs from [0,1] + 10 for error + 10 full gas debit during tx ~ 99999980
+      checkPactResultSuccess "sender bal 1" sbal1 $ assertEqual "sender bal 1" (pDecimal 99999979.92)
+      -- miner second is up 10 from error plus epsilon from [1,2,3] ~ 12
+      checkPactResultSuccess "miner bal 1" mbal1 $ assertEqual "miner bal 1" (pDecimal 12.424523)
     test r = assertFailure $ "Expected 5 results, got: " ++ show r
 
 

--- a/test/Chainweb/Test/Pact/PactInProcApi.hs
+++ b/test/Chainweb/Test/Pact/PactInProcApi.hs
@@ -111,7 +111,7 @@ modifyPayloadWithText
     -> PayloadWithText
 modifyPayloadWithText f pwt = mkPayloadWithText newPayload
   where
-    oldPayload = _payloadObj pwt
+    oldPayload = payloadObj pwt
     newPayload = f oldPayload
 
 testMemPoolAccess :: MemPoolAccess

--- a/test/Chainweb/Test/Pact/PactInProcApi.hs
+++ b/test/Chainweb/Test/Pact/PactInProcApi.hs
@@ -103,6 +103,17 @@ _getBlockHeaders cid n = gbh0 : take (n - 1) (testBlockHeaders gbh0)
   where
     gbh0 = genesisBlockHeader testVersion cid
 
+-- moved here, should NEVER be in production code:
+-- you can't modify a payload without recomputing hash/signatures
+modifyPayloadWithText
+    :: (Payload PublicMeta ParsedCode -> Payload PublicMeta ParsedCode)
+    -> PayloadWithText
+    -> PayloadWithText
+modifyPayloadWithText f pwt = mkPayloadWithText newPayload
+  where
+    oldPayload = _payloadObj pwt
+    newPayload = f oldPayload
+
 testMemPoolAccess :: MemPoolAccess
 testMemPoolAccess = MemPoolAccess
     { mpaGetBlock = \validate bh hash _header ->

--- a/test/Chainweb/Test/Pact/RemotePactTest.hs
+++ b/test/Chainweb/Test/Pact/RemotePactTest.hs
@@ -42,6 +42,7 @@ import Data.Default (def)
 import Data.Either
 import Data.Foldable (toList)
 import qualified Data.HashMap.Strict as HashMap
+import Data.List
 import qualified Data.List.NonEmpty as NEL
 import qualified Data.Map.Strict as M
 import Data.Maybe
@@ -49,7 +50,6 @@ import Data.Streaming.Network (HostPreference)
 import Data.String.Conv (toS)
 import Data.Text (Text)
 import qualified Data.Text as T
-import qualified Data.Text.Encoding as T
 import Data.Text.Encoding (encodeUtf8)
 import Data.Thyme.Clock
 import Data.Thyme.Calendar
@@ -78,6 +78,7 @@ import Pact.Types.Hash (Hash)
 import qualified Pact.Types.PactError as Pact
 import Pact.Types.Command
 import Pact.Types.Exp
+import Pact.Types.Gas
 import Pact.Types.PactValue
 import Pact.Types.Term
 
@@ -95,7 +96,6 @@ import Chainweb.Pact.Service.Types
 import Chainweb.Test.P2P.Peer.BootstrapConfig
 import Chainweb.Test.Pact.Utils
 import Chainweb.Test.Utils
-import Chainweb.Transaction
 import Chainweb.Time
 import Chainweb.Utils
 import Chainweb.Version
@@ -128,6 +128,9 @@ cid = head . toList $ chainIds v
 
 pactCid :: HasCallStack => Pact.ChainId
 pactCid = Pact.ChainId $ chainIdToText cid
+
+gp :: GasPrice
+gp = 0.1
 
 -- ------------------------------------------------------------------------- --
 -- Tests. GHCI use `runSchedRocks tests`
@@ -177,7 +180,7 @@ localTest :: IO (Time Integer) -> IO ChainwebNetwork -> IO ()
 localTest iot nio = do
     cenv <- fmap _getClientEnv nio
     mv <- newMVar 0
-    SubmitBatch batch <- testBatch iot mv
+    SubmitBatch batch <- testBatch iot mv gp
     let cmd = head $ toList batch
     sid <- mkChainId v (0 :: Int)
     res <- local sid cenv cmd
@@ -230,28 +233,29 @@ sendValidationTest iot nio =
         step "check sending poisoned TTL batch"
         cenv <- fmap _getClientEnv nio
         mv <- newMVar 0
-        SubmitBatch batch1 <- testBatch' iot 10000 mv
-        SubmitBatch batch2 <- testBatch' (return $ Time $ TimeSpan 0) 2 mv
+        SubmitBatch batch1 <- testBatch' iot 10000 mv gp
+        SubmitBatch batch2 <- testBatch' (return $ Time $ TimeSpan 0) 2 mv gp
         let batch = SubmitBatch $ batch1 <> batch2
-        sid <- mkChainId v (0 :: Int)
-        expectSendFailure $ flip runClientM cenv $ do
-            pactSendApiClient v sid batch
+        expectSendFailure "Transaction time is invalid or TTL is expired" $
+          flip runClientM cenv $
+            pactSendApiClient v cid batch
 
         step "check sending mismatched chain id"
-        batch3 <- testBatch'' "40" iot 20000 mv
-        expectSendFailure $ flip runClientM cenv $ do
-            pactSendApiClient v sid batch3
+        cid0 <- mkChainId v (0 :: Int)
+        batch3 <- testBatch'' "40" iot 20000 mv gp
+        expectSendFailure "Transaction metadata (chain id, chainweb version) conflicts with this endpoint" $
+          flip runClientM cenv $
+            pactSendApiClient v cid0 batch3
 
         step "check insufficient gas"
-        (SubmitBatch batch4) <- testBatch' iot 10000 mv
-        let b4 = SubmitBatch $ fmap mungeGasPrice batch4
-        expectSendFailure $ flip runClientM cenv $
-            pactSendApiClient v sid b4
+        batch4 <- testBatch' iot 10000 mv 10000000000
+        expectSendFailure "Sender account has insufficient gas" $ flip runClientM cenv $
+            pactSendApiClient v cid batch4
 
         step "check bad sender"
         batch5 <- mkBadGasTxBatch "(+ 1 2)" "invalid-sender" sender00KeyPair Nothing
-        expectSendFailure $ flip runClientM cenv $
-            pactSendApiClient v sid batch5
+        expectSendFailure "Sender account has insufficient gas" $ flip runClientM cenv $
+            pactSendApiClient v cid0 batch5
 
   where
     mkBadGasTxBatch code senderName senderKeyPair capList = do
@@ -263,24 +267,16 @@ sendValidationTest iot nio =
       cmds <- mapM cmd (0 NEL.:| [1..5])
       return $ SubmitBatch cmds
 
-    decodeOne = either error id . decodePayload . encodeUtf8
-    mungeGasPrice = fmap (T.decodeUtf8 . encodePayload . mungePayload . decodeOne)
-      where
-        mungePayload =
-            modifyPayloadWithText (set (pMeta . Pact.pmGasPrice) 10000000000)
-
-expectSendFailure :: Show a => IO (Either b a) -> IO ()
-expectSendFailure act = do
-    m <- (wrap `catch` h)
-    maybe (return ()) (\msg -> assertBool msg False) m
+expectSendFailure :: (Show a,Show b) => String -> IO (Either b a) -> Assertion
+expectSendFailure expectErr act = do
+  r :: Either SomeException (Either b a) <- try act
+  case r of
+    (Right (Left e)) -> test $ show e
+    (Right (Right out)) -> assertFailure $ "expected exception on bad tx, got: "
+                           <> show out
+    (Left e) -> test $ show e
   where
-    wrap = do
-        let ef out = Just ("expected exception on bad tx, got: "
-                           <> show out)
-        act >>= return . either (const Nothing) ef
-
-    h :: SomeException -> IO (Maybe String)
-    h _ = return Nothing
+    test er = assertSatisfies ("Expected message containing '" ++ expectErr ++ "'") er (isInfixOf expectErr)
 
 
 spvTest :: IO (Time Integer) -> IO ChainwebNetwork -> TestTree
@@ -597,7 +593,7 @@ withRequestKeys iot ioNonce networkIO f = withResource mkKeys (\_ -> return ()) 
         testSend iot mNonce cenv
 
 testSend :: IO (Time Integer) -> MVar Int -> ClientEnv -> IO RequestKeys
-testSend iot mNonce env = testBatch iot mNonce >>= sending cid env
+testSend iot mNonce env = testBatch iot mNonce gp >>= sending cid env
 
 getClientEnv :: BaseUrl -> IO ClientEnv
 getClientEnv url = do
@@ -719,8 +715,8 @@ polling sid cenv rks pollingExpectation =
       Just cr ->  _crReqKey cr == rk && validate (_crResult cr)
       Nothing -> False
 
-testBatch'' :: Pact.ChainId -> IO (Time Integer) -> Integer -> MVar Int -> IO SubmitBatch
-testBatch'' chain iot ttl mnonce = modifyMVar mnonce $ \(!nn) -> do
+testBatch'' :: Pact.ChainId -> IO (Time Integer) -> Integer -> MVar Int -> GasPrice -> IO SubmitBatch
+testBatch'' chain iot ttl mnonce gp' = modifyMVar mnonce $ \(!nn) -> do
     let nonce = "nonce" <> sshow nn
     t <- toTxCreationTime <$> iot
     kps <- testKeyPairs sender00KeyPair Nothing
@@ -728,12 +724,12 @@ testBatch'' chain iot ttl mnonce = modifyMVar mnonce $ \(!nn) -> do
     pure (succ nn, SubmitBatch (pure c))
   where
     pm :: Pact.TxCreationTime -> Pact.PublicMeta
-    pm = Pact.PublicMeta chain "sender00" 1000 0.1 (fromInteger ttl)
+    pm = Pact.PublicMeta chain "sender00" 1000 gp' (fromInteger ttl)
 
-testBatch' :: IO (Time Integer) -> Integer -> MVar Int -> IO SubmitBatch
+testBatch' :: IO (Time Integer) -> Integer -> MVar Int -> GasPrice -> IO SubmitBatch
 testBatch' = testBatch'' pactCid
 
-testBatch :: IO (Time Integer) -> MVar Int -> IO SubmitBatch
+testBatch :: IO (Time Integer) -> MVar Int -> GasPrice -> IO SubmitBatch
 testBatch iot mnonce = testBatch' iot ttl mnonce
   where
     ttl = 2 * 24 * 60 * 60

--- a/test/Chainweb/Test/Pact/SPV.hs
+++ b/test/Chainweb/Test/Pact/SPV.hs
@@ -140,19 +140,19 @@ standard = do
 
 
 wrongChain :: Assertion
-wrongChain = do -- expectFailure "enforceYield: yield provenance" $
+wrongChain = do
   (c1,c3) <- roundtrip 0 1 txGenerator1 txGenerator3
   checkResult c1 0 "ObjectMap"
   checkResult c3 1 "Failure: enforceYield: yield provenance"
 
 invalidProof :: Assertion
-invalidProof = do -- expectFailure "resumePact: no previous execution found" $
+invalidProof = do
   (c1,c3) <- roundtrip 0 1 txGenerator1 txGenerator4
   checkResult c1 0 "ObjectMap"
   checkResult c3 1 "Failure: resumePact: no previous execution found"
 
 wrongChainProof :: Assertion
-wrongChainProof = do -- expectFailure "cannot redeem continuation proof on wrong target chain" $
+wrongChainProof = do
   (c1,c3) <- roundtrip 0 1 txGenerator1 txGenerator5
   checkResult c1 0 "ObjectMap"
   checkResult c3 1 "cannot redeem continuation proof on wrong target chain"
@@ -160,7 +160,7 @@ wrongChainProof = do -- expectFailure "cannot redeem continuation proof on wrong
 
 checkResult :: HasCallStack => CutOutputs -> Word32 -> String -> Assertion
 checkResult co ci expect =
-  assertSatisfies ("Success result on chain " ++ show ci ++ " contains '" ++ show expect ++ "'")
+  assertSatisfies ("result on chain " ++ show ci ++ " contains '" ++ show expect ++ "'")
     (HM.lookup (unsafeChainId ci) co) (isInfixOf expect . show)
 
 

--- a/test/Chainweb/Test/Pact/SPV.hs
+++ b/test/Chainweb/Test/Pact/SPV.hs
@@ -29,9 +29,8 @@ module Chainweb.Test.Pact.SPV
 
 import Control.Arrow ((***))
 import Control.Concurrent.MVar
-import Control.Exception (SomeException, finally, throwIO)
+import Control.Exception (SomeException, finally)
 import Control.Lens hiding ((.=))
-import Control.Monad.Catch (catch)
 import Control.Monad
 
 import Data.Aeson as Aeson
@@ -40,7 +39,6 @@ import Data.ByteString.Lazy (toStrict)
 import Data.CAS (casLookupM)
 import Data.Foldable
 import Data.Function
-import Data.Functor (void)
 import qualified Data.HashMap.Strict as HM
 import Data.IORef
 import Data.List (isInfixOf)
@@ -48,6 +46,7 @@ import Data.Text (pack,Text)
 import qualified Data.Text.IO as T
 import Data.Vector (Vector, fromList)
 import qualified Data.Vector as Vector
+import Data.Word
 
 import NeatInterpolation (text)
 
@@ -83,6 +82,7 @@ import Chainweb.SPV.CreateProof
 import Chainweb.Sync.WebBlockHeaderStore
 import Chainweb.Test.CutDB
 import Chainweb.Test.Pact.Utils
+import Chainweb.Test.Utils
 import Chainweb.Time
 import Chainweb.Transaction
 import Chainweb.Utils hiding (check)
@@ -120,8 +120,6 @@ gorder = int . order . _chainGraph $ v
 height :: Chainweb.ChainId -> Cut -> BlockHeight
 height cid c = _blockHeight $ c ^?! ixg cid
 
-handle :: SomeException -> IO (Bool, String)
-handle e = return (False, show e)
 
 -- debugging
 _handle' :: SomeException -> IO (Bool, String)
@@ -130,40 +128,40 @@ _handle' e =
       s = show e
     in logg System.LogLevel.Error (pack s) >> return (False, s)
 
--- | expected failures take this form.
---
-expectFailure :: String -> IO (Bool, String) -> Assertion
-expectFailure err test = do
-    (b, s) <- catch test handle
-    if err `isInfixOf` s then
-      assertBool "Unexpected success" $ not b
-    else throwIO $ userError s
-
-
--- | expected successes take this form
---
-expectSuccess :: IO (Bool, String) -> Assertion
-expectSuccess test = do
-    (b, s) <- catch test handle
-    assertBool ("Unexpected failure: " <> s) b
 
 -- -------------------------------------------------------------------------- --
 -- tests
 
 standard :: Assertion
-standard = expectSuccess $ roundtrip 0 1 txGenerator1 txGenerator2
+standard = do
+  (c1,c3) <- roundtrip 0 1 txGenerator1 txGenerator2
+  checkResult c1 0 "ObjectMap"
+  checkResult c3 1 "Write succeeded"
+
 
 wrongChain :: Assertion
-wrongChain = expectFailure "enforceYield: yield provenance" $
-    roundtrip 0 1 txGenerator1 txGenerator3
+wrongChain = do -- expectFailure "enforceYield: yield provenance" $
+  (c1,c3) <- roundtrip 0 1 txGenerator1 txGenerator3
+  checkResult c1 0 "ObjectMap"
+  checkResult c3 1 "Failure: enforceYield: yield provenance"
 
 invalidProof :: Assertion
-invalidProof = expectFailure "resumePact: no previous execution found" $
-    roundtrip 0 1 txGenerator1 txGenerator4
+invalidProof = do -- expectFailure "resumePact: no previous execution found" $
+  (c1,c3) <- roundtrip 0 1 txGenerator1 txGenerator4
+  checkResult c1 0 "ObjectMap"
+  checkResult c3 1 "Failure: resumePact: no previous execution found"
 
 wrongChainProof :: Assertion
-wrongChainProof = expectFailure "cannot redeem continuation proof on wrong target chain" $
-    roundtrip 0 1 txGenerator1 txGenerator5
+wrongChainProof = do -- expectFailure "cannot redeem continuation proof on wrong target chain" $
+  (c1,c3) <- roundtrip 0 1 txGenerator1 txGenerator5
+  checkResult c1 0 "ObjectMap"
+  checkResult c3 1 "cannot redeem continuation proof on wrong target chain"
+  return ()
+
+checkResult :: HasCallStack => CutOutputs -> Word32 -> String -> Assertion
+checkResult co ci expect =
+  assertSatisfies ("Success result on chain " ++ show ci ++ " contains '" ++ show expect ++ "'")
+    (HM.lookup (unsafeChainId ci) co) (isInfixOf expect . show)
 
 
 withAll :: ChainwebVersion -> ([SQLiteEnv] -> IO c) -> IO c
@@ -181,7 +179,7 @@ roundtrip
       -- ^ burn tx generator
     -> CreatesGenerator
       -- ^ create tx generator
-    -> IO (Bool, String)
+    -> IO (CutOutputs, CutOutputs)
 roundtrip sid0 tid0 burn create =
   withAll v $ \sqlenv0s -> withAll v $ \sqlenv1s -> withAll v $ \sqlenv2s -> do
     -- Pact service that is used to initialize the cut data base
@@ -216,12 +214,17 @@ roundtrip sid0 tid0 burn create =
 
             c0 <- _cut cutDb
 
+            -- _debugCut "c0" c0 payloadDb
+
             -- get tx output from `(coin.delete-coin ...)` call.
             -- Note: we must mine at least (diam + 1) * graph order many blocks
             -- to ensure we synchronize the cutdb across all chains
 
             c1 <- fmap fromJuste $ extendAwait cutDb pact1 ((diam + 1) * gorder) $
                 ((<) `on` height sid) c0
+
+            -- _debugCut "c1" c1 payloadDb
+
 
             -- A proof can only be constructed if the block hash of the source
             -- block is included in the block hash of the target. Extending the
@@ -245,6 +248,8 @@ roundtrip sid0 tid0 burn create =
             c2 <- fmap fromJuste $ extendAwait cutDb pact1 10 $ \c ->
                 height tid c > diam + height sid c1
 
+            -- _debugCut "c2" c2 payloadDb
+
             -- execute '(coin.create-coin ...)' using the  correct chain id and block height
             t2 <- getCurrentTimeIntegral
             txGen2 <- create t2 cdb pidv sid tid (height sid c1)
@@ -255,16 +260,30 @@ roundtrip sid0 tid0 burn create =
             syncPact cutDb pact2
 
             -- consume the stream and mine second batch of transactions
-            void $ fmap fromJuste $ extendAwait cutDb pact2 ((diam + 1) * gorder) $
+            c3 <- fmap fromJuste $ extendAwait cutDb pact2 ((diam + 1) * gorder) $
                 ((<) `on` height tid) c2
 
-            return (True, "test succeeded")
+            -- _debugCut "c3" c3 payloadDb
+
+            (,) <$> cutToPayloadOutputs c1 payloadDb <*>
+              cutToPayloadOutputs c3 payloadDb
+
+_debugCut :: PayloadCas cas => String -> Cut -> PayloadDb cas -> IO ()
+_debugCut msg c pdb = do
+  putStrLn $ "CUT: =============== " ++ msg
+  outs <- cutToPayloadOutputs c pdb
+  forM_ (HM.toList outs) $ \(cid,vs) -> do
+    putStrLn $ "Chain: " ++ show cid
+    forM_ vs $ \(cmd,pr) -> do
+      putStrLn $ show (_cmdHash cmd) ++ ": " ++ show pr
+
+type CutOutputs = HM.HashMap Chainweb.ChainId (Vector (Command Text,HashCommandResult))
 
 cutToPayloadOutputs
   :: PayloadCas cas
   => Cut
   -> PayloadDb cas
-  -> IO (HM.HashMap Chainweb.ChainId (Vector (Command Text,HashCommandResult)))
+  -> IO CutOutputs
 cutToPayloadOutputs c pdb = do
   forM (_cutMap c) $ \bh -> do
     outs <- casLookupM pdb (_blockPayloadHash bh)


### PR DESCRIPTION
This addresses a bug in the tx exec logic which failed to reward miners in the case of payloads that failed for whatever reason.  