### PR TITLE
Restore infos on pre-compiled terms

### DIFF
--- a/chainweb.cabal
+++ b/chainweb.cabal
@@ -381,6 +381,7 @@ library
         , tls >=1.5.2
         , token-bucket >= 0.1
         , transformers >= 0.5
+        , trifecta >= 2.1
         , unordered-containers >= 0.2
         , uuid >= 1.3
         , wai >= 3.2

--- a/src/Chainweb/Pact/Templates.hs
+++ b/src/Chainweb/Pact/Templates.hs
@@ -30,6 +30,8 @@ import qualified Data.Aeson as A
 import Data.Default (def)
 import Data.Text (Text)
 
+import Text.Trifecta.Delta (Delta(..))
+
 import Pact.Parse
 import Pact.Types.Command
 import Pact.Types.RPC
@@ -38,20 +40,24 @@ import Pact.Types.Runtime
 import Chainweb.Miner.Pact
 import Chainweb.Pact.Types
 
+inf :: Info
+inf = Info $ Just (Code "",Parsed (Columns 0 0) 0)
+{-# NOINLINE inf #-}
+
 app :: Name -> [Term Name] -> Term Name
-app f as = TApp (App (TVar f def) as def) def
+app f as = TApp (App (TVar f inf) as inf) inf
 {-# INLINE app #-}
 
 qn :: ModuleName -> Text -> Name
-qn mn d = QName $ QualifiedName mn d def
+qn mn d = QName $ QualifiedName mn d inf
 {-# INLINE qn #-}
 
 bn :: Text -> Name
-bn n = Name $ BareName n def
+bn n = Name $ BareName n inf
 {-# INLINE bn #-}
 
 strLit :: Text -> Term Name
-strLit s = TLiteral (LString s) def
+strLit s = TLiteral (LString s) inf
 {-# INLINE strLit #-}
 
 strArgSetter :: Int -> ASetter' (Term Name) Text


### PR DESCRIPTION
Should resolve replay issue, was able to reproduce JSON output on a bad coinbase:

```  Chainweb.Test.Pact.PactExec
    testBadMinerFails: {
    "Right": {
        "gas": 0,
        "result": {
            "status": "failure",
            "error": {
                "callStack": [
                    "<interactive>:0:11303: (enforce (native `=`  Compare alike terms for equality, ret... \"account guards do not match\")",
                    "<interactive>:0:11175: (bind: [balance:<af> 100000000.0, retg:<ag> KeySet {keys: [368820f80c324bbc7c2b0610688a7da43e3...])",
                    "<interactive>:0:11088: (with-default-read (deftable coin-table:(defschema coin-schema \"The c... \"sender00\" {\"balance\": 0.0,\"guard\": KeySet {keys: [skdjhfskj]... ({balance:<af> \"balance\",retg:<ag> \"guard\"} [(nati...)",
                    "<interactive>:0:9096: (credit \"sender00\" KeySet {keys: [skdjhfskj],pred: bad} 2.304523)",
                    "<interactive>:0:9056: (with-capability ((defcap coin.CREDIT:<f> (receiver:string) Capabil... [((defun coin.credit:string (account:string guard:...)",
                    "<interactive>:0:0: (coinbase \"sender00\" KeySet {keys: [skdjhfskj],pred: bad} 2.304523)"
                ],
                "type": "TxFailure",
                "message": "account guards do not match",
                "info": "<interactive>:0:11303"
            }
        },
        "reqKey": "IkFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUEi",
        "logs": "wsATyGqckuIvlm89hhd2j4t6RMkCrcwJe_oeCYr7Th8",
        "metaData": null,
        "continuation": null,
        "txId": null
    }
}
OK (0.10s)```