### PR TITLE
prune peer db and update peer selection

### DIFF
--- a/src/P2P/Node/PeerDB.hs
+++ b/src/P2P/Node/PeerDB.hs
@@ -400,7 +400,12 @@ peerDbInsertList peers (PeerDb _ lock var) =
 
 peerDbInsertPeerInfoList :: NetworkId -> [PeerInfo] -> PeerDb -> IO ()
 peerDbInsertPeerInfoList _ _ (PeerDb True _ _) = return ()
-peerDbInsertPeerInfoList nid ps db = peerDbInsertList (newPeerEntry nid <$> ps) db
+peerDbInsertPeerInfoList nid ps db = do
+    now <- getCurrentTime
+    peerDbInsertList (mkEntry now <$> ps) db
+  where
+    mkEntry now x = newPeerEntry nid x
+        & set peerEntryLastSuccess (LastSuccess (Just now))
 
 peerDbInsertPeerInfoList_ :: Bool -> NetworkId -> [PeerInfo] -> PeerDb -> IO ()
 peerDbInsertPeerInfoList_ _ _ _ (PeerDb True _ _) = return ()


### PR DESCRIPTION
* [x] prune peer db on each peer db sync (is that too often?)
* [x] limit number of _new_ peers on each sync to at most 32
* [x] process up to 16 new peers concurrently (most of the overhead is in the connection check which is IO bound and thus there is no need to limit it to the number of capabilities)
* [x] on new peers selection only use two priority classes and sort the second class by successive failures (ascending).