### PR TITLE
Primed Mining Coordination

### DIFF
--- a/src/Chainweb/BlockHeader.hs
+++ b/src/Chainweb/BlockHeader.hs
@@ -930,10 +930,10 @@ newBlockHeader
         -- ^ Randomness to affect the block hash
     -> BlockCreationTime
         -- ^ Creation time of the block
-    -> BlockHeader
+    -> ParentHeader
         -- ^ parent block header
     -> BlockHeader
-newBlockHeader adj pay nonce t b = fromLog $ newMerkleLog
+newBlockHeader adj pay nonce t (ParentHeader b) = fromLog $ newMerkleLog
     $ nonce
     :+: t
     :+: _blockHash b
@@ -973,11 +973,11 @@ testBlockHeader
         -- ^ Adjacent parent hashes
     -> Nonce
         -- ^ Randomness to affect the block hash
-    -> BlockHeader
+    -> ParentHeader
         -- ^ parent block header
     -> BlockHeader
-testBlockHeader adj nonce b
-    = newBlockHeader adj (testBlockPayload b) nonce (BlockCreationTime $ add second t) b
+testBlockHeader adj nonce p@(ParentHeader b) =
+    newBlockHeader adj (testBlockPayload b) nonce (BlockCreationTime $ add second t) p
   where
     BlockCreationTime t = _blockCreationTime b
 
@@ -986,17 +986,17 @@ testBlockHeader adj nonce b
 --
 -- Should only be used for testing purposes.
 --
-testBlockHeaders :: BlockHeader -> [BlockHeader]
-testBlockHeaders = unfoldr (Just . (id &&& id) . f)
+testBlockHeaders :: ParentHeader -> [BlockHeader]
+testBlockHeaders (ParentHeader p) = unfoldr (Just . (id &&& id) . f) p
   where
-    f b = testBlockHeader (BlockHashRecord mempty) (_blockNonce b) b
+    f b = testBlockHeader (BlockHashRecord mempty) (_blockNonce b) $ ParentHeader b
 
 -- | Given a `BlockHeader` of some initial parent, generate an infinite stream
 -- of `BlockHeader`s which form a legal chain.
 --
 -- Should only be used for testing purposes.
 --
-testBlockHeadersWithNonce :: Nonce -> BlockHeader -> [BlockHeader]
-testBlockHeadersWithNonce n = unfoldr (Just . (id &&& id) . f)
+testBlockHeadersWithNonce :: Nonce -> ParentHeader -> [BlockHeader]
+testBlockHeadersWithNonce n (ParentHeader p) = unfoldr (Just . (id &&& id) . f) p
   where
-    f b = testBlockHeader (BlockHashRecord mempty) n b
+    f b = testBlockHeader (BlockHashRecord mempty) n $ ParentHeader b

--- a/src/Chainweb/BlockHeader.hs
+++ b/src/Chainweb/BlockHeader.hs
@@ -928,14 +928,14 @@ newBlockHeader
         -- ^ payload hash
     -> Nonce
         -- ^ Randomness to affect the block hash
-    -> Time Micros
+    -> BlockCreationTime
         -- ^ Creation time of the block
     -> BlockHeader
         -- ^ parent block header
     -> BlockHeader
 newBlockHeader adj pay nonce t b = fromLog $ newMerkleLog
     $ nonce
-    :+: BlockCreationTime t
+    :+: t
     :+: _blockHash b
     :+: target
     :+: pay
@@ -943,13 +943,13 @@ newBlockHeader adj pay nonce t b = fromLog $ newMerkleLog
     :+: _blockWeight b + BlockWeight (targetToDifficulty target)
     :+: _blockHeight b + 1
     :+: v
-    :+: epochStart b (BlockCreationTime t)
+    :+: epochStart b t
     :+: FeatureFlags 0
     :+: MerkleLogBody (blockHashRecordToVector adj)
   where
     cid = _chainId b
     v = _blockChainwebVersion b
-    target = powTarget b (BlockCreationTime t)
+    target = powTarget b t
 
 -- -------------------------------------------------------------------------- --
 -- TreeDBEntry instance
@@ -977,7 +977,7 @@ testBlockHeader
         -- ^ parent block header
     -> BlockHeader
 testBlockHeader adj nonce b
-    = newBlockHeader adj (testBlockPayload b) nonce (add second t) b
+    = newBlockHeader adj (testBlockPayload b) nonce (BlockCreationTime $ add second t) b
   where
     BlockCreationTime t = _blockCreationTime b
 

--- a/src/Chainweb/Chainweb/MinerResources.hs
+++ b/src/Chainweb/Chainweb/MinerResources.hs
@@ -69,6 +69,7 @@ import Chainweb.Version
 import Chainweb.WebPactExecutionService (_webPactExecutionService)
 
 import Data.LogMessage (JsonLog(..), LogFunction)
+import Utils.Logging.Trace (trace)
 
 -- -------------------------------------------------------------------------- --
 -- Miner

--- a/src/Chainweb/Chainweb/MinerResources.hs
+++ b/src/Chainweb/Chainweb/MinerResources.hs
@@ -5,6 +5,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TupleSections #-}
 {-# LANGUAGE TypeFamilies #-}
 
 -- |
@@ -28,36 +29,44 @@ module Chainweb.Chainweb.MinerResources
 
 import Data.Generics.Wrapped (_Unwrapped)
 import Data.HashMap.Strict (HashMap)
+import qualified Data.HashMap.Strict as HM
+import qualified Data.HashSet as HS
 import Data.IORef (IORef, atomicWriteIORef, newIORef, readIORef)
+import Data.List (foldl')
 import qualified Data.Map.Strict as M
-import Data.Tuple.Strict (T3(..))
+import qualified Data.Set as S
+import Data.Tuple.Strict (T2(..), T3(..))
 import qualified Data.Vector as V
 
 import Control.Concurrent (threadDelay)
-import Control.Concurrent.Async (concurrently)
+import Control.Concurrent.Async (Concurrently(..), runConcurrently)
 import Control.Concurrent.STM (atomically)
-import Control.Concurrent.STM.TVar (TVar, modifyTVar', newTVarIO, readTVar)
-import Control.Lens (over)
+import Control.Concurrent.STM.TVar
+import Control.Lens (at, over, view, (&), (?~), (^?!))
 
 import System.LogLevel (LogLevel(..))
 import qualified System.Random.MWC as MWC
 
 -- internal modules
 
-import Chainweb.BlockHeader (BlockCreationTime(..))
+import Chainweb.BlockHeader
 import Chainweb.ChainId
 import Chainweb.Chainweb.ChainResources
-import Chainweb.CutDB (CutDb)
+import Chainweb.Cut (Cut, _cutMap)
+import Chainweb.CutDB (CutDb, awaitNewCutByChainId, cutDbPayloadStore, _cut)
 import Chainweb.Logger (Logger, logFunction)
 import Chainweb.Miner.Config
 import Chainweb.Miner.Coordinator
-    (MiningState(..), MiningStats(..), PrevTime(..))
 import Chainweb.Miner.Miners
+import Chainweb.Miner.Pact (Miner(..), minerId)
 import Chainweb.Payload (PayloadWithOutputs(..))
 import Chainweb.Payload.PayloadStore
+import Chainweb.Sync.WebBlockHeaderStore (_webBlockPayloadStorePact)
+import Chainweb.Sync.WebBlockHeaderStore (PactExecutionService, _pactNewBlock)
 import Chainweb.Time (Micros, Time(..), getCurrentTimeIntegral)
-import Chainweb.Utils (runForever)
-import Chainweb.Version (ChainwebVersion(..), window)
+import Chainweb.Utils (fromJuste, ixg, runForever, thd)
+import Chainweb.Version
+import Chainweb.WebPactExecutionService (_webPactExecutionService)
 
 import Data.LogMessage (JsonLog(..), LogFunction)
 
@@ -85,24 +94,83 @@ withMiningCoordination
     -> CutDb cas
     -> (Maybe (MiningCoordination logger cas) -> IO a)
     -> IO a
-withMiningCoordination logger conf cutDb inner
+withMiningCoordination logger conf cdb inner
     | not (_coordinationEnabled conf) = inner Nothing
     | otherwise = do
+        cut <- _cut cdb
         t <- newTVarIO mempty
+        let !miners = S.toList $ _coordinationMiners conf
+        m <- initialPayloads cut miners >>= newTVarIO
         c503 <- newIORef 0
         c403 <- newIORef 0
         l <- newIORef (_coordinationUpdateStreamLimit conf)
-        fmap snd . concurrently (prune t c503 c403) $ inner . Just $ MiningCoordination
-            { _coordLogger = logger
-            , _coordCutDb = cutDb
-            , _coordState = t
-            , _coordLimit = _coordinationReqLimit conf
-            , _coord503s = c503
-            , _coord403s = c403
-            , _coordConf = conf
-            , _coordUpdateStreamCount = l
-            }
+        fmap thd . runConcurrently $ (,,)
+            <$> Concurrently (prune t c503 c403)
+            <*> Concurrently (primeWork miners m cut $ unsafeChainId 0)  -- TODO per chain
+            <*> Concurrently (inner . Just $ MiningCoordination
+                { _coordLogger = logger
+                , _coordCutDb = cdb
+                , _coordState = t
+                , _coordLimit = _coordinationReqLimit conf
+                , _coord503s = c503
+                , _coord403s = c403
+                , _coordConf = conf
+                , _coordUpdateStreamCount = l })
   where
+    -- | THREAD: Keep a live-updated cache of Payloads for specific miners, such
+    -- that when they request new work, the block can be instantly constructed
+    -- without interacting with the Pact Queue.
+    --
+    primeWork :: [Miner] -> TVar PrimedWork -> Cut -> ChainId -> IO ()
+    primeWork miners tpw cut cid = do
+        -- Even if the `cut` passed to the function is old, this call here will
+        -- immediately detect the newest `BlockHeader` on the given chain.
+        new <- awaitNewCutByChainId cdb cid cut
+        let !newParent = ParentHeader . fromJuste . HM.lookup cid $ _cutMap new
+        -- Generate new payloads, one for each Miner we're managing --
+        payloads <- traverse (\m -> T2 m <$> getPayload newParent m) miners
+        -- Update the cache in a single step --
+        atomically $ modifyTVar' tpw (\pw -> foldl' (updateCache cid) pw payloads)
+        primeWork miners tpw new cid  -- TODO runForever?
+
+    updateCache
+        :: ChainId
+        -> PrimedWork
+        -> T2 Miner (T2 PayloadWithOutputs BlockCreationTime)
+        -> PrimedWork
+    updateCache cid (PrimedWork pw) (T2 (Miner mid _) payload) =
+        PrimedWork (pw & at mid . traverse . at cid ?~ payload)
+
+    initialPayloads :: Cut -> [Miner] -> IO PrimedWork
+    initialPayloads cut ms =
+        PrimedWork . HM.fromList <$> traverse (\m -> (view minerId m,) <$> fromCut m pairs) ms
+      where
+        cids :: [ChainId]
+        cids = HS.toList . chainIds $ _chainwebVersion cdb
+
+        pairs :: [T2 ChainId ParentHeader]
+        pairs = map (\cid -> T2 cid (ParentHeader (cut ^?! ixg cid))) cids
+
+    -- | Based on a `Cut`, form payloads for each chain for a given `Miner`.
+    --
+    fromCut
+      :: Miner
+      -> [T2 ChainId ParentHeader]
+      -> IO (HM.HashMap ChainId (T2 PayloadWithOutputs BlockCreationTime))
+    fromCut m cut = HM.fromList <$> traverse (\(T2 cid bh) -> (cid,) <$> getPayload bh m) cut
+
+    getPayload :: ParentHeader -> Miner -> IO (T2 PayloadWithOutputs BlockCreationTime)
+    getPayload (ParentHeader parent) m = do
+        creationTime <- BlockCreationTime <$> getCurrentTimeIntegral
+        payload <- _pactNewBlock pact m parent creationTime
+        pure $ T2 payload creationTime
+
+    pact :: PactExecutionService
+    pact = _webPactExecutionService . _webBlockPayloadStorePact $ view cutDbPayloadStore cdb
+
+    -- | THREAD: Periodically clear out the cached payloads kept for Mining
+    -- Coordination.
+    --
     prune :: TVar MiningState -> IORef Int -> IORef Int -> IO ()
     prune t c503 c403 = runForever (logFunction logger) "MinerResources.prune" $ do
         let !d = 30_000_000  -- 30 seconds

--- a/src/Chainweb/Chainweb/MinerResources.hs
+++ b/src/Chainweb/Chainweb/MinerResources.hs
@@ -177,8 +177,8 @@ withMiningCoordination logger conf cdb inner
     getPayload :: ParentHeader -> Miner -> IO (T2 PayloadWithOutputs BlockCreationTime)
     getPayload (ParentHeader parent) m = do
         creationTime <- BlockCreationTime <$> getCurrentTimeIntegral
-        payload <- trace logFun "Chainweb.Chainweb.MinerResources.withMiningCoordination.newBlock" () 1
-            (_pactNewBlock pact m parent creationTime)
+        payload <- trace (logFunction logger) "Chainweb.Chainweb.MinerResources.withMiningCoordination.newBlock"
+            () 1 (_pactNewBlock pact m parent creationTime)
         pure $ T2 payload creationTime
 
     pact :: PactExecutionService

--- a/src/Chainweb/Chainweb/MinerResources.hs
+++ b/src/Chainweb/Chainweb/MinerResources.hs
@@ -176,7 +176,8 @@ withMiningCoordination logger conf cdb inner
     getPayload :: ParentHeader -> Miner -> IO (T2 PayloadWithOutputs BlockCreationTime)
     getPayload (ParentHeader parent) m = do
         creationTime <- BlockCreationTime <$> getCurrentTimeIntegral
-        payload <- _pactNewBlock pact m parent creationTime
+        payload <- trace logFun "Chainweb.Chainweb.MinerResources.withMiningCoordination.newBlock" () 1
+            (_pactNewBlock pact m parent creationTime)
         pure $ T2 payload creationTime
 
     pact :: PactExecutionService

--- a/src/Chainweb/Cut/Test.hs
+++ b/src/Chainweb/Cut/Test.hs
@@ -156,7 +156,7 @@ createNewCut n t pay i c = do
     p = c ^?! ixg cid
 
     newHeader :: BlockHashRecord -> BlockHeader
-    newHeader as = newBlockHeader as pay n t p
+    newHeader as = newBlockHeader as pay n (BlockCreationTime t) p
 
     -- | Try to get all adjacent hashes dependencies.
     --

--- a/src/Chainweb/Cut/Test.hs
+++ b/src/Chainweb/Cut/Test.hs
@@ -156,7 +156,7 @@ createNewCut n t pay i c = do
     p = c ^?! ixg cid
 
     newHeader :: BlockHashRecord -> BlockHeader
-    newHeader as = newBlockHeader as pay n (BlockCreationTime t) p
+    newHeader as = newBlockHeader as pay n (BlockCreationTime t) $ ParentHeader p
 
     -- | Try to get all adjacent hashes dependencies.
     --

--- a/src/Chainweb/Miner/Config.hs
+++ b/src/Chainweb/Miner/Config.hs
@@ -43,7 +43,7 @@ import Control.Lens (lens, view)
 import Control.Monad (when)
 import Control.Monad.Except (throwError)
 
-import qualified Data.HashSet as HS
+import qualified Data.Set as S
 
 import GHC.Generics (Generic)
 
@@ -53,7 +53,7 @@ import Pact.Types.Term (mkKeySet)
 
 -- internal modules
 
-import Chainweb.Miner.Pact (Miner(..), MinerId, MinerKeys(..), minerId)
+import Chainweb.Miner.Pact (Miner(..), MinerKeys(..), minerId)
 import Chainweb.Time (Seconds)
 
 ---
@@ -106,10 +106,10 @@ data CoordinationConfig = CoordinationConfig
       -- present on the node.
     , _coordinationMode :: !CoordinationMode
       -- ^ `Public` or `Private`.
-    , _coordinationMiners :: !(HS.HashSet MinerId)
+    , _coordinationMiners :: !(S.Set Miner)
       -- ^ When the mode is set to `Private`, this field must contain at least
-      -- one `MinerId` (i.e. account name) in order for work requests to be
-      -- made.
+      -- one `Miner` identity in order for work requests to be made.
+      -- Further, such miners are eligible for "Primed Coordination".
     , _coordinationReqLimit :: !Int
       -- ^ The number of @/mining/work/@ requests that can be made to this node
       -- in a 5 minute period.
@@ -128,14 +128,16 @@ coordinationLimit = lens _coordinationReqLimit (\m c -> m { _coordinationReqLimi
 coordinationMode :: Lens' CoordinationConfig CoordinationMode
 coordinationMode = lens _coordinationMode (\m c -> m { _coordinationMode = c })
 
-coordinationMiners :: Lens' CoordinationConfig (HS.HashSet MinerId)
+coordinationMiners :: Lens' CoordinationConfig (S.Set Miner)
 coordinationMiners = lens _coordinationMiners (\m c -> m { _coordinationMiners = c })
 
 coordinationUpdateStreamLimit :: Lens' CoordinationConfig Int
-coordinationUpdateStreamLimit = lens _coordinationUpdateStreamLimit (\m c -> m { _coordinationUpdateStreamLimit = c })
+coordinationUpdateStreamLimit =
+    lens _coordinationUpdateStreamLimit (\m c -> m { _coordinationUpdateStreamLimit = c })
 
 coordinationUpdateStreamTimeout :: Lens' CoordinationConfig Seconds
-coordinationUpdateStreamTimeout = lens _coordinationUpdateStreamTimeout (\m c -> m { _coordinationUpdateStreamTimeout = c })
+coordinationUpdateStreamTimeout =
+    lens _coordinationUpdateStreamTimeout (\m c -> m { _coordinationUpdateStreamTimeout = c })
 
 instance ToJSON CoordinationConfig where
     toJSON o = object

--- a/src/Chainweb/Miner/Coordinator.hs
+++ b/src/Chainweb/Miner/Coordinator.hs
@@ -26,6 +26,7 @@ module Chainweb.Miner.Coordinator
   , MiningStats(..)
   , PrevTime(..)
   , ChainChoice(..)
+  , PrimedWork(..)
     -- * Functions
   , newWork
   , publish
@@ -66,7 +67,7 @@ import Chainweb.Cut.CutHashes
 import Chainweb.CutDB
 import Chainweb.Difficulty
 import Chainweb.Logging.Miner
-import Chainweb.Miner.Pact (Miner, minerId)
+import Chainweb.Miner.Pact (Miner, MinerId(..), minerId)
 import Chainweb.Payload
 import Chainweb.Sync.WebBlockHeaderStore
 import Chainweb.Time (Micros(..), getCurrentTimeIntegral)
@@ -79,6 +80,12 @@ import Utils.Logging.Trace (trace)
 
 -- -------------------------------------------------------------------------- --
 -- Miner
+
+-- | Precached payloads for Private Miners. This allows new work requests to be
+-- made as often as desired, without clogging the Pact queue.
+--
+newtype PrimedWork =
+    PrimedWork (HM.HashMap MinerId (HM.HashMap ChainId (T2 PayloadWithOutputs BlockCreationTime)))
 
 -- | Data shared between the mining threads represented by `newWork` and
 -- `publish`.

--- a/src/Chainweb/Miner/Coordinator.hs
+++ b/src/Chainweb/Miner/Coordinator.hs
@@ -5,6 +5,7 @@
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
@@ -27,6 +28,7 @@ module Chainweb.Miner.Coordinator
   , PrevTime(..)
   , ChainChoice(..)
   , PrimedWork(..)
+  , CachedPayload
     -- * Functions
   , newWork
   , publish
@@ -34,6 +36,7 @@ module Chainweb.Miner.Coordinator
 
 import Data.Aeson (ToJSON)
 import Data.Bool (bool)
+import Data.Coerce (coerce)
 
 import Control.Concurrent.STM.TVar
 import Control.DeepSeq (NFData)
@@ -68,6 +71,7 @@ import Chainweb.Cut.CutHashes
 import Chainweb.CutDB
 import Chainweb.Difficulty
 import Chainweb.Logging.Miner
+import Chainweb.Miner.Config (CoordinationMode(..))
 import Chainweb.Miner.Pact (Miner(..), MinerId(..), minerId)
 import Chainweb.Payload
 import Chainweb.Sync.WebBlockHeaderStore
@@ -86,8 +90,10 @@ import Utils.Logging.Trace (trace)
 -- made as often as desired, without clogging the Pact queue.
 --
 newtype PrimedWork =
-    PrimedWork (HM.HashMap MinerId (HM.HashMap ChainId (T2 PayloadWithOutputs BlockCreationTime)))
+    PrimedWork (HM.HashMap MinerId (HM.HashMap ChainId (Maybe CachedPayload)))
     deriving newtype (Semigroup, Monoid)
+
+type CachedPayload = T2 PayloadWithOutputs BlockCreationTime
 
 -- | Data shared between the mining threads represented by `newWork` and
 -- `publish`.
@@ -118,13 +124,14 @@ data ChainChoice = Anything | TriedLast ChainId | Suggestion ChainId
 --
 newWork
     :: LogFunction
+    -> CoordinationMode
     -> ChainChoice
     -> Miner
     -> PactExecutionService
     -> TVar PrimedWork
     -> Cut
     -> IO (T3 PrevTime BlockHeader PayloadWithOutputs)
-newWork logFun choice miner@(Miner mid _) pact tpw c = do
+newWork logFun mode choice miner@(Miner mid _) pact tpw c = do
     -- Randomly pick a chain to mine on, unless the caller specified a specific
     -- one.
     --
@@ -134,43 +141,35 @@ newWork logFun choice miner@(Miner mid _) pact tpw c = do
     -- contain at least a genesis block, so this otherwise naughty
     -- `^?!` will always succeed.
     --
-    let !p = c ^?! ixg cid
+    let !p = ParentHeader (c ^?! ixg cid)
 
-    -- Check if the chain can be mined on by determining if adjacent parents
-    -- also exist. If they don't, we test other chains on this same `Cut`,
-    -- since we still believe this `Cut` to be good.
-    --
-    -- Note that if the caller did specify a specific chain to mine on, we only
-    -- attempt this once. We assume they'd rather have /some/ work on /some/
-    -- chain rather than no work on their chosen chain. This will also help
-    -- rebalance "selfish" mining, for remote clients who claim that they want
-    -- to focus their hash power on a certain chain.
-    --
-    -- TODO Consider instead some maximum amount of retries?
-    --
-    case getAdjacentParents c p of
-        Nothing -> newWork logFun (TriedLast cid) miner pact tpw c
-        Just adjParents -> do
-            PrimedWork pw <- readTVarIO tpw
-            T2 payload creationTime <- case HM.lookup mid pw >>= HM.lookup cid of
-                Just pt -> pure pt
-                Nothing -> do
-                    -- Fetch a Pact Transaction payload. This is an expensive call
-                    -- that shouldn't be repeated.
-                    --
-                    creationTime <- BlockCreationTime <$> getCurrentTimeIntegral
-                    payload <- trace logFun "Chainweb.Miner.Coordinator.newWork.newBlock" () 1
-                        (_pactNewBlock pact miner p creationTime)
-                    pure $ T2 payload creationTime
-
+    bool (public p) (private cid p <$> readTVarIO tpw) (mode == Private) >>= \case
+        -- The proposed Chain wasn't mineable, either because the adjacent
+        -- parents weren't available, or because the chain is mid-update.
+        Nothing -> newWork logFun mode (TriedLast cid) miner pact tpw c
+        Just (T2 (T2 payload creationTime) adjParents) -> do
             -- Assemble a candidate `BlockHeader` without a specific `Nonce`
             -- value. `Nonce` manipulation is assumed to occur within the
             -- core Mining logic.
             --
             let !phash = _payloadWithOutputsPayloadHash payload
                 !header = newBlockHeader adjParents phash (Nonce 0) creationTime p
+            pure $ T3 (PrevTime . _blockCreationTime $ coerce p) header payload
+  where
+    private :: ChainId -> ParentHeader -> PrimedWork -> Maybe (T2 CachedPayload BlockHashRecord)
+    private cid (ParentHeader p) (PrimedWork pw) = T2
+        <$> (HM.lookup mid pw >>= HM.lookup cid >>= id)
+        <*> getAdjacentParents c p
 
-            pure $ T3 (PrevTime $ _blockCreationTime p) header payload
+    public :: ParentHeader -> IO (Maybe (T2 CachedPayload BlockHashRecord))
+    public (ParentHeader p) = case getAdjacentParents c p of
+        Nothing -> pure Nothing
+        Just adj -> do
+            creationTime <- BlockCreationTime <$> getCurrentTimeIntegral
+            -- This is an expensive call --
+            payload <- trace logFun "Chainweb.Miner.Coordinator.newWork.newBlock" () 1
+                (_pactNewBlock pact miner p creationTime)
+            pure . Just $ T2 (T2 payload creationTime) adj
 
 chainChoice :: Cut -> ChainChoice -> IO ChainId
 chainChoice c choice = case choice of

--- a/src/Chainweb/Miner/Coordinator.hs
+++ b/src/Chainweb/Miner/Coordinator.hs
@@ -77,6 +77,8 @@ import Chainweb.Version
 
 import Data.LogMessage (JsonLog(..), LogFunction)
 
+import Utils.Logging.Trace (trace)
+
 -- -------------------------------------------------------------------------- --
 -- Miner
 
@@ -157,7 +159,8 @@ newWork logFun choice miner@(Miner mid _) pact tpw c = do
                     -- that shouldn't be repeated.
                     --
                     creationTime <- BlockCreationTime <$> getCurrentTimeIntegral
-                    payload <- _pactNewBlock pact miner p creationTime
+                    payload <- trace logFun "Chainweb.Miner.Coordinator.newWork.newBlock" () 1
+                        (_pactNewBlock pact miner p creationTime)
                     pure $ T2 payload creationTime
 
             -- Assemble a candidate `BlockHeader` without a specific `Nonce`

--- a/src/Chainweb/Miner/Miners.hs
+++ b/src/Chainweb/Miner/Miners.hs
@@ -32,6 +32,7 @@ import Data.Tuple.Strict (T2(..), T3(..))
 
 import Control.Concurrent (threadDelay)
 import Control.Concurrent.Async (race)
+import Control.Concurrent.STM.TVar (TVar)
 import Control.Lens (view)
 
 import Numeric.Natural (Natural)
@@ -71,17 +72,18 @@ import Data.LogMessage (LogFunction)
 localTest
     :: LogFunction
     -> ChainwebVersion
+    -> TVar PrimedWork
     -> Miner
     -> CutDb cas
     -> MWC.GenIO
     -> MinerCount
     -> IO ()
-localTest lf v m cdb gen miners = runForever lf "Chainweb.Miner.Miners.localTest" loop
+localTest lf v tpw m cdb gen miners = runForever lf "Chainweb.Miner.Miners.localTest" loop
   where
     loop :: IO a
     loop = do
         c <- _cut cdb
-        T3 p bh pl <- newWork lf Anything m pact c
+        T3 p bh pl <- newWork lf Anything m pact tpw c
         let !phash = _blockPayloadHash bh
             !bct = _blockCreationTime bh
             ms = MiningState $ M.singleton (T2 bct phash) (T3 m p pl)
@@ -121,13 +123,13 @@ mempoolNoopMiner lf chainRes =
 
 -- | A single-threaded in-process Proof-of-Work mining loop.
 --
-localPOW :: LogFunction -> ChainwebVersion -> Miner -> CutDb cas -> IO ()
-localPOW lf v m cdb = runForever lf "Chainweb.Miner.Miners.localPOW" loop
+localPOW :: LogFunction -> ChainwebVersion -> TVar PrimedWork -> Miner -> CutDb cas -> IO ()
+localPOW lf v tpw m cdb = runForever lf "Chainweb.Miner.Miners.localPOW" loop
   where
     loop :: IO a
     loop = do
         c <- _cut cdb
-        T3 p bh pl <- newWork lf Anything m pact c
+        T3 p bh pl <- newWork lf Anything m pact tpw c
         let !phash = _blockPayloadHash bh
             !bct = _blockCreationTime bh
             ms = MiningState $ M.singleton (T2 bct phash) (T3 m p pl)

--- a/src/Chainweb/Miner/Miners.hs
+++ b/src/Chainweb/Miner/Miners.hs
@@ -48,7 +48,7 @@ import Chainweb.CutDB
 import Chainweb.Difficulty (encodeHashTarget)
 import Chainweb.Mempool.Mempool
 import qualified Chainweb.Mempool.Mempool as Mempool
-import Chainweb.Miner.Config (MinerCount(..))
+import Chainweb.Miner.Config (CoordinationMode(..), MinerCount(..))
 import Chainweb.Miner.Coordinator
 import Chainweb.Miner.Core
 import Chainweb.Miner.Pact (Miner)
@@ -83,7 +83,7 @@ localTest lf v tpw m cdb gen miners = runForever lf "Chainweb.Miner.Miners.local
     loop :: IO a
     loop = do
         c <- _cut cdb
-        T3 p bh pl <- newWork lf Anything m pact tpw c
+        T3 p bh pl <- newWork lf Public Anything m pact tpw c
         let !phash = _blockPayloadHash bh
             !bct = _blockCreationTime bh
             ms = MiningState $ M.singleton (T2 bct phash) (T3 m p pl)
@@ -129,7 +129,7 @@ localPOW lf v tpw m cdb = runForever lf "Chainweb.Miner.Miners.localPOW" loop
     loop :: IO a
     loop = do
         c <- _cut cdb
-        T3 p bh pl <- newWork lf Anything m pact tpw c
+        T3 p bh pl <- newWork lf Public Anything m pact tpw c
         let !phash = _blockPayloadHash bh
             !bct = _blockCreationTime bh
             ms = MiningState $ M.singleton (T2 bct phash) (T3 m p pl)

--- a/src/Chainweb/Miner/RestAPI/Server.hs
+++ b/src/Chainweb/Miner/RestAPI/Server.hs
@@ -102,12 +102,21 @@ workHandler'
     -> IO WorkBytes
 workHandler' mr mcid m = do
     c <- _cut cdb
-    T3 p bh pl <- newWork (logFunction $ _coordLogger mr) (maybe Anything Suggestion mcid) m pact (_coordPrimedWork mr) c
+    T3 p bh pl <- newWork logf mode choice m pact (_coordPrimedWork mr) c
     let !phash = _blockPayloadHash bh
         !bct = _blockCreationTime bh
     atomically . modifyTVar' (_coordState mr) . over _Unwrapped . M.insert (T2 bct phash) $ T3 m p pl
     pure . suncurry3 workBytes $ transferableBytes bh
   where
+    logf :: LogFunction
+    logf = logFunction $ _coordLogger mr
+
+    mode :: CoordinationMode
+    mode = _coordinationMode $ _coordConf mr
+
+    choice :: ChainChoice
+    choice = maybe Anything Suggestion mcid
+
     cdb :: CutDb cas
     cdb = _coordCutDb mr
 

--- a/src/Chainweb/Miner/RestAPI/Server.hs
+++ b/src/Chainweb/Miner/RestAPI/Server.hs
@@ -31,10 +31,10 @@ import Control.Monad.STM (atomically)
 
 import Data.Binary.Builder (fromByteString)
 import Data.Generics.Wrapped (_Unwrapped)
-import qualified Data.HashSet as HS
 import Data.IORef (IORef, atomicModifyIORef', newIORef, readIORef, writeIORef)
 import qualified Data.Map.Strict as M
 import Data.Proxy (Proxy(..))
+import qualified Data.Set as S
 import qualified Data.Text.Lazy as TL
 import qualified Data.Text.Lazy.Encoding as TL
 import Data.Tuple.Strict (T2(..), T3(..))
@@ -61,7 +61,7 @@ import Chainweb.Miner.Coordinator
 import Chainweb.Miner.Core
     (ChainBytes(..), HeaderBytes(..), WorkBytes, workBytes)
 import Chainweb.Miner.Miners (transferableBytes)
-import Chainweb.Miner.Pact (Miner(..), MinerId(..), minerId)
+import Chainweb.Miner.Pact (Miner(..), MinerId(..))
 import Chainweb.Miner.RestAPI (MiningApi)
 import Chainweb.RestAPI.Utils (SomeServer(..))
 import Chainweb.Sync.WebBlockHeaderStore
@@ -87,7 +87,7 @@ workHandler mr mcid m@(Miner (MinerId mid) _) = do
         throwError err503 { errBody = "Too many work requests" }
     let !conf = _coordConf mr
     when (_coordinationMode conf == Private
-          && not (HS.member (view minerId m) (_coordinationMiners conf))) $ do
+          && not (S.member m (_coordinationMiners conf))) $ do
         liftIO $ atomicModifyIORef' (_coord403s mr) (\c -> (c + 1, ()))
         let midb = TL.encodeUtf8 $ TL.fromStrict mid
         throwError err403 { errBody = "Unauthorized Miner: " <> midb }

--- a/src/Chainweb/Miner/RestAPI/Server.hs
+++ b/src/Chainweb/Miner/RestAPI/Server.hs
@@ -102,7 +102,7 @@ workHandler'
     -> IO WorkBytes
 workHandler' mr mcid m = do
     c <- _cut cdb
-    T3 p bh pl <- newWork (logFunction $ _coordLogger mr) (maybe Anything Suggestion mcid) m pact c
+    T3 p bh pl <- newWork (logFunction $ _coordLogger mr) (maybe Anything Suggestion mcid) m pact (_coordPrimedWork mr) c
     let !phash = _blockPayloadHash bh
         !bct = _blockCreationTime bh
     atomically . modifyTVar' (_coordState mr) . over _Unwrapped . M.insert (T2 bct phash) $ T3 m p pl

--- a/src/Chainweb/Pact/Backend/ForkingBench.hs
+++ b/src/Chainweb/Pact/Backend/ForkingBench.hs
@@ -240,7 +240,7 @@ mineBlock parentHeader nonce pdb bhdb r = do
               (_payloadWithOutputsPayloadHash payload)
               nonce
               creationTime
-              parentHeader
+              (ParentHeader parentHeader)
          hbytes = HeaderBytes . runPutS $ encodeBlockHeaderWithoutHash bh
          tbytes = TargetBytes . runPutS . encodeHashTarget $ _blockTarget bh
 
@@ -279,7 +279,7 @@ noMineBlock validate parentHeader nonce r = do
               (_payloadWithOutputsPayloadHash payload)
               nonce
               creationTime
-              parentHeader
+              (ParentHeader parentHeader)
 
      when validate $ do
        mv' <- validateBlock bh (payloadWithOutputsToPayloadData payload) r

--- a/src/Chainweb/Utils.hs
+++ b/src/Chainweb/Utils.hs
@@ -167,8 +167,11 @@ module Chainweb.Utils
 , concurrentWith
 , withLink
 
+-- * Tuples
+, thd
+
 -- * Strict Tuples
-, sfst
+, sfst  -- TODO remove these
 , ssnd
 , scurry
 , suncurry
@@ -1148,6 +1151,14 @@ withLink act = do
   a <- async act
   link a
   return a
+
+
+-- -------------------------------------------------------------------------- --
+-- Tuples
+
+thd :: (a,b,c) -> c
+thd (_,_,c) = c
+{-# INLINE thd #-}
 
 -- -------------------------------------------------------------------------- --
 -- Strict Tuple

--- a/test/Chainweb/Test/Pact/ChainData.hs
+++ b/test/Chainweb/Test/Pact/ChainData.hs
@@ -173,7 +173,7 @@ mineBlock parentHeader nonce iopdb iobhdb r = do
               (_payloadWithOutputsPayloadHash payload)
               nonce
               creationTime
-              parentHeader
+              (ParentHeader parentHeader)
          hbytes = HeaderBytes . runPutS $ encodeBlockHeaderWithoutHash bh
          tbytes = TargetBytes . runPutS . encodeHashTarget $ _blockTarget bh
 

--- a/test/Chainweb/Test/Pact/ChainData.hs
+++ b/test/Chainweb/Test/Pact/ChainData.hs
@@ -156,8 +156,8 @@ mineBlock
 mineBlock parentHeader nonce iopdb iobhdb r = do
 
      -- assemble block without nonce and timestamp
-     creationTime <- getCurrentTimeIntegral
-     mv <- r >>= newBlock noMiner parentHeader (BlockCreationTime creationTime)
+     creationTime <- BlockCreationTime <$> getCurrentTimeIntegral
+     mv <- r >>= newBlock noMiner parentHeader creationTime
      payload <- takeMVar mv >>= \case
         Right x -> return x
         Left e -> throwM $ TestException

--- a/test/Chainweb/Test/Pact/PactInProcApi.hs
+++ b/test/Chainweb/Test/Pact/PactInProcApi.hs
@@ -99,7 +99,7 @@ goldenBytes label (Right a) = return $ BL.fromStrict $ Y.encode $ object
     ]
 
 _getBlockHeaders :: ChainId -> Int -> [BlockHeader]
-_getBlockHeaders cid n = gbh0 : take (n - 1) (testBlockHeaders gbh0)
+_getBlockHeaders cid n = gbh0 : take (n - 1) (testBlockHeaders $ ParentHeader gbh0)
   where
     gbh0 = genesisBlockHeader testVersion cid
 

--- a/test/Chainweb/Test/Pact/PactReplay.hs
+++ b/test/Chainweb/Test/Pact/PactReplay.hs
@@ -245,7 +245,7 @@ mineBlock parentHeader nonce iopdb iobhdb r = do
               (_payloadWithOutputsPayloadHash payload)
               nonce
               creationTime
-              parentHeader
+              (ParentHeader parentHeader)
          hbytes = HeaderBytes . runPutS $ encodeBlockHeaderWithoutHash bh
          tbytes = TargetBytes . runPutS . encodeHashTarget $ _blockTarget bh
 

--- a/test/Chainweb/Test/Pact/PactReplay.hs
+++ b/test/Chainweb/Test/Pact/PactReplay.hs
@@ -235,9 +235,9 @@ mineBlock
 mineBlock parentHeader nonce iopdb iobhdb r = do
 
      -- assemble block without nonce and timestamp
-     creationTime <- getCurrentTimeIntegral
+     creationTime <- BlockCreationTime <$> getCurrentTimeIntegral
 
-     mv <- r >>= newBlock noMiner parentHeader (BlockCreationTime creationTime)
+     mv <- r >>= newBlock noMiner parentHeader creationTime
      payload <- assertNotLeft =<< takeMVar mv
 
      let bh = newBlockHeader

--- a/test/Chainweb/Test/Pact/TTL.hs
+++ b/test/Chainweb/Test/Pact/TTL.hs
@@ -192,7 +192,7 @@ mineBlock parentHeader nonce iopdb iobhdb r = do
               (_payloadWithOutputsPayloadHash payload)
               nonce
               creationTime
-              parentHeader
+              (ParentHeader parentHeader)
          hbytes = HeaderBytes . runPutS $ encodeBlockHeaderWithoutHash bh
          tbytes = TargetBytes . runPutS . encodeHashTarget $ _blockTarget bh
 

--- a/test/Chainweb/Test/Pact/TTL.hs
+++ b/test/Chainweb/Test/Pact/TTL.hs
@@ -182,9 +182,9 @@ mineBlock
 mineBlock parentHeader nonce iopdb iobhdb r = do
 
      -- assemble block without nonce and timestamp
-     creationTime <- getCurrentTimeIntegral
+     creationTime <- BlockCreationTime <$> getCurrentTimeIntegral
 
-     mv <- r >>= newBlock noMiner parentHeader (BlockCreationTime creationTime)
+     mv <- r >>= newBlock noMiner parentHeader creationTime
      payload <- assertNotLeft =<< takeMVar mv
 
      let bh = newBlockHeader

--- a/test/Chainweb/Test/RestAPI.hs
+++ b/test/Chainweb/Test/RestAPI.hs
@@ -76,7 +76,8 @@ genesisBh :: MonadIO m => BlockHeaderDb -> m BlockHeader
 genesisBh db = head <$> headers db
 
 missingKey :: MonadIO m => BlockHeaderDb -> m (DbKey BlockHeaderDb)
-missingKey db = key . head . testBlockHeadersWithNonce (Nonce 34523) <$> genesisBh db
+missingKey db =
+    key . head . testBlockHeadersWithNonce (Nonce 34523) . ParentHeader <$> genesisBh db
 
 -- -------------------------------------------------------------------------- --
 -- Response Predicates
@@ -125,7 +126,7 @@ httpHeaderTests :: IO TestClientEnv_ -> ChainId -> TestTree
 httpHeaderTests envIO cid =
     testGroup ("http header tests for chain " <> sshow cid) $
         [ go "headerClient" $ \v h -> headerClient' v cid (key h)
-        , go "headerPutClient" $ \v h -> headerPutClient' v cid (head $ testBlockHeaders h)
+        , go "headerPutClient" $ \v h -> headerPutClient' v cid (head $ testBlockHeaders $ ParentHeader h)
         , go "headersClient" $ \v _ -> headersClient' v cid Nothing Nothing Nothing Nothing
         , go "hashesClient" $ \v _ -> hashesClient' v cid Nothing Nothing Nothing Nothing
         , go "branchHashesClient" $ \v _ -> branchHashesClient' v cid Nothing Nothing Nothing
@@ -194,7 +195,7 @@ simpleClientSession envIO cid =
             (Actual gen1)
 
         void $ liftIO $ step "headerPutClient: put 3 new blocks"
-        let newHeaders = take 3 $ testBlockHeaders gbh0
+        let newHeaders = take 3 $ testBlockHeaders (ParentHeader gbh0)
         forM_ newHeaders $ \h -> do
             void $ liftIO $ step $ "headerPutClient: " <> T.unpack (encodeToText (_blockHash h))
             void $ headerPutClient version cid h
@@ -304,7 +305,7 @@ simpleClientSession envIO cid =
         -- branch hashes with fork
 
         void $ liftIO $ step "headerPutClient: put 3 new blocks on a new fork"
-        let newHeaders2 = take 3 $ testBlockHeadersWithNonce (Nonce 17) gbh0
+        let newHeaders2 = take 3 $ testBlockHeadersWithNonce (Nonce 17) (ParentHeader gbh0)
         forM_ newHeaders2 $ \h -> do
             void $ liftIO $ step $ "headerPutClient: " <> T.unpack (encodeToText (_blockHash h))
             void $ headerPutClient version cid h
@@ -345,7 +346,7 @@ putNewBlockHeader :: IO TestClientEnv_ -> TestTree
 putNewBlockHeader = simpleTest "put new block header" isRight $ \h0 ->
     headerPutClient (_chainwebVersion h0) (_chainId h0)
         . head
-        $ testBlockHeadersWithNonce (Nonce 1) h0
+        $ testBlockHeadersWithNonce (Nonce 1) (ParentHeader h0)
 
 putExisting :: IO TestClientEnv_ -> TestTree
 putExisting = simpleTest "put existing block header" isRight $ \h0 ->
@@ -358,6 +359,7 @@ putOnWrongChain = simpleTest "put on wrong chain fails" (isErrorCode 400)
         headerPutClient (_chainwebVersion h0) (_chainId h0)
             . head
             . testBlockHeadersWithNonce (Nonce 2)
+            . ParentHeader
             $ genesisBlockHeader v cid
   where
     v = Test petersonChainGraph
@@ -366,13 +368,13 @@ putMissingParent :: IO TestClientEnv_ -> TestTree
 putMissingParent = simpleTest "put missing parent" (isErrorCode 400) $ \h0 ->
     headerPutClient (_chainwebVersion h0) (_chainId h0)
         . (!! 2)
-        $ testBlockHeadersWithNonce (Nonce 3) h0
+        $ testBlockHeadersWithNonce (Nonce 3) (ParentHeader h0)
 
 put5NewBlockHeaders :: IO TestClientEnv_ -> TestTree
 put5NewBlockHeaders = simpleTest "put 5 new block header" isRight $ \h0 ->
     mapM_ (headerPutClient (_chainwebVersion h0) (_chainId h0))
         . take 5
-        $ testBlockHeadersWithNonce (Nonce 4) h0
+        $ testBlockHeadersWithNonce (Nonce 4) (ParentHeader h0)
 
 putTests :: RocksDb -> Bool -> ChainwebVersion -> TestTree
 putTests rdb tls version =
@@ -488,4 +490,3 @@ testPageLimitHashesClient :: ChainwebVersion -> IO TestClientEnv_ -> TestTree
 testPageLimitHashesClient version = pagingTest "hashesClient" hashes id False request
   where
     request cid l n = hashesClient version cid l n Nothing Nothing
-

--- a/test/Chainweb/Test/Utils.hs
+++ b/test/Chainweb/Test/Utils.hs
@@ -266,7 +266,7 @@ genesisBlockHeaderForChain v i
 insertN :: (TreeDb db, DbEntry db ~ BlockHeader) => Int -> BlockHeader -> db -> IO ()
 insertN n g db = traverse_ (insert db) bhs
   where
-    bhs = take n $ testBlockHeaders g
+    bhs = take n $ testBlockHeaders $ ParentHeader g
 
 -- | Useful for terminal-based debugging. A @Tree BlockHeader@ can be obtained
 -- from any `TreeDb` via `toTree`.
@@ -399,7 +399,7 @@ linearBlockHeaderDbs n genDbs = do
   where
     populateDb (_, db) = do
         gbh0 <- root db
-        traverse_ (insert db) . take (int n) $ testBlockHeaders gbh0
+        traverse_ (insert db) . take (int n) . testBlockHeaders $ ParentHeader gbh0
 
 starBlockHeaderDbs
     :: Natural
@@ -412,7 +412,7 @@ starBlockHeaderDbs n genDbs = do
   where
     populateDb (_, db) = do
         gbh0 <- root db
-        traverse_ (\i -> insert db $ newEntry i gbh0) [0 .. (int n-1)]
+        traverse_ (\i -> insert db . newEntry i $ ParentHeader gbh0) [0 .. (int n-1)]
 
     newEntry i h = head $ testBlockHeadersWithNonce (Nonce i) h
 


### PR DESCRIPTION
This PR allows a Node to set a list of "blessed" Miner identities. Each such miner will have Payloads preformed for it, such that new work requests will return (almost) immediately without incurring the usual costs of going through `_pactNewBlock`.

**Note:** As is, this PR breaks existing configurations! What was previously:
```yaml
      miners:
      - abc123  # just an account name
      - zxy098
```
Must now be:

```yaml
      miners:
      - account: abc123
        predicate: keys-all
        public-keys:
        - 3438e5bcfd086c5eeee1a2f227b7624df889773e00bd623babf5fc72c8f9aa63
      - account: zxy098
        predicate: keys-all
        public-keys:
        - cfd7816f15bd9413e5163308e18bf1b13925f3182aeac9b30ed303e8571ce997
```

It honestly should have been this shape from the beginning.

Closes #598 