### PR TITLE
Raise minimum accepted chainweb node version to 1.3

### DIFF
--- a/src/Chainweb/NodeVersion.hs
+++ b/src/Chainweb/NodeVersion.hs
@@ -60,8 +60,11 @@ instance FromJSON NodeVersion where
     parseJSON = parseJsonFromText "NodeVersion"
     {-# INLINE parseJSON #-}
 
+-- | Node verison 1.3 performs a centralized hard fork at 2019-12-10T21:00:00Z.
+-- From that date onward any node with version < 1.3 is rejected.
+--
 minAcceptedVersion :: NodeVersion
-minAcceptedVersion = NodeVersion [1,2]
+minAcceptedVersion = NodeVersion [1,3]
 {-# INLINE minAcceptedVersion #-}
 
 isAcceptedVersion :: NodeVersion -> Bool


### PR DESCRIPTION
Version 1.3 will perform a centralized hard fork at 2019-12-10T21:00:00Z. After that date nodes with version <= 1.2 are considered not being part of the network any more.

Nodes <= 1.2 are vulnerable to the coinbase injection attack. New blocks resulting from this attacks will cause validation failures in nodes >= 1.3 after the fork date.
