### PR TITLE
Use block time instead of tx creation time

### DIFF
--- a/src/Chainweb/Pact/TransactionExec.hs
+++ b/src/Chainweb/Pact/TransactionExec.hs
@@ -76,7 +76,7 @@ import Pact.Gas.Table
 import Pact.Interpreter
 import Pact.Native.Capabilities (evalCap)
 import Pact.Parse (parseExprs)
-import Pact.Parse (ParsedDecimal(..), ParsedInteger(..))
+import Pact.Parse (ParsedDecimal(..))
 import Pact.Runtime.Capabilities (popCapStack)
 import Pact.Types.Capability
 import Pact.Types.Command
@@ -257,10 +257,7 @@ applyCoinbase v logger dbEnv (Miner mid mks) reward@(ParsedDecimal d) pd ph
     forkTime = vuln797FixDate v
     fork1_3InEffect = blockTime >= forkTime
     throwCritical = fork1_3InEffect || enfCBFailure
-    blockTime =
-      let (TxCreationTime (ParsedInteger !bt)) =
-            view (pdPublicMeta . pmCreationTime) pd
-      in Time (TimeSpan (Micros (fromIntegral bt)))
+    blockTime = Time (TimeSpan (Micros $ _pdBlockTime pd))
 
     tenv = TransactionEnv Transactional dbEnv logger pd noSPVSupport
            Nothing 0.0 rk 0 restrictiveExecutionConfig


### PR DESCRIPTION
This was not caught in testing because `DevNet` fork time was set to `epoch`, and `def` for public meta's tx creation time is 0 - also `epoch`. These changes will make use of whatever the block time in the public data is from the header of the previous block of the current one. 