### PR TITLE
Call sqlite3_wal_checkpoint_v2() on startup to free disk space.

### DIFF
--- a/src/Chainweb/Pact/Backend/SQLite/V2.hs
+++ b/src/Chainweb/Pact/Backend/SQLite/V2.hs
@@ -12,3 +12,12 @@ foreign import ccall "sqlite3_open_v2"
 
 foreign import ccall "sqlite3_close_v2"
     c_sqlite3_close_v2 :: Ptr CDatabase -> IO CError
+
+foreign import ccall "sqlite3_wal_checkpoint_v2"
+    c_sqlite3_wal_checkpoint_v2
+        :: Ptr CDatabase
+        -> CString
+        -> CInt
+        -> Ptr CInt
+        -> Ptr CInt
+        -> IO CError


### PR DESCRIPTION
Checkpointing the WAL (with _TRUNCATE) will move any unsaved data to the DB and truncate the WAL on startup. For some reason our WAL files were not being truncated on checkpoint before.