### PR TITLE
Primed Coordination for all Whitelisted Miners

### DIFF
--- a/src/Chainweb/Miner/Coordinator.hs
+++ b/src/Chainweb/Miner/Coordinator.hs
@@ -72,7 +72,6 @@ import Chainweb.Cut.CutHashes
 import Chainweb.CutDB
 import Chainweb.Difficulty
 import Chainweb.Logging.Miner
-import Chainweb.Miner.Config (CoordinationMode(..))
 import Chainweb.Miner.Pact (Miner(..), MinerId(..), minerId)
 import Chainweb.Payload
 import Chainweb.Sync.WebBlockHeaderStore
@@ -135,14 +134,13 @@ minerStatus (Plebian m) = m
 --
 newWork
     :: LogFunction
-    -> CoordinationMode
     -> ChainChoice
     -> MinerStatus
     -> PactExecutionService
     -> TVar PrimedWork
     -> Cut
     -> IO (T3 PrevTime BlockHeader PayloadWithOutputs)
-newWork logFun mode choice eminer pact tpw c = do
+newWork logFun choice eminer pact tpw c = do
     -- Randomly pick a chain to mine on, unless the caller specified a specific
     -- one.
     --
@@ -160,7 +158,7 @@ newWork logFun mode choice eminer pact tpw c = do
     case mr of
         -- The proposed Chain wasn't mineable, either because the adjacent
         -- parents weren't available, or because the chain is mid-update.
-        Nothing -> newWork logFun mode (TriedLast cid) eminer pact tpw c
+        Nothing -> newWork logFun (TriedLast cid) eminer pact tpw c
         Just (T2 (T2 payload creationTime) adjParents) -> do
             -- Assemble a candidate `BlockHeader` without a specific `Nonce`
             -- value. `Nonce` manipulation is assumed to occur within the

--- a/src/Chainweb/Miner/Miners.hs
+++ b/src/Chainweb/Miner/Miners.hs
@@ -83,7 +83,7 @@ localTest lf v tpw m cdb gen miners = runForever lf "Chainweb.Miner.Miners.local
     loop :: IO a
     loop = do
         c <- _cut cdb
-        T3 p bh pl <- newWork lf Public Anything (Left m) pact tpw c
+        T3 p bh pl <- newWork lf Public Anything (Plebian m) pact tpw c
         let !phash = _blockPayloadHash bh
             !bct = _blockCreationTime bh
             ms = MiningState $ M.singleton (T2 bct phash) (T3 m p pl)
@@ -129,7 +129,7 @@ localPOW lf v tpw m cdb = runForever lf "Chainweb.Miner.Miners.localPOW" loop
     loop :: IO a
     loop = do
         c <- _cut cdb
-        T3 p bh pl <- newWork lf Public Anything (Left m) pact tpw c
+        T3 p bh pl <- newWork lf Public Anything (Plebian m) pact tpw c
         let !phash = _blockPayloadHash bh
             !bct = _blockCreationTime bh
             ms = MiningState $ M.singleton (T2 bct phash) (T3 m p pl)

--- a/src/Chainweb/Miner/Miners.hs
+++ b/src/Chainweb/Miner/Miners.hs
@@ -83,7 +83,7 @@ localTest lf v tpw m cdb gen miners = runForever lf "Chainweb.Miner.Miners.local
     loop :: IO a
     loop = do
         c <- _cut cdb
-        T3 p bh pl <- newWork lf Public Anything m pact tpw c
+        T3 p bh pl <- newWork lf Public Anything (Left m) pact tpw c
         let !phash = _blockPayloadHash bh
             !bct = _blockCreationTime bh
             ms = MiningState $ M.singleton (T2 bct phash) (T3 m p pl)
@@ -129,7 +129,7 @@ localPOW lf v tpw m cdb = runForever lf "Chainweb.Miner.Miners.localPOW" loop
     loop :: IO a
     loop = do
         c <- _cut cdb
-        T3 p bh pl <- newWork lf Public Anything m pact tpw c
+        T3 p bh pl <- newWork lf Public Anything (Left m) pact tpw c
         let !phash = _blockPayloadHash bh
             !bct = _blockCreationTime bh
             ms = MiningState $ M.singleton (T2 bct phash) (T3 m p pl)

--- a/src/Chainweb/Miner/Miners.hs
+++ b/src/Chainweb/Miner/Miners.hs
@@ -48,7 +48,7 @@ import Chainweb.CutDB
 import Chainweb.Difficulty (encodeHashTarget)
 import Chainweb.Mempool.Mempool
 import qualified Chainweb.Mempool.Mempool as Mempool
-import Chainweb.Miner.Config (CoordinationMode(..), MinerCount(..))
+import Chainweb.Miner.Config (MinerCount(..))
 import Chainweb.Miner.Coordinator
 import Chainweb.Miner.Core
 import Chainweb.Miner.Pact (Miner)
@@ -83,7 +83,7 @@ localTest lf v tpw m cdb gen miners = runForever lf "Chainweb.Miner.Miners.local
     loop :: IO a
     loop = do
         c <- _cut cdb
-        T3 p bh pl <- newWork lf Public Anything (Plebian m) pact tpw c
+        T3 p bh pl <- newWork lf Anything (Plebian m) pact tpw c
         let !phash = _blockPayloadHash bh
             !bct = _blockCreationTime bh
             ms = MiningState $ M.singleton (T2 bct phash) (T3 m p pl)
@@ -129,7 +129,7 @@ localPOW lf v tpw m cdb = runForever lf "Chainweb.Miner.Miners.localPOW" loop
     loop :: IO a
     loop = do
         c <- _cut cdb
-        T3 p bh pl <- newWork lf Public Anything (Plebian m) pact tpw c
+        T3 p bh pl <- newWork lf Anything (Plebian m) pact tpw c
         let !phash = _blockPayloadHash bh
             !bct = _blockCreationTime bh
             ms = MiningState $ M.singleton (T2 bct phash) (T3 m p pl)

--- a/src/Chainweb/Miner/RestAPI/Server.hs
+++ b/src/Chainweb/Miner/RestAPI/Server.hs
@@ -102,7 +102,7 @@ workHandler'
     -> IO WorkBytes
 workHandler' mr mcid m = do
     c <- _cut cdb
-    T3 p bh pl <- newWork logf mode choice m pact (_coordPrimedWork mr) c
+    T3 p bh pl <- newWork logf choice m pact (_coordPrimedWork mr) c
     let !phash = _blockPayloadHash bh
         !bct = _blockCreationTime bh
     atomically . modifyTVar' (_coordState mr) . over _Unwrapped . M.insert (T2 bct phash) $ T3 (minerStatus m) p pl
@@ -110,9 +110,6 @@ workHandler' mr mcid m = do
   where
     logf :: LogFunction
     logf = logFunction $ _coordLogger mr
-
-    mode :: CoordinationMode
-    mode = _coordinationMode $ _coordConf mr
 
     choice :: ChainChoice
     choice = maybe Anything Suggestion mcid

--- a/src/Chainweb/Miner/RestAPI/Server.hs
+++ b/src/Chainweb/Miner/RestAPI/Server.hs
@@ -85,9 +85,9 @@ workHandler mr mcid m@(Miner (MinerId mid) _) = do
         liftIO $ atomicModifyIORef' (_coord503s mr) (\c -> (c + 1, ()))
         throwError err503 { errBody = "Too many work requests" }
     let !conf = _coordConf mr
-        !priv = S.member m $ _coordinationMiners conf
-        !miner = bool (Plebian m) (Primed m) priv
-    when (_coordinationMode conf == Private && priv) $ do
+        !primed = S.member m $ _coordinationMiners conf
+        !miner = bool (Plebian m) (Primed m) primed
+    when (_coordinationMode conf == Private && not primed) $ do
         liftIO $ atomicModifyIORef' (_coord403s mr) (\c -> (c + 1, ()))
         let midb = TL.encodeUtf8 $ TL.fromStrict mid
         throwError err403 { errBody = "Unauthorized Miner: " <> midb }


### PR DESCRIPTION
This PR alters the coordinator to give preferential treatment to any whitelisted miner in the `miners` list, regardless of the public/private mining scheme.