### PR TITLE
[DO NOT MERGE] Release Candidate for 1.4

### DIFF
--- a/.github/workflows/applications.yml
+++ b/.github/workflows/applications.yml
@@ -135,7 +135,7 @@ jobs:
     - name: Build
       run: cabal v2-build chainweb-node
     - name: Run Tests
-      run: cabal v2-run chainweb-tests -- --hide-successes
+      run: cabal v2-run chainweb-tests -- --hide-successes --pattern='!/remote pact tests/'
     - name: Run Benchmarks and Certificate Validation Tests
       run: cabal v2-run cwtool -- slow-tests
     - name: Sync dist cache

--- a/src/Chainweb/Version.hs
+++ b/src/Chainweb/Version.hs
@@ -578,7 +578,7 @@ txEnabledDate TimedConsensus{} = Nothing
 txEnabledDate PowConsensus{} = Nothing
 txEnabledDate TimedCPM{} = Nothing
 txEnabledDate FastTimedCPM{} = Nothing
-txEnabledDate Development = Just [timeMicrosQQ| 2019-12-14T18:55:00.0 |]
+txEnabledDate Development = Just [timeMicrosQQ| 2019-12-14T21:50:00.0 |]
 txEnabledDate Testnet04 = Nothing
 txEnabledDate Mainnet01 = Just [timeMicrosQQ| 2019-12-17T15:30:00.0 |]
 
@@ -593,7 +593,7 @@ transferActivationDate TimedConsensus{} = Nothing
 transferActivationDate PowConsensus{} = Nothing
 transferActivationDate TimedCPM{} = Nothing
 transferActivationDate FastTimedCPM{} = Nothing
-transferActivationDate Development = Just [timeMicrosQQ| 2019-12-14T18:55:00.0 |]
+transferActivationDate Development = Just [timeMicrosQQ| 2019-12-14T21:40:00.0 |]
 transferActivationDate Testnet04 = Nothing
 transferActivationDate Mainnet01 = Just [timeMicrosQQ| 2019-12-17T16:00:00.0 |]
 
@@ -623,6 +623,6 @@ upgradeCoinV2Date TimedConsensus{} = Nothing
 upgradeCoinV2Date PowConsensus{} = Nothing
 upgradeCoinV2Date TimedCPM{} = Nothing
 upgradeCoinV2Date FastTimedCPM{} = Nothing
-upgradeCoinV2Date Development = Just [timeMicrosQQ| 2019-12-14T18:50:00.0 |]
+upgradeCoinV2Date Development = Just [timeMicrosQQ| 2019-12-14T21:30:00.0 |]
 upgradeCoinV2Date Testnet04 = Nothing
 upgradeCoinV2Date Mainnet01 = Just [timeMicrosQQ| 2019-12-17T15:00:00.0 |]

--- a/src/Chainweb/Version.hs
+++ b/src/Chainweb/Version.hs
@@ -578,7 +578,7 @@ txEnabledDate TimedConsensus{} = Nothing
 txEnabledDate PowConsensus{} = Nothing
 txEnabledDate TimedCPM{} = Nothing
 txEnabledDate FastTimedCPM{} = Nothing
-txEnabledDate Development = Just [timeMicrosQQ| 2019-12-14T21:50:00.0 |]
+txEnabledDate Development = Just [timeMicrosQQ| 2019-12-14T22:40:00.0 |]
 txEnabledDate Testnet04 = Nothing
 txEnabledDate Mainnet01 = Just [timeMicrosQQ| 2019-12-17T15:30:00.0 |]
 
@@ -593,7 +593,7 @@ transferActivationDate TimedConsensus{} = Nothing
 transferActivationDate PowConsensus{} = Nothing
 transferActivationDate TimedCPM{} = Nothing
 transferActivationDate FastTimedCPM{} = Nothing
-transferActivationDate Development = Just [timeMicrosQQ| 2019-12-14T21:40:00.0 |]
+transferActivationDate Development = Just [timeMicrosQQ| 2019-12-14T22:50:00.0 |]
 transferActivationDate Testnet04 = Nothing
 transferActivationDate Mainnet01 = Just [timeMicrosQQ| 2019-12-17T16:00:00.0 |]
 
@@ -623,6 +623,6 @@ upgradeCoinV2Date TimedConsensus{} = Nothing
 upgradeCoinV2Date PowConsensus{} = Nothing
 upgradeCoinV2Date TimedCPM{} = Nothing
 upgradeCoinV2Date FastTimedCPM{} = Nothing
-upgradeCoinV2Date Development = Just [timeMicrosQQ| 2019-12-14T21:30:00.0 |]
+upgradeCoinV2Date Development = Just [timeMicrosQQ| 2019-12-14T22:30:00.0 |]
 upgradeCoinV2Date Testnet04 = Nothing
 upgradeCoinV2Date Mainnet01 = Just [timeMicrosQQ| 2019-12-17T15:00:00.0 |]


### PR DESCRIPTION
# Release Candidate for 1.4

Please push changes for 1.4 directly to the respective feature PRs and not to this PR. Only experimental, testing, and temporary changes may be pushed to this PR. This PR will be discarded once all feature PRs for 1.4 are merged.

## Pending PRs

* [x] #838 Load default modules from pact db
* [x] #835 [bump version to 1.4]
    * [x] included in release candidate builds
    * [x] approved
* [x] #830 Upgrades and remediation
    * [x] included in release candidate builds
    * [x] approved
    * [x] tested
* [x] #831 [Pact service: recover from bad tx in new block]
    * [x] included in release candidate builds
    * [x] approved
    * [x] tested
* [x] #809 [Coin Contract v2]
    * [x] included release candidate builds
    * [x] ready for review
    * [x] approved
    * [x] tested
* [x] #821 [Inspecting the module cache on node restart]
    * [x] test on devnet witout #820
    * [x] included release candidate builds
    * [x] ready for review
    * [x] approved
    * [x] tested
* [x] #823 [set kill switch for 1.4 to 2020-01-15]
    * [x] included in release candidate builds
    * [x] date confirmed by @slpopejoy and @mightybyte 
    * [x] approved
    * [x] tested
* [x] #820 [Disable charging gas for module lookups]
    * [x] included release candidate builds
    * [x] ready for review
    * [x] approved
    * [x] tested
* [x] #833 [do github-ci builds for release-candiate branches]
    * [x] included release candidate builds
    * [x] approved

## Pending Bugs

* [x] #829 [Tx fails in newBlock BuyGas but isn't removed from mempool]

## TODO

* [x] Finalize list of included PRs
* [x] Review and merge all pending PRs into master
* [ ] Test on devnet
* [ ] Test on mainnet01
* [ ] scan code for possibly obsolete `KILLSWITCH` logic
* [ ] update value of confirm relevant dates 
    * [x] `txEnabledDate Mainnet01 = Just [timeMicrosQQ| 2019-12-17T15:30:00.0 |]`
    * [x] `transferActivationDate Mainnet01 = Just [timeMicrosQQ| 2019-12-17T16:00:00.0 |]`
        Review activation logic in:
        * [ ] `Chainweb.Mempool.InMem.validateOne`
        * [ ] `Chainweb.Mempool.RestAPI.Server.insertHandler`
        * [ ] `Chainweb.Pact.RestAPI.Server.sendHandler`
    * [ ] in `node/ChainwebNode`: `killSwitchDate = Just "2020-01-15T00:00:00Z"`
* [x] update CHANGELOG.md
* [x] update cabal version to 1.4
* [ ] tag release 1.4
* [ ] Wait for CI builds
    * [ ] nix pins
    * [ ] ubuntu builds
* [ ] rollout (slowly) to bootstrap nodes
* [ ] provide release candidate to beta testers

## Testing

* [x] Devnet test scenarios for #820 and #821 proposed by @LindaOrtega (see comment below)

* [ ] *Devnet*
    * [ ] Test 1.4 release candidate (with all relevant trigger set to past values / epoch)
        * [ ] bootstrap devnet with 1.4
        * [ ] check for performance regressions regressions
        * [ ] check functional regressions (run @ggobugi27 's tests)

 * [ ] *Test transition scenario on devnet*

    If possible reserve plenty of time for this and ensure that all devs are available that are
    needed to perform that included steps. Do not choose to tight test dates, so that there's enough time to repeat tests if something goes wrong.

    * [ ] bootstrap devenet with 1.0.6
    * [ ] roll over nodes from 1.1.1, 1.2, 1.3, 1.3.1 until only 1.3 and 1.3.1 nodes are in the network.
        * [ ] TODO: do we need a 1.3 build with a kill switch for testing or do we just kill 1.3 nodes manually?
    * [ ] verify that know attack is mitigated
    * [ ] verify that tx are disabled not enabled
    * [ ] verify that tx cause validation failure
    * [ ] test full catchup
    * [ ] test restarts
    * [ ] deploy 1.4. with 
        * [ ] slash-date in the near future (after 1.3 nodes are killed)
        * [ ] tx-validation >slash-date
        * [ ] tx-activiation >= tx-validation
    * [ ] verify that know attack is mitigated
    * [ ] verify that tx are disabled not enabled
    * [ ] verify that tx cause validation failure
    * [ ] verify that attacks are not possible
    * [ ] run test suites
    * [ ] test catchup
    * [ ] await slash date and verify results
    * [ ] await tx-validation date (possibly verify that tx are disabled, if tx-activation is larger than tx-validation)
    * [ ] await tx-activation date
    * [ ] verify that that tx are enabled
    * [ ] run comprehensive tests
    * [ ] test catchup

* [ ] test mining coordination with external devnet miners

* [ ] *Mainnet*
    * [ ] start catchup on regular basis
        * [ ] wait for catchup to finish on final release bits
    * [ ] test on nodes with mining coordination disabled
    * [ ] check that that tx are disabled
    * [ ] test on nodes with mining coordination enabled
        * [ ] private mining
        * [ ] public mining
    
* [ ] *Beta testers*
    * [ ] ask beta testers to test with different miners 