### PR TITLE
Load default modules from pact db

### DIFF
--- a/src/Chainweb/Version.hs
+++ b/src/Chainweb/Version.hs
@@ -578,7 +578,7 @@ txEnabledDate TimedConsensus{} = Nothing
 txEnabledDate PowConsensus{} = Nothing
 txEnabledDate TimedCPM{} = Nothing
 txEnabledDate FastTimedCPM{} = Nothing
-txEnabledDate Development = Just [timeMicrosQQ| 2019-11-30T05:00:00.0 |]
+txEnabledDate Development = Just [timeMicrosQQ| 2019-12-14T00:44:00.0 |]
 txEnabledDate Testnet04 = Nothing
 txEnabledDate Mainnet01 = Just [timeMicrosQQ| 2019-12-17T15:30:00.0 |]
 
@@ -593,7 +593,7 @@ transferActivationDate TimedConsensus{} = Nothing
 transferActivationDate PowConsensus{} = Nothing
 transferActivationDate TimedCPM{} = Nothing
 transferActivationDate FastTimedCPM{} = Nothing
-transferActivationDate Development = Just [timeMicrosQQ| 2019-12-13T23:25:00.0 |]
+transferActivationDate Development = Just [timeMicrosQQ| 2019-12-14T00:45:00.0 |]
 transferActivationDate Testnet04 = Nothing
 transferActivationDate Mainnet01 = Just [timeMicrosQQ| 2019-12-17T16:00:00.0 |]
 
@@ -623,6 +623,6 @@ upgradeCoinV2Date TimedConsensus{} = Nothing
 upgradeCoinV2Date PowConsensus{} = Nothing
 upgradeCoinV2Date TimedCPM{} = Nothing
 upgradeCoinV2Date FastTimedCPM{} = Nothing
-upgradeCoinV2Date Development = Just [timeMicrosQQ| 2019-12-13T23:15:00.0 |]
+upgradeCoinV2Date Development = Just [timeMicrosQQ| 2019-12-14T00:40:00.0 |]
 upgradeCoinV2Date Testnet04 = Nothing
 upgradeCoinV2Date Mainnet01 = Just [timeMicrosQQ| 2019-12-17T15:00:00.0 |]


### PR DESCRIPTION
Caveats:
- only loads `ns` and `coin`, whereas the previous solution also loaded `gas-payer-v1` and `fungible-v1`. Since this changes at upgrade, thought to go conservative for now. We can consider an `Interpreter`-based approach that pokes around more deeply, loading any module in the default namespace.
- Simple equality didn't work for testing the modules loaded from the PactDb vs loaded from genesis. However the module hashes match, so the test checks that.