### PR TITLE
Set line buffering for stderr

### DIFF
--- a/node/ChainwebNode.hs
+++ b/node/ChainwebNode.hs
@@ -70,6 +70,7 @@ import Numeric.Natural
 import qualified Streaming.Prelude as S
 
 import System.Directory
+import System.IO (hSetBuffering, stderr, BufferMode(LineBuffering))
 import qualified System.Logger as L
 import System.LogLevel
 
@@ -507,6 +508,7 @@ mainInfo = programInfoValidate
 main :: IO ()
 main = withWatchdog . runWithPkgInfoConfiguration mainInfo pkgInfo $ \conf -> do
     let v = _configChainwebVersion $ _nodeConfigChainweb conf
+    hSetBuffering stderr LineBuffering
     withNodeLogger (_nodeConfigLog conf) v $ \logger -> do
         kt <- mapM (parseTimeM False defaultTimeLocale timeFormat) killSwitchDate
         withKillSwitch (logFunctionText logger) kt $


### PR DESCRIPTION
`Data.Text.IO.putStrLn` makes one write system call for each character when buffering is disabled. The reason for (or benefit of) that is unclear.

Even when other backends are in use, chainweb node still writes logging-system errors to stderr (e.g. when the logging backend fails). With elasticsearch this can happen, if the cluster reaches is capacity limits or in case of network connection hiccups. Those logs shouldn't be buffered too long in order to makes sure they are not lost in case of a node crash, since these logs may contain important debugging information.

However, the logging-system error logs are mostly short new-line terminated messages that are likely to be writing in a single system. So doing line buffering is fine in this case.