### PR TITLE
Supplemented Stale Solution Statistics

### DIFF
--- a/src/Chainweb/Logging/Miner.hs
+++ b/src/Chainweb/Logging/Miner.hs
@@ -47,6 +47,7 @@ data NewMinedBlock = NewMinedBlock
 data OrphanedBlock = OrphanedBlock
     { _orphanedHeader :: !(ObjectEncoded BlockHeader)
     , _orphanedMiner :: !Text
-    , _orphanedReason :: Text }
+    , _orphanedReason :: !Text
+    , _orhpanedCode :: !Int }
     deriving stock (Eq, Show, Generic)
     deriving anyclass (ToJSON, NFData)

--- a/src/Chainweb/Logging/Miner.hs
+++ b/src/Chainweb/Logging/Miner.hs
@@ -48,6 +48,6 @@ data OrphanedBlock = OrphanedBlock
     { _orphanedHeader :: !(ObjectEncoded BlockHeader)
     , _orphanedMiner :: !Text
     , _orphanedReason :: !Text
-    , _orhpanedCode :: !Int }
+    , _orphanedCode :: !Int }
     deriving stock (Eq, Show, Generic)
     deriving anyclass (ToJSON, NFData)

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,6 +1,6 @@
-resolver: lts-14.14
+resolver: lts-14.17
 
-#ghc-options: {"$locals": -ddump-to-file -ddump-hi -funclutter-valid-hole-fits -fmax-relevant-binds=0}
+#ghc-options: {"$locals": -ddump-to-file -ddump-hi}
 
 extra-deps:
   # --- Missing from Stackage --- #
@@ -15,6 +15,7 @@ extra-deps:
   - strict-tuple-0.1.3
   - yet-another-logger-0.3.1
   - random-strings-0.1.1.0
+
   # --- Transitive Pact Dependencies --- #
   - ed25519-donna-0.1.1
   - sbv-8.2


### PR DESCRIPTION
This PR adds a code to the `OrphanedBlock` log message, so that it's easier to discern programmatically what the cause of staling was.