### PR TITLE
Deletes blockheight log in header-dump tool

### DIFF
--- a/tools/header-dump/HeaderDump.hs
+++ b/tools/header-dump/HeaderDump.hs
@@ -398,10 +398,6 @@ run config logger = withChainDbs logger config $ \pdb cdb -> do
 progress :: LogFunctionText -> S.Stream (Of BlockHeader) IO a -> S.Stream (Of BlockHeader) IO a
 progress logg s = s
     & S.chain (logg Debug . sshow)
-    & S.chain
-        (\x -> when (_blockHeight x `mod` 100 == 0) $
-            logg Info ("BlockHeight: " <> sshow (_blockHeight x))
-        )
 
 miner
     :: MonadThrow m


### PR DESCRIPTION
We're currently logging the block height periodically in the header-dump tool. This makes it difficult to transform these header outputs into useful JSON values using command line tools like `grep` and `jq`.