### PR TITLE
Bound the `network` Dependency

### DIFF
--- a/chainweb.cabal
+++ b/chainweb.cabal
@@ -361,7 +361,7 @@ library
         , mwc-random >= 0.13
         , mwc-probability >= 2.0 && <2.2
         , neat-interpolation >= 0.3.2
-        , network >= 2.6 && < 3
+        , network >= 2.6 && < 3.1.1
         , optparse-applicative >= 0.14
         , pact >= 2.6
         , paths >= 0.2
@@ -509,7 +509,7 @@ test-suite chainweb-tests
         , loglevel >= 0.1
         , mtl >= 2.2
         , neat-interpolation >= 0.3
-        , network >= 2.6 && < 3
+        , network >= 2.6 && < 3.1.1
         , http-client-tls >=0.3
         , pact >= 2.6
         , paths >= 0.2
@@ -769,7 +769,7 @@ executable cwtool
         , mtl >= 2.2
         , mwc-random >= 0.13
         , neat-interpolation >= 0.3.2
-        , network >= 2.6 && < 3
+        , network >= 2.6 && < 3.1.1
         , nonempty-containers >= 0.1
         , optparse-applicative >= 0.14
         , pact >= 2.6

--- a/chainweb.cabal
+++ b/chainweb.cabal
@@ -357,7 +357,7 @@ library
         , mwc-random >= 0.13
         , mwc-probability >= 2.0 && <2.2
         , neat-interpolation >= 0.3.2
-        , network >= 2.6
+        , network >= 2.6 && < 3
         , optparse-applicative >= 0.14
         , pact >= 2.6
         , paths >= 0.2
@@ -504,7 +504,7 @@ test-suite chainweb-tests
         , loglevel >= 0.1
         , mtl >= 2.2
         , neat-interpolation >= 0.3
-        , network >= 2.6
+        , network >= 2.6 && < 3
         , http-client-tls >=0.3
         , pact >= 2.6
         , paths >= 0.2
@@ -757,7 +757,7 @@ executable cwtool
         , mtl >= 2.2
         , mwc-random >= 0.13
         , neat-interpolation >= 0.3.2
-        , network >= 2.6
+        , network >= 2.6 && < 3
         , nonempty-containers >= 0.1
         , optparse-applicative >= 0.14
         , pact >= 2.6

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-14.21
+resolver: lts-14.25
 
 #ghc-options: {"$locals": -ddump-to-file -ddump-hi}
 
@@ -30,8 +30,8 @@ extra-deps:
   - lens-aeson-1.1
   - tls-1.5.3
   - tls-session-manager-0.0.4
-  - warp-3.3.6
-  - warp-tls-3.2.10
+  - warp-3.3.9
+  - warp-tls-3.2.11
 
   # --- Custom Pins --- #
   - github: kadena-io/pact


### PR DESCRIPTION
This is an experimental PR to see how usage of the `network-2.8` series affects our node stability.

---

After a number of lengthy experiments, we now believe the issue to be a regression introduced in `network-3.1.1.0`. Our official Ubuntu builds will now avoid that version until this has been fixed upstream.