### PR TITLE
improve header dump tool

### DIFF
--- a/chainweb.cabal
+++ b/chainweb.cabal
@@ -681,7 +681,8 @@ executable cwtool
     default-language: Haskell2010
     ghc-options:
         -threaded
-        -with-rtsopts=-N
+        -rtsopts
+        "-with-rtsopts=-N -H1G -A64M"
     hs-source-dirs: tools/cwtool tools/chain2gexf tools/ea tools/encode-decode tools/genconf tools/run-nodes tools/standalone tools/txg tools/txstream tools/test-miner tools/header-dump node test
     main-is: CwTool.hs
     other-modules:

--- a/chainweb.cabal
+++ b/chainweb.cabal
@@ -500,7 +500,7 @@ test-suite chainweb-tests
         , http-client >= 0.5
         , http-types >= 0.12
         , lens >= 4.16
-        , lens-aeson
+        , lens-aeson >= 1.1
         , loglevel >= 0.1
         , mtl >= 2.2
         , neat-interpolation >= 0.3
@@ -723,7 +723,7 @@ executable cwtool
         , QuickCheck >= 2.12.6
         , aeson >= 1.4
         , aeson-pretty >= 0.8
-        , lens-aeson >= 1.0.2
+        , lens-aeson >= 1.1
         , async >= 2.2
         , attoparsec >= 0.13
         , base >= 4.12 && < 5

--- a/overrides.nix
+++ b/overrides.nix
@@ -191,6 +191,12 @@ let # Working on getting this function upstreamed into nixpkgs, but
         sha256 = "1vg0m27phd6yf0pszcy2c2wbqx509fr9gacn34yja521z17cxd8z";
       };
 
+      lens-aeson = callHackageDirect {
+        pkg = "lens-aeson";
+        ver = "1.1";
+        sha256 = "0bx7ay7dx6ljhy1a6bmjdz52vfwmx8af8sd96p38yc0m9irjz02h";
+      };
+
       streaming-concurrency = callHackageDirect {
         pkg = "streaming-concurrency";
         ver = "0.3.1.3";


### PR DESCRIPTION
This unifies the output format across different output types:

```json
{
    "chainId": INT,
    "height": INT,
    "data": OBJECT
}
```