### PR TITLE
PowHeader Endpoint

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-14.21
+resolver: lts-14.23
 
 #ghc-options: {"$locals": -ddump-to-file -ddump-hi}
 


### PR DESCRIPTION
This PR adds a new endpoint which yields JSON-encoded `BlockHeader`s along with their POW hash, for usage with external tools.