### PR TITLE
Add configuration options for checking payload hashes during pact replay

### DIFF
--- a/src/Chainweb/Chainweb.hs
+++ b/src/Chainweb/Chainweb.hs
@@ -316,9 +316,8 @@ data ChainwebConfiguration = ChainwebConfiguration
     , _configBlockGasLimit :: !Mempool.GasLimit
     , _configPactQueueSize :: !Natural
     , _configReorgLimit :: !Natural
-    , _configPedantic :: !Bool
-        -- ^ Be pedantic during pact validation. Re-validates payload hashes
-        -- during replay.
+    , _configValidateHashesOnReplay :: !Bool
+        -- ^ Re-validate payload hashes during replay.
     } deriving (Show, Eq, Generic)
 
 makeLenses ''ChainwebConfiguration
@@ -350,7 +349,7 @@ defaultChainwebConfiguration v = ChainwebConfiguration
     , _configBlockGasLimit = 15000
     , _configPactQueueSize = 2000
     , _configReorgLimit = int defaultReorgLimit
-    , _configPedantic = False
+    , _configValidateHashesOnReplay = False
     }
 
 instance ToJSON ChainwebConfiguration where
@@ -368,7 +367,7 @@ instance ToJSON ChainwebConfiguration where
         , "gasLimitOfBlock" .= _configBlockGasLimit o
         , "pactQueueSize" .= _configPactQueueSize o
         , "reorgLimit" .= _configReorgLimit o
-        , "pedantic" .= _configPedantic o
+        , "validateHashesOnReplay" .= _configValidateHashesOnReplay o
         ]
 
 instance FromJSON (ChainwebConfiguration -> ChainwebConfiguration) where
@@ -386,7 +385,7 @@ instance FromJSON (ChainwebConfiguration -> ChainwebConfiguration) where
         <*< configBlockGasLimit ..: "gasLimitOfBlock" % o
         <*< configPactQueueSize ..: "pactQueueSize" % o
         <*< configReorgLimit ..: "reorgLimit" % o
-        <*< configPedantic ..: "pedantic" % o
+        <*< configValidateHashesOnReplay ..: "validateHashesOnReplay" % o
 
 pChainwebConfiguration :: MParser ChainwebConfiguration
 pChainwebConfiguration = id
@@ -420,9 +419,9 @@ pChainwebConfiguration = id
         <> help "Max allowed reorg depth.\
                 \ Consult https://github.com/kadena-io/chainweb-node/blob/master/docs/RecoveringFromDeepForks.md for\
                 \ more information. "
-    <*< configPedantic .:: boolOption_
-        % long "pedantic"
-        <> help "Be pedantic during pact validation. Re-validates payload hashes during transaction replay."
+    <*< configValidateHashesOnReplay .:: boolOption_
+        % long "validateHashesOnReplay"
+        <> help "Re-validate payload hashes during transaction replay."
 
 -- -------------------------------------------------------------------------- --
 -- Chainweb Resources
@@ -574,7 +573,7 @@ withChainwebInternal conf logger peer rocksDb dbDir nodeid resetDb inner = do
             let mcfg = validatingMempoolConfig cid v (_configBlockGasLimit conf)
             withChainResources v cid rocksDb peer (chainLogger cid)
                      mcfg payloadDb prune dbDir nodeid
-                     resetDb deepForkLimit (_configPactQueueSize conf) (_configPedantic conf))
+                     resetDb deepForkLimit (_configPactQueueSize conf) (_configValidateHashesOnReplay conf))
 
         -- initialize global resources after all chain resources are initialized
         (\cs -> global (HM.fromList $ zip cidsList cs))

--- a/src/Chainweb/Chainweb.hs
+++ b/src/Chainweb/Chainweb.hs
@@ -316,6 +316,9 @@ data ChainwebConfiguration = ChainwebConfiguration
     , _configBlockGasLimit :: !Mempool.GasLimit
     , _configPactQueueSize :: !Natural
     , _configReorgLimit :: !Natural
+    , _configPedantic :: !Bool
+        -- ^ Be pedantic during pact validation. Re-validates payload hashes
+        -- during replay.
     } deriving (Show, Eq, Generic)
 
 makeLenses ''ChainwebConfiguration
@@ -347,6 +350,7 @@ defaultChainwebConfiguration v = ChainwebConfiguration
     , _configBlockGasLimit = 15000
     , _configPactQueueSize = 2000
     , _configReorgLimit = int defaultReorgLimit
+    , _configPedantic = False
     }
 
 instance ToJSON ChainwebConfiguration where
@@ -364,6 +368,7 @@ instance ToJSON ChainwebConfiguration where
         , "gasLimitOfBlock" .= _configBlockGasLimit o
         , "pactQueueSize" .= _configPactQueueSize o
         , "reorgLimit" .= _configReorgLimit o
+        , "pedantic" .= _configPedantic o
         ]
 
 instance FromJSON (ChainwebConfiguration -> ChainwebConfiguration) where
@@ -381,6 +386,7 @@ instance FromJSON (ChainwebConfiguration -> ChainwebConfiguration) where
         <*< configBlockGasLimit ..: "gasLimitOfBlock" % o
         <*< configPactQueueSize ..: "pactQueueSize" % o
         <*< configReorgLimit ..: "reorgLimit" % o
+        <*< configPedantic ..: "pedantic" % o
 
 pChainwebConfiguration :: MParser ChainwebConfiguration
 pChainwebConfiguration = id
@@ -414,7 +420,9 @@ pChainwebConfiguration = id
         <> help "Max allowed reorg depth.\
                 \ Consult https://github.com/kadena-io/chainweb-node/blob/master/docs/RecoveringFromDeepForks.md for\
                 \ more information. "
-
+    <*< configPedantic .:: boolOption_
+        % long "pedantic"
+        <> help "Be pedantic during pact validation. Re-validates payload hashes during transaction replay."
 
 -- -------------------------------------------------------------------------- --
 -- Chainweb Resources
@@ -566,7 +574,7 @@ withChainwebInternal conf logger peer rocksDb dbDir nodeid resetDb inner = do
             let mcfg = validatingMempoolConfig cid v (_configBlockGasLimit conf)
             withChainResources v cid rocksDb peer (chainLogger cid)
                      mcfg payloadDb prune dbDir nodeid
-                     resetDb deepForkLimit (_configPactQueueSize conf))
+                     resetDb deepForkLimit (_configPactQueueSize conf) (_configPedantic conf))
 
         -- initialize global resources after all chain resources are initialized
         (\cs -> global (HM.fromList $ zip cidsList cs))

--- a/src/Chainweb/Chainweb/ChainResources.hs
+++ b/src/Chainweb/Chainweb/ChainResources.hs
@@ -129,12 +129,12 @@ withChainResources
     -> Natural
         -- ^ deep fork limit
     -> Bool
-        -- ^ Be pedantic. Re-validate payload hashes during replay.
+        -- ^ Re-validate payload hashes during replay.
     -> (ChainResources logger -> IO a)
     -> IO a
 withChainResources
   v cid rdb peer logger mempoolCfg0 payloadDb prune dbDir nodeid resetDb
-  pactQueueSize deepForkLimit pedantic inner =
+  pactQueueSize deepForkLimit revalidate inner =
     withBlockHeaderDb rdb v cid $ \cdb -> do
       pexMv <- newEmptyMVar
       let mempoolCfg = mempoolCfg0 pexMv
@@ -142,7 +142,7 @@ withChainResources
         mpc <- MPCon.mkMempoolConsensus mempool cdb $ Just payloadDb
         withPactService v cid (setComponent "pact" logger) mpc cdb
                         payloadDb dbDir nodeid resetDb pactQueueSize
-                        deepForkLimit pedantic $ \requestQ -> do
+                        deepForkLimit revalidate $ \requestQ -> do
             -- prune block header db
             when prune $ do
                 logg Info "start pruning block header database"

--- a/src/Chainweb/Chainweb/ChainResources.hs
+++ b/src/Chainweb/Chainweb/ChainResources.hs
@@ -128,11 +128,13 @@ withChainResources
     -> Natural
     -> Natural
         -- ^ deep fork limit
+    -> Bool
+        -- ^ Be pedantic. Re-validate payload hashes during replay.
     -> (ChainResources logger -> IO a)
     -> IO a
 withChainResources
   v cid rdb peer logger mempoolCfg0 payloadDb prune dbDir nodeid resetDb
-  pactQueueSize deepForkLimit inner =
+  pactQueueSize deepForkLimit pedantic inner =
     withBlockHeaderDb rdb v cid $ \cdb -> do
       pexMv <- newEmptyMVar
       let mempoolCfg = mempoolCfg0 pexMv
@@ -140,7 +142,7 @@ withChainResources
         mpc <- MPCon.mkMempoolConsensus mempool cdb $ Just payloadDb
         withPactService v cid (setComponent "pact" logger) mpc cdb
                         payloadDb dbDir nodeid resetDb pactQueueSize
-                        deepForkLimit $ \requestQ -> do
+                        deepForkLimit pedantic $ \requestQ -> do
             -- prune block header db
             when prune $ do
                 logg Info "start pruning block header database"

--- a/src/Chainweb/Pact/Backend/ForkingBench.hs
+++ b/src/Chainweb/Pact/Backend/ForkingBench.hs
@@ -348,7 +348,8 @@ withResources trunkLength logLevel f = C.envWithCleanup create destroy unwrap
 
     startPact version l bhdb pdb mempool sqlEnv = do
         reqQ <- atomically $ newTBQueue pactQueueSize
-        a <- async $ initPactService version cid l reqQ mempool bhdb pdb sqlEnv 100000
+        let bePedantic = False
+        a <- async $ initPactService version cid l reqQ mempool bhdb pdb sqlEnv 100000 bePedantic
         return (a, reqQ)
 
     stopPact (a, _) = cancel a

--- a/src/Chainweb/Pact/Types.hs
+++ b/src/Chainweb/Pact/Types.hs
@@ -69,6 +69,7 @@ module Chainweb.Pact.Types
   , psReorgLimit
   , psOnFatalError
   , psVersion
+  , psValidateHashesOnReplay
 
     -- * Pact Service State
   , PactServiceState(..)
@@ -296,6 +297,7 @@ data PactServiceEnv cas = PactServiceEnv
     , _psReorgLimit :: {-# UNPACK #-} !Word64
     , _psOnFatalError :: forall a. PactException -> Text -> IO a
     , _psVersion :: ChainwebVersion
+    , _psValidateHashesOnReplay :: !Bool
     }
 makeLenses ''PactServiceEnv
 

--- a/test/Chainweb/Test/Pact/ModuleCacheOnRestart.hs
+++ b/test/Chainweb/Test/Pact/ModuleCacheOnRestart.hs
@@ -151,6 +151,7 @@ initPactService'' ver cid chainwebLogger bhDb pdb sqlenv reorgLimit act = do
                 , _psReorgLimit = reorgLimit
                 , _psOnFatalError = defaultOnFatalError (logFunctionText chainwebLogger)
                 , _psVersion = ver
+                , _psValidateHashesOnReplay = True
                 }
         !pst = PactServiceState Nothing mempty 0 t0 Nothing noSPVSupport
     runPactServiceM pst pse act

--- a/test/Chainweb/Test/Pact/Utils.hs
+++ b/test/Chainweb/Test/Pact/Utils.hs
@@ -422,6 +422,7 @@ testPactCtx v cid bhdb pdb = do
         , _psReorgLimit = defaultReorgLimit
         , _psOnFatalError = defaultOnFatalError mempty
         , _psVersion = v
+        , _psValidateHashesOnReplay = True
         }
 
 testPactCtxSQLite
@@ -455,6 +456,7 @@ testPactCtxSQLite v cid bhdb pdb sqlenv = do
         , _psReorgLimit = defaultReorgLimit
         , _psOnFatalError = defaultOnFatalError mempty
         , _psVersion = v
+        , _psValidateHashesOnReplay = True
         }
 
 
@@ -595,6 +597,7 @@ withPactCtxSQLite v bhdbIO pdbIO gasModel f =
             , _psReorgLimit = defaultReorgLimit
             , _psOnFatalError = defaultOnFatalError mempty
             , _psVersion = v
+            , _psValidateHashesOnReplay = True
             }
 
 withMVarResource :: a -> (IO (MVar a) -> TestTree) -> TestTree
@@ -666,8 +669,9 @@ withPact version logLevel iopdb iobhdb mempool iodir deepForkLimit f =
         bhdb <- iobhdb
         dir <- iodir
         sqlEnv <- startSqliteDb version cid logger (Just dir) Nothing False
+        let bePedantic = True
         a <- async $
-             initPactService version cid logger reqQ mempool bhdb pdb sqlEnv deepForkLimit
+             initPactService version cid logger reqQ mempool bhdb pdb sqlEnv deepForkLimit bePedantic
         return (a, sqlEnv, reqQ)
 
     stopPact (a, sqlEnv, _) = cancel a >> stopSqliteDb sqlEnv

--- a/test/Chainweb/Test/TreeDB.hs
+++ b/test/Chainweb/Test/TreeDB.hs
@@ -44,9 +44,9 @@ import Chainweb.Utils (len)
 
 treeDbInvariants
     :: (TreeDb db, IsBlockHeader (DbEntry db), Ord (DbEntry db), Ord (DbKey db))
-    -- | Given a generic entry, should yield a database for testing, and then
-    -- safely close it after use.
     => (DbEntry db -> (db -> IO Bool) -> IO Bool)
+        -- ^ Given a generic entry, should yield a database for testing, and then
+        -- safely close it after use.
     -> RunStyle
     -> TestTree
 treeDbInvariants f rs = testGroup "TreeDb Invariants"

--- a/tools/ea/Ea.hs
+++ b/tools/ea/Ea.hs
@@ -124,8 +124,9 @@ genPayloadModule v tag txFiles =
 
         let logger = genericLogger Warn TIO.putStrLn
         pdb <- newPayloadDb
+        let bePedantic = True -- validate payload hashes during replay
         payloadWO <- withSqliteDb v cid logger Nothing Nothing False $ \env ->
-            initPactService' v cid logger bhdb pdb env 1000 $
+            initPactService' v cid logger bhdb pdb env 1000 bePedantic $
                 execNewGenesisBlock noMiner (V.fromList cwTxs)
 
         let payloadYaml = TE.decodeUtf8 $ Yaml.encode payloadWO

--- a/tools/standalone/Standalone/Chainweb.hs
+++ b/tools/standalone/Standalone/Chainweb.hs
@@ -120,8 +120,9 @@ withChainResourcesStandalone
             -- placing mempool access shim here
             -- putting a default here for now.
               let mpa = onlyCoinTransferMemPoolAccess cid 10
+              let bePedantic = True -- check payload hashes during replay
               withSqliteDb v cid logger dbDir nodeid resetDb $ \sqlenv ->
-                withPactService' v cid (setComponent "pact" logger) mpa cdb payloadDb sqlenv pactQueueSize 1000 $
+                withPactService' v cid (setComponent "pact" logger) mpa cdb payloadDb sqlenv pactQueueSize 1000 bePedantic $
                   \requestQ -> do
                       -- prune blockheader db
                       when prune $ do


### PR DESCRIPTION
Normally, payload hashes are validated only for blocks for which validation is requested, but not for possible checkpointer replays. Normally that is fine because normally we trust the existing databases. But sometimes we want to be extra pedantic.

Moreover, when rebuilding a pact database from an existing chain database (or each time we start with a pact db that is "behind" the latest cut of the chaindb), the pact does an initial database sync during which the payload hashes must be revalidated. 

Ideally, we would always enable pedantic hash validation during the initial sync and possibly disable it afterwards. But for that we would have to extend the pact service API to support enabling and disabling pedantic checks. Which which would be a large change that would involve some API design choices. It's something we may consider for a follow up PR. 

### Follow-Up PRs (for a post February 20 release)

1. Collect all pact-service/checkpointer related configuration options in a subsection in the configuration file

2. Consider allowing to enable and disable the `_psValidateHashesOnReplay` in pact service and enable it during initial sync and disable it after that.