### PR TITLE
Cleanup module dependencies

### DIFF
--- a/chainweb.cabal
+++ b/chainweb.cabal
@@ -116,7 +116,8 @@ library
     autogen-modules:
         Paths_chainweb
     exposed-modules:
-          Chainweb.BlockHash
+          Chainweb.BlockCreationTime
+        , Chainweb.BlockHash
         , Chainweb.BlockHeader
         , Chainweb.BlockHeader.Genesis
         , Chainweb.BlockHeader.Genesis.Development0Payload

--- a/chainweb.cabal
+++ b/chainweb.cabal
@@ -141,6 +141,8 @@ library
         , Chainweb.BlockHeaderDB.RestAPI.Client
         , Chainweb.BlockHeaderDB.RestAPI.Server
         , Chainweb.BlockHeaderDB.Types
+        , Chainweb.BlockHeight
+        , Chainweb.BlockWeight
         , Chainweb.ChainId
         , Chainweb.Chainweb
         , Chainweb.Chainweb.ChainResources

--- a/chainweb.cabal
+++ b/chainweb.cabal
@@ -268,6 +268,7 @@ library
         , Chainweb.Pact.Backend.SQLite.V2
         , Chainweb.Pact.Backend.Types
         , Chainweb.Pact.Backend.Utils
+        , Chainweb.Pact.NoCoinbase
         , Chainweb.Pact.PactService
         , Chainweb.Pact.RestAPI
         , Chainweb.Pact.RestAPI.Server
@@ -455,6 +456,7 @@ test-suite chainweb-tests
         Chainweb.Test.Pact.ChainData
         Chainweb.Test.Pact.Checkpointer
         Chainweb.Test.Pact.ModuleCacheOnRestart
+        Chainweb.Test.Pact.NoCoinbase
         Chainweb.Test.Pact.RewardsTest
         Chainweb.Test.Pact.PactExec
         Chainweb.Test.Pact.PactReplay

--- a/src/Chainweb/BlockCreationTime.hs
+++ b/src/Chainweb/BlockCreationTime.hs
@@ -1,0 +1,67 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+-- |
+-- Module: Chainweb.BlockCreationTime
+-- Copyright: Copyright © 2019 Kadena LLC.
+-- License: MIT
+-- Maintainer: Lars Kuhtz <lars@kadena.io>
+-- Stability: experimental
+--
+-- TODO
+--
+module Chainweb.BlockCreationTime
+(
+-- * BlockCreationTime
+  BlockCreationTime(..)
+, encodeBlockCreationTime
+, decodeBlockCreationTime
+) where
+
+import Control.DeepSeq
+
+import Data.Aeson
+import Data.Bytes.Get
+import Data.Bytes.Put
+import Data.Hashable
+
+import GHC.Generics
+
+import Numeric.AffineSpace
+
+-- internal modules
+
+import Chainweb.Crypto.MerkleLog
+import Chainweb.Time
+import Chainweb.MerkleUniverse
+
+-- -------------------------------------------------------------------------- --
+-- Block Creation Time
+
+newtype BlockCreationTime = BlockCreationTime { _bct :: (Time Micros) }
+    deriving stock (Show, Eq, Ord, Generic)
+    deriving anyclass (NFData)
+    deriving newtype (ToJSON, FromJSON, Hashable, LeftTorsor)
+
+instance IsMerkleLogEntry ChainwebHashTag BlockCreationTime where
+    type Tag BlockCreationTime = 'BlockCreationTimeTag
+    toMerkleNode = encodeMerkleInputNode encodeBlockCreationTime
+    fromMerkleNode = decodeMerkleInputNode decodeBlockCreationTime
+    {-# INLINE toMerkleNode #-}
+    {-# INLINE fromMerkleNode #-}
+
+encodeBlockCreationTime :: MonadPut m => BlockCreationTime -> m ()
+encodeBlockCreationTime (BlockCreationTime t) = encodeTime t
+
+decodeBlockCreationTime :: MonadGet m => m BlockCreationTime
+decodeBlockCreationTime = BlockCreationTime <$> decodeTime
+

--- a/src/Chainweb/BlockHeader.hs
+++ b/src/Chainweb/BlockHeader.hs
@@ -54,11 +54,6 @@ module Chainweb.BlockHeader
 , encodeNonceToWord64
 , decodeNonce
 
--- * BlockCreationTime
-, BlockCreationTime(..)
-, encodeBlockCreationTime
-, decodeBlockCreationTime
-
 -- * EpochStartTime
 , EpochStartTime(..)
 , encodeEpochStartTime
@@ -150,6 +145,7 @@ import GHC.Generics (Generic)
 
 -- Internal imports
 
+import Chainweb.BlockCreationTime
 import Chainweb.BlockHash
 import Chainweb.BlockHeight
 import Chainweb.BlockWeight
@@ -252,27 +248,6 @@ instance ToJSON Nonce where
 instance FromJSON Nonce where
     parseJSON = withText "Nonce"
         $ either fail (return . Nonce) . readEither . T.unpack
-
--- -------------------------------------------------------------------------- --
--- Block Creation Time
-
-newtype BlockCreationTime = BlockCreationTime { _bct :: (Time Micros) }
-    deriving stock (Show, Eq, Ord, Generic)
-    deriving anyclass (NFData)
-    deriving newtype (ToJSON, FromJSON, Hashable, LeftTorsor)
-
-instance IsMerkleLogEntry ChainwebHashTag BlockCreationTime where
-    type Tag BlockCreationTime = 'BlockCreationTimeTag
-    toMerkleNode = encodeMerkleInputNode encodeBlockCreationTime
-    fromMerkleNode = decodeMerkleInputNode decodeBlockCreationTime
-    {-# INLINE toMerkleNode #-}
-    {-# INLINE fromMerkleNode #-}
-
-encodeBlockCreationTime :: MonadPut m => BlockCreationTime -> m ()
-encodeBlockCreationTime (BlockCreationTime t) = encodeTime t
-
-decodeBlockCreationTime :: MonadGet m => m BlockCreationTime
-decodeBlockCreationTime = BlockCreationTime <$> decodeTime
 
 -- -------------------------------------------------------------------------- --
 -- POW Target Computation

--- a/src/Chainweb/BlockHeader/Genesis.hs
+++ b/src/Chainweb/BlockHeader/Genesis.hs
@@ -41,6 +41,8 @@ import Pact.Types.Hash (Hash)
 
 import Chainweb.BlockHash
 import Chainweb.BlockHeader
+import Chainweb.BlockHeight
+import Chainweb.BlockWeight
 import qualified Chainweb.BlockHeader.Genesis.Development0Payload as DN0
 import qualified Chainweb.BlockHeader.Genesis.DevelopmentNPayload as DNN
 import qualified Chainweb.BlockHeader.Genesis.FastTimedCPM0Payload as TN0

--- a/src/Chainweb/BlockHeader/Genesis.hs
+++ b/src/Chainweb/BlockHeader/Genesis.hs
@@ -39,6 +39,7 @@ import Pact.Types.Hash (Hash)
 
 -- internal modules
 
+import Chainweb.BlockCreationTime
 import Chainweb.BlockHash
 import Chainweb.BlockHeader
 import Chainweb.BlockHeight

--- a/src/Chainweb/BlockHeader/Genesis.hs
+++ b/src/Chainweb/BlockHeader/Genesis.hs
@@ -34,9 +34,6 @@ import qualified Data.HashMap.Strict as HM
 import qualified Data.HashSet as HS
 import Data.MerkleLog hiding (Actual, Expected, MerkleHash)
 
-import Pact.Types.Command (CommandResult)
-import Pact.Types.Hash (Hash)
-
 -- internal modules
 
 import Chainweb.BlockCreationTime
@@ -103,8 +100,7 @@ emptyPayload = PayloadWithOutputs mempty miner coinbase h i o
   where
     (BlockPayload h i o) = newBlockPayload miner coinbase mempty
     miner = MinerData $ encodeToByteString noMiner
-    coinbase = CoinbaseOutput $ encodeToByteString
-      (noCoinbase :: CommandResult Hash)
+    coinbase = noCoinbaseOutput
 
 -- | The moment of creation of a Genesis Block. For test chains, this is the
 -- Linux Epoch. Production chains are otherwise fixed to a specific timestamp.

--- a/src/Chainweb/BlockHeader/Validation.hs
+++ b/src/Chainweb/BlockHeader/Validation.hs
@@ -60,6 +60,7 @@ import qualified Data.List as L
 
 -- internal modules
 
+import Chainweb.BlockCreationTime
 import Chainweb.BlockHash
 import Chainweb.BlockHeader
 import Chainweb.BlockHeader.Genesis (genesisBlockTarget, genesisParentBlockHash)

--- a/src/Chainweb/BlockHeaderDB.hs
+++ b/src/Chainweb/BlockHeaderDB.hs
@@ -76,6 +76,7 @@ import Chainweb.BlockHash
 import Chainweb.BlockHeader
 import Chainweb.BlockHeaderDB.Types
 import Chainweb.BlockHeader.Genesis (genesisBlockHeader)
+import Chainweb.BlockHeight
 import Chainweb.ChainId
 import Chainweb.Logger
 import Chainweb.TreeDB

--- a/src/Chainweb/BlockHeaderDB/Types.hs
+++ b/src/Chainweb/BlockHeaderDB/Types.hs
@@ -33,6 +33,7 @@ import Prelude hiding (lookup)
 
 import Chainweb.BlockHash
 import Chainweb.BlockHeader
+import Chainweb.BlockHeight
 import Chainweb.ChainId
 import Chainweb.Version
 

--- a/src/Chainweb/BlockHeight.hs
+++ b/src/Chainweb/BlockHeight.hs
@@ -1,0 +1,79 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeFamilies #-}
+
+-- |
+-- Module: Chainweb.BlockHeight
+-- Copyright: Copyright © 2020 Kadena LLC.
+-- License: MIT
+-- Maintainer: Lars Kuhtz <lars@kadena.io>
+-- Stability: experimental
+--
+-- TODO
+--
+module Chainweb.BlockHeight
+(
+-- * Block Height
+  BlockHeight(..)
+, encodeBlockHeight
+, decodeBlockHeight
+, encodeBlockHeightBe
+, decodeBlockHeightBe
+) where
+
+import Control.DeepSeq
+
+import Data.Aeson
+import Data.Bytes.Get
+import Data.Bytes.Put
+import Data.Hashable
+import Data.Word
+
+import GHC.Generics (Generic)
+
+-- Internal imports
+
+import Chainweb.Crypto.MerkleLog
+import Chainweb.MerkleUniverse
+
+import Numeric.Additive
+
+-- -------------------------------------------------------------------------- --
+-- | BlockHeight
+--
+newtype BlockHeight = BlockHeight { _height :: Word64 }
+    deriving (Eq, Ord, Generic)
+    deriving anyclass (NFData)
+    deriving newtype
+        ( Hashable, ToJSON, FromJSON
+        , AdditiveSemigroup, AdditiveAbelianSemigroup, AdditiveMonoid
+        , Num, Integral, Real, Enum
+        )
+instance Show BlockHeight where show (BlockHeight b) = show b
+
+instance IsMerkleLogEntry ChainwebHashTag BlockHeight where
+    type Tag BlockHeight = 'BlockHeightTag
+    toMerkleNode = encodeMerkleInputNode encodeBlockHeight
+    fromMerkleNode = decodeMerkleInputNode decodeBlockHeight
+    {-# INLINE toMerkleNode #-}
+    {-# INLINE fromMerkleNode #-}
+
+encodeBlockHeight :: MonadPut m => BlockHeight -> m ()
+encodeBlockHeight (BlockHeight h) = putWord64le h
+
+decodeBlockHeight :: MonadGet m => m BlockHeight
+decodeBlockHeight = BlockHeight <$> getWord64le
+
+encodeBlockHeightBe :: MonadPut m => BlockHeight -> m ()
+encodeBlockHeightBe (BlockHeight r) = putWord64be r
+
+decodeBlockHeightBe :: MonadGet m => m BlockHeight
+decodeBlockHeightBe = BlockHeight <$> getWord64be
+

--- a/src/Chainweb/BlockWeight.hs
+++ b/src/Chainweb/BlockWeight.hs
@@ -1,0 +1,85 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeFamilies #-}
+
+-- |
+-- Module: Chainweb.BlockWeight
+-- Copyright: Copyright © 2020 Kadena LLC.
+-- License: MIT
+-- Maintainer: Lars Kuhtz <lars@kadena.io>
+-- Stability: experimental
+--
+-- TODO
+--
+module Chainweb.BlockWeight
+(
+-- * Block Weight
+  BlockWeight(..)
+, encodeBlockWeight
+, decodeBlockWeight
+, encodeBlockWeightBe
+, decodeBlockWeightBe
+) where
+
+import Control.DeepSeq
+
+import Data.Aeson
+import Data.Bytes.Get
+import Data.Bytes.Put
+import Data.Hashable
+
+import GHC.Generics (Generic)
+
+-- Internal imports
+
+import Chainweb.Crypto.MerkleLog
+import Chainweb.Difficulty
+import Chainweb.MerkleUniverse
+
+import Numeric.Additive
+
+-- -------------------------------------------------------------------------- --
+-- Block Weight
+--
+-- This is the accumulated Hash difficulty
+--
+newtype BlockWeight = BlockWeight HashDifficulty
+    deriving (Show, Eq, Ord, Generic)
+    deriving anyclass (NFData)
+    deriving newtype
+        ( Hashable
+        , ToJSON, FromJSON, ToJSONKey, FromJSONKey
+        , AdditiveSemigroup, AdditiveAbelianSemigroup
+        , Num
+        )
+
+instance IsMerkleLogEntry ChainwebHashTag BlockWeight where
+    type Tag BlockWeight = 'BlockWeightTag
+    toMerkleNode = encodeMerkleInputNode encodeBlockWeight
+    fromMerkleNode = decodeMerkleInputNode decodeBlockWeight
+    {-# INLINE toMerkleNode #-}
+    {-# INLINE fromMerkleNode #-}
+
+encodeBlockWeight :: MonadPut m => BlockWeight -> m ()
+encodeBlockWeight (BlockWeight w) = encodeHashDifficulty w
+{-# INLINE encodeBlockWeight #-}
+
+decodeBlockWeight :: MonadGet m => m BlockWeight
+decodeBlockWeight = BlockWeight <$> decodeHashDifficulty
+{-# INLINE decodeBlockWeight #-}
+
+encodeBlockWeightBe :: MonadPut m => BlockWeight -> m ()
+encodeBlockWeightBe (BlockWeight w) = encodeHashDifficultyBe w
+{-# INLINE encodeBlockWeightBe #-}
+
+decodeBlockWeightBe :: MonadGet m => m BlockWeight
+decodeBlockWeightBe = BlockWeight <$> decodeHashDifficultyBe
+{-# INLINE decodeBlockWeightBe #-}
+

--- a/src/Chainweb/Chainweb.hs
+++ b/src/Chainweb/Chainweb.hs
@@ -165,6 +165,7 @@ import qualified Pact.Types.Command as P
 import Chainweb.BlockHeader
 import Chainweb.BlockHeaderDB (BlockHeaderDb)
 import Chainweb.BlockHeaderDB.RestAPI (HeaderStream(..))
+import Chainweb.BlockHeight
 import Chainweb.ChainId
 import Chainweb.Chainweb.ChainResources
 import Chainweb.Chainweb.CutResources

--- a/src/Chainweb/Chainweb/MinerResources.hs
+++ b/src/Chainweb/Chainweb/MinerResources.hs
@@ -49,6 +49,7 @@ import qualified System.Random.MWC as MWC
 
 -- internal modules
 
+import Chainweb.BlockCreationTime
 import Chainweb.BlockHeader
 import Chainweb.ChainId
 import Chainweb.Chainweb.ChainResources

--- a/src/Chainweb/Cut.hs
+++ b/src/Chainweb/Cut.hs
@@ -112,6 +112,8 @@ import qualified Streaming.Prelude as S
 import Chainweb.BlockHash
 import Chainweb.BlockHeader
 import Chainweb.BlockHeader.Genesis (genesisBlockHeaders)
+import Chainweb.BlockHeight
+import Chainweb.BlockWeight
 import Chainweb.ChainId
 import Chainweb.Graph
 import Chainweb.TreeDB hiding (properties)

--- a/src/Chainweb/Cut/CutHashes.hs
+++ b/src/Chainweb/Cut/CutHashes.hs
@@ -83,6 +83,8 @@ import System.IO.Unsafe
 
 import Chainweb.BlockHash
 import Chainweb.BlockHeader
+import Chainweb.BlockHeight
+import Chainweb.BlockWeight
 import Chainweb.ChainId
 import Chainweb.Cut
 import Chainweb.Utils

--- a/src/Chainweb/Cut/Test.hs
+++ b/src/Chainweb/Cut/Test.hs
@@ -79,6 +79,7 @@ import qualified Test.QuickCheck.Monadic as T
 
 -- internal modules
 
+import Chainweb.BlockCreationTime
 import Chainweb.BlockHash
 import Chainweb.BlockHeader
 import Chainweb.BlockHeight

--- a/src/Chainweb/Cut/Test.hs
+++ b/src/Chainweb/Cut/Test.hs
@@ -81,6 +81,7 @@ import qualified Test.QuickCheck.Monadic as T
 
 import Chainweb.BlockHash
 import Chainweb.BlockHeader
+import Chainweb.BlockHeight
 import Chainweb.ChainId
 import Chainweb.Cut
 import Chainweb.Difficulty (checkTarget)

--- a/src/Chainweb/CutDB.hs
+++ b/src/Chainweb/CutDB.hs
@@ -120,6 +120,8 @@ import System.Timeout
 
 import Chainweb.BlockHash
 import Chainweb.BlockHeader
+import Chainweb.BlockHeight
+import Chainweb.BlockWeight
 import Chainweb.BlockHeaderDB
 import Chainweb.ChainId
 import Chainweb.Cut

--- a/src/Chainweb/CutDB/Sync.hs
+++ b/src/Chainweb/CutDB/Sync.hs
@@ -33,7 +33,7 @@ import System.LogLevel
 
 -- internal modules
 
-import Chainweb.BlockHeader (BlockHeight)
+import Chainweb.BlockHeight
 import Chainweb.Cut (_cutHeight)
 import Chainweb.Cut.CutHashes
 import Chainweb.CutDB

--- a/src/Chainweb/Logging/Amberdata.hs
+++ b/src/Chainweb/Logging/Amberdata.hs
@@ -63,6 +63,7 @@ import System.LogLevel
 
 -- internal modules
 
+import Chainweb.BlockCreationTime
 import Chainweb.BlockHash
 import Chainweb.BlockHeader
 import Chainweb.BlockHeight

--- a/src/Chainweb/Logging/Amberdata.hs
+++ b/src/Chainweb/Logging/Amberdata.hs
@@ -65,6 +65,8 @@ import System.LogLevel
 
 import Chainweb.BlockHash
 import Chainweb.BlockHeader
+import Chainweb.BlockHeight
+import Chainweb.BlockWeight
 import Chainweb.CutDB
 import Chainweb.HostAddress
 import Chainweb.Logger

--- a/src/Chainweb/Mempool/InMem.hs
+++ b/src/Chainweb/Mempool/InMem.hs
@@ -61,7 +61,7 @@ import System.Random
 -- internal imports
 
 import Chainweb.BlockHash
-import Chainweb.BlockHeader
+import Chainweb.BlockHeight
 import Chainweb.Logger
 import Chainweb.Mempool.InMemTypes
 import Chainweb.Mempool.Mempool

--- a/src/Chainweb/Mempool/Mempool.hs
+++ b/src/Chainweb/Mempool/Mempool.hs
@@ -127,7 +127,7 @@ import Pact.Types.Gas (GasLimit(..), GasPrice(..))
 import qualified Pact.Types.Hash as H
 
 import Chainweb.BlockHash
-import Chainweb.BlockHeader
+import Chainweb.BlockHeight
 import Chainweb.Time (Micros(..), Time(..), TimeSpan(..))
 import qualified Chainweb.Time as Time
 import Chainweb.Transaction

--- a/src/Chainweb/Miner/Coordinator.hs
+++ b/src/Chainweb/Miner/Coordinator.hs
@@ -67,6 +67,7 @@ import System.LogLevel (LogLevel(..))
 import Chainweb.BlockHash (BlockHash, BlockHashRecord(..))
 import Chainweb.BlockHeader
 import Chainweb.BlockHeader.Validation (prop_block_pow)
+import Chainweb.BlockHeight
 import Chainweb.Cut
 import Chainweb.Cut.CutHashes
 import Chainweb.CutDB

--- a/src/Chainweb/Miner/Coordinator.hs
+++ b/src/Chainweb/Miner/Coordinator.hs
@@ -64,6 +64,7 @@ import System.LogLevel (LogLevel(..))
 
 -- internal modules
 
+import Chainweb.BlockCreationTime
 import Chainweb.BlockHash (BlockHash, BlockHashRecord(..))
 import Chainweb.BlockHeader
 import Chainweb.BlockHeader.Validation (prop_block_pow)

--- a/src/Chainweb/Miner/Pact.hs
+++ b/src/Chainweb/Miner/Pact.hs
@@ -59,7 +59,7 @@ import Data.Word
 
 -- internal modules
 
-import Chainweb.BlockHeader (BlockHeight(..))
+import Chainweb.BlockHeight (BlockHeight(..))
 import Chainweb.Graph (HasChainGraph(..), order)
 import Chainweb.Payload (MinerData(..))
 import Chainweb.Utils

--- a/src/Chainweb/Pact/Backend/Bench.hs
+++ b/src/Chainweb/Pact/Backend/Bench.hs
@@ -36,7 +36,7 @@ import qualified Pact.Types.SQLite as PSQL
 -- chainweb imports
 
 import Chainweb.BlockHash
-import Chainweb.BlockHeader
+import Chainweb.BlockHeight
 import Chainweb.MerkleLogHash
 import Chainweb.Pact.Backend.RelationalCheckpointer
 import Chainweb.Pact.Backend.Types

--- a/src/Chainweb/Pact/Backend/ChainwebPactDb.hs
+++ b/src/Chainweb/Pact/Backend/ChainwebPactDb.hs
@@ -51,7 +51,6 @@ import qualified Data.Serialize
 import qualified Data.Set as Set
 import Data.String
 import Data.String.Conv
-import Data.Text (Text)
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as T
 import qualified Data.Vector as V
@@ -76,7 +75,7 @@ import Pact.Types.Util (AsString(..))
 -- chainweb
 
 import Chainweb.BlockHash
-import Chainweb.BlockHeader
+import Chainweb.BlockHeight
 import Chainweb.Pact.Backend.Types
 import Chainweb.Pact.Backend.Utils
 import Chainweb.Pact.Service.Types (PactException(..), internalError)

--- a/src/Chainweb/Pact/Backend/ForkingBench.hs
+++ b/src/Chainweb/Pact/Backend/ForkingBench.hs
@@ -82,6 +82,7 @@ import Pact.Types.Util hiding (unwrap)
 
 -- chainweb imports
 
+import Chainweb.BlockCreationTime
 import Chainweb.BlockHash
 import Chainweb.BlockHeader
 import Chainweb.BlockHeader.Genesis

--- a/src/Chainweb/Pact/Backend/ForkingBench.hs
+++ b/src/Chainweb/Pact/Backend/ForkingBench.hs
@@ -86,6 +86,7 @@ import Chainweb.BlockHash
 import Chainweb.BlockHeader
 import Chainweb.BlockHeader.Genesis
 import Chainweb.BlockHeaderDB
+import Chainweb.BlockHeight
 import Chainweb.ChainId
 import Chainweb.Difficulty
 import Chainweb.Logger

--- a/src/Chainweb/Pact/Backend/InMemoryCheckpointer.hs
+++ b/src/Chainweb/Pact/Backend/InMemoryCheckpointer.hs
@@ -31,7 +31,7 @@ import Pact.Types.Logger
 
 -- internal modules
 import Chainweb.BlockHash
-import Chainweb.BlockHeader
+import Chainweb.BlockHeight
 import Chainweb.Pact.Backend.Types
 import Chainweb.Pact.Service.Types (internalError)
 

--- a/src/Chainweb/Pact/Backend/RelationalCheckpointer.hs
+++ b/src/Chainweb/Pact/Backend/RelationalCheckpointer.hs
@@ -45,7 +45,7 @@ import Pact.Types.SQLite
 
 -- chainweb
 import Chainweb.BlockHash
-import Chainweb.BlockHeader
+import Chainweb.BlockHeight
 import Chainweb.Pact.Backend.ChainwebPactDb
 import Chainweb.Pact.Backend.Types
 import Chainweb.Pact.Backend.Utils

--- a/src/Chainweb/Pact/Backend/Types.hs
+++ b/src/Chainweb/Pact/Backend/Types.hs
@@ -111,6 +111,7 @@ import Pact.Types.Runtime
 -- internal modules
 import Chainweb.BlockHash
 import Chainweb.BlockHeader
+import Chainweb.BlockHeight
 import Chainweb.Mempool.Mempool (MempoolPreBlockCheck)
 import Chainweb.Transaction
 

--- a/src/Chainweb/Pact/NoCoinbase.hs
+++ b/src/Chainweb/Pact/NoCoinbase.hs
@@ -1,0 +1,33 @@
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+-- |
+-- Module: Chainweb.Pact.NoCoinbase
+-- Copyright: Copyright © 2020 Kadena LLC.
+-- License: MIT
+-- Maintainer: Lars Kuhtz <lars@kadena.io>
+-- Stability: experimental
+--
+-- TODO
+--
+module Chainweb.Pact.NoCoinbase
+( noCoinbase
+) where
+
+-- internal modules
+
+import Pact.Types.Command
+import Pact.Types.Exp
+import Pact.Types.Hash
+import Pact.Types.PactValue
+
+-- | No-op coinbase payload
+--
+noCoinbase :: CommandResult a
+noCoinbase = CommandResult
+    (RequestKey pactInitialHash) Nothing
+    (PactResult (Right (PLiteral (LString "NO_COINBASE"))))
+    0 Nothing Nothing Nothing
+{-# NOINLINE noCoinbase #-}
+

--- a/src/Chainweb/Pact/PactService.hs
+++ b/src/Chainweb/Pact/PactService.hs
@@ -108,6 +108,7 @@ import Chainweb.BlockHash
 import Chainweb.BlockHeader
 import Chainweb.BlockHeader.Genesis (genesisBlockHeader, genesisBlockPayload)
 import Chainweb.BlockHeaderDB
+import Chainweb.BlockHeight
 import Chainweb.Logger
 import Chainweb.Mempool.Mempool as Mempool
 import Chainweb.Miner.Pact

--- a/src/Chainweb/Pact/PactService.hs
+++ b/src/Chainweb/Pact/PactService.hs
@@ -104,6 +104,7 @@ import Pact.Types.Term (Term(..))
 ------------------------------------------------------------------------------
 -- internal modules
 
+import Chainweb.BlockCreationTime
 import Chainweb.BlockHash
 import Chainweb.BlockHeader
 import Chainweb.BlockHeader.Genesis (genesisBlockHeader, genesisBlockPayload)

--- a/src/Chainweb/Pact/PactService.hs
+++ b/src/Chainweb/Pact/PactService.hs
@@ -117,6 +117,7 @@ import Chainweb.NodeId
 import Chainweb.Pact.Backend.RelationalCheckpointer (initRelationalCheckpointer)
 import Chainweb.Pact.Backend.Types
 import Chainweb.Pact.Backend.Utils
+import Chainweb.Pact.NoCoinbase
 import Chainweb.Pact.Service.PactQueue (PactQueue, getNextRequest)
 import Chainweb.Pact.Service.Types
 import Chainweb.Pact.SPV

--- a/src/Chainweb/Pact/RestAPI/Server.hs
+++ b/src/Chainweb/Pact/RestAPI/Server.hs
@@ -77,6 +77,7 @@ import Pact.Types.Pretty (pretty)
 
 import Chainweb.BlockHash
 import Chainweb.BlockHeader
+import Chainweb.BlockHeight
 import Chainweb.ChainId
 import Chainweb.Chainweb.ChainResources
 import Chainweb.Chainweb.CutResources

--- a/src/Chainweb/Pact/SPV.hs
+++ b/src/Chainweb/Pact/SPV.hs
@@ -46,6 +46,7 @@ import qualified Streaming.Prelude as S
 import Chainweb.BlockHash
 import Chainweb.BlockHeader
 import Chainweb.BlockHeaderDB
+import Chainweb.BlockHeight
 import Chainweb.Pact.Service.Types
 import Chainweb.Pact.Utils (aeson)
 import Chainweb.Payload

--- a/src/Chainweb/Pact/Service/BlockValidation.hs
+++ b/src/Chainweb/Pact/Service/BlockValidation.hs
@@ -31,6 +31,7 @@ import Pact.Types.Hash
 
 import Chainweb.BlockHash
 import Chainweb.BlockHeader
+import Chainweb.BlockHeight
 import Chainweb.Mempool.Mempool (InsertError)
 import Chainweb.Miner.Pact
 import Chainweb.Pact.Service.PactQueue

--- a/src/Chainweb/Pact/Service/BlockValidation.hs
+++ b/src/Chainweb/Pact/Service/BlockValidation.hs
@@ -29,6 +29,7 @@ import Data.Vector (Vector)
 import Pact.Types.Command
 import Pact.Types.Hash
 
+import Chainweb.BlockCreationTime
 import Chainweb.BlockHash
 import Chainweb.BlockHeader
 import Chainweb.BlockHeight

--- a/src/Chainweb/Pact/Service/PactInProcApi.hs
+++ b/src/Chainweb/Pact/Service/PactInProcApi.hs
@@ -39,6 +39,7 @@ import System.LogLevel
 import Chainweb.BlockHash
 import Chainweb.BlockHeader
 import Chainweb.BlockHeaderDB.Types
+import Chainweb.BlockHeight
 import Chainweb.ChainId
 import Chainweb.Logger
 import Chainweb.Mempool.Consensus

--- a/src/Chainweb/Pact/Service/Types.hs
+++ b/src/Chainweb/Pact/Service/Types.hs
@@ -37,6 +37,7 @@ import Pact.Types.Hash
 
 import Chainweb.BlockHash
 import Chainweb.BlockHeader
+import Chainweb.BlockHeight
 import Chainweb.Mempool.Mempool (InsertError(..))
 import Chainweb.Miner.Pact
 import Chainweb.Payload

--- a/src/Chainweb/Pact/Service/Types.hs
+++ b/src/Chainweb/Pact/Service/Types.hs
@@ -35,6 +35,7 @@ import Pact.Types.Hash
 
 -- internal chainweb modules
 
+import Chainweb.BlockCreationTime
 import Chainweb.BlockHash
 import Chainweb.BlockHeader
 import Chainweb.BlockHeight

--- a/src/Chainweb/Pact/TransactionExec.hs
+++ b/src/Chainweb/Pact/TransactionExec.hs
@@ -91,6 +91,7 @@ import Pact.Types.SPV
 
 -- internal Chainweb modules
 
+import Chainweb.BlockCreationTime
 import Chainweb.BlockHeader
 import Chainweb.Miner.Pact
 import Chainweb.Pact.Service.Types

--- a/src/Chainweb/Pact/Types.hs
+++ b/src/Chainweb/Pact/Types.hs
@@ -135,6 +135,7 @@ import Pact.Types.Term (PactId(..), Ref)
 
 import Chainweb.BlockHash
 import Chainweb.BlockHeader
+import Chainweb.BlockHeight
 import Chainweb.BlockHeaderDB
 import Chainweb.Miner.Pact
 import Chainweb.Pact.Backend.Types

--- a/src/Chainweb/Pact/Types.hs
+++ b/src/Chainweb/Pact/Types.hs
@@ -133,6 +133,7 @@ import Pact.Types.Term (PactId(..), Ref)
 
 -- internal chainweb modules
 
+import Chainweb.BlockCreationTime
 import Chainweb.BlockHash
 import Chainweb.BlockHeader
 import Chainweb.BlockHeight

--- a/src/Chainweb/Pact/Utils.hs
+++ b/src/Chainweb/Pact/Utils.hs
@@ -31,7 +31,7 @@ import qualified Pact.Types.ChainId as P
 import Pact.Types.ChainMeta
 import Pact.Types.Command
 
-import Chainweb.BlockHeader
+import Chainweb.BlockCreationTime
 import Chainweb.ChainId
 import Chainweb.Pact.Backend.Types
 import Chainweb.Time

--- a/src/Chainweb/Payload.hs
+++ b/src/Chainweb/Payload.hs
@@ -61,7 +61,7 @@ module Chainweb.Payload
 
 , MinerData(..)
 , CoinbaseOutput(..)
-, noCoinbase
+, noCoinbaseOutput
 
 , BlockOutputsLog
 , newBlockOutputLog
@@ -107,11 +107,6 @@ import GHC.Generics
 import GHC.Stack
 
 -- internal modules
-
-import Pact.Types.Command
-import Pact.Types.Exp
-import Pact.Types.Hash
-import Pact.Types.PactValue
 
 import Chainweb.Crypto.MerkleLog
 import Chainweb.MerkleLogHash
@@ -488,12 +483,22 @@ coinbaseOutputFromText t = either (throwM . TextFormatException . sshow) return
 
 -- | No-op coinbase payload
 --
-noCoinbase :: CommandResult a
-noCoinbase = CommandResult
-    (RequestKey pactInitialHash) Nothing
-    (PactResult (Right (PLiteral (LString "NO_COINBASE"))))
-    0 Nothing Nothing Nothing
-{-# NOINLINE noCoinbase #-}
+noCoinbaseOutput :: CoinbaseOutput
+noCoinbaseOutput = CoinbaseOutput $ encodeToByteString $ object
+    [ "gas" .= (0 :: Int)
+    , "result" .= object
+        [ "status" .= ("success" :: String)
+        , "data" .= ("NO_COINBASE" :: String)
+        ]
+    , "reqKey" .= ("DldRwCblQ7Loqy6wYJnaodHl30d3j3eH-qtFzfEv46g" :: String)
+        -- this is the unique hash value define in @Pact.Types.Hash.initialHash@
+    , "logs" .= Null
+    , "metaData" .= Null
+    , "continuation" .= Null
+    , "txId" .= Null
+    ]
+{-# NOINLINE noCoinbaseOutput #-}
+
 
 instance HasTextRepresentation CoinbaseOutput where
     toText = coinbaseOutputToText

--- a/src/Chainweb/RestAPI/Orphans.hs
+++ b/src/Chainweb/RestAPI/Orphans.hs
@@ -49,6 +49,8 @@ import Servant.API
 import Chainweb.BlockHash
 import Chainweb.BlockHeader
 import Chainweb.BlockHeaderDB
+import Chainweb.BlockHeight
+import Chainweb.BlockWeight
 import Chainweb.ChainId
 import Chainweb.Cut.CutHashes
 import Chainweb.Difficulty hiding (properties)

--- a/src/Chainweb/RestAPI/Orphans.hs
+++ b/src/Chainweb/RestAPI/Orphans.hs
@@ -46,6 +46,7 @@ import Servant.API
 
 -- internal modules
 
+import Chainweb.BlockCreationTime
 import Chainweb.BlockHash
 import Chainweb.BlockHeader
 import Chainweb.BlockHeaderDB

--- a/src/Chainweb/SPV.hs
+++ b/src/Chainweb/SPV.hs
@@ -40,6 +40,7 @@ import Prelude hiding (lookup)
 -- internal modules
 
 import Chainweb.BlockHeader
+import Chainweb.BlockHeight
 import Chainweb.ChainId
 import Chainweb.Utils
 

--- a/src/Chainweb/SPV/CreateProof.hs
+++ b/src/Chainweb/SPV/CreateProof.hs
@@ -42,6 +42,7 @@ import Prelude hiding (lookup)
 
 import Chainweb.BlockHash
 import Chainweb.BlockHeader
+import Chainweb.BlockHeight
 import Chainweb.ChainId
 import Chainweb.Crypto.MerkleLog
 import Chainweb.CutDB

--- a/src/Chainweb/SPV/RestAPI.hs
+++ b/src/Chainweb/SPV/RestAPI.hs
@@ -44,7 +44,7 @@ import Servant.API
 
 -- internal modules
 
-import Chainweb.BlockHeader
+import Chainweb.BlockHeight
 import Chainweb.ChainId
 import Chainweb.RestAPI.Orphans ()
 import Chainweb.RestAPI.Utils

--- a/src/Chainweb/SPV/RestAPI/Client.hs
+++ b/src/Chainweb/SPV/RestAPI/Client.hs
@@ -32,7 +32,7 @@ import Servant.Client
 
 -- internal modules
 
-import Chainweb.BlockHeader
+import Chainweb.BlockHeight
 import Chainweb.ChainId
 import Chainweb.SPV
 import Chainweb.SPV.RestAPI

--- a/src/Chainweb/SPV/RestAPI/Server.hs
+++ b/src/Chainweb/SPV/RestAPI/Server.hs
@@ -39,7 +39,7 @@ import Servant
 
 -- internal modules
 
-import Chainweb.BlockHeader
+import Chainweb.BlockHeight
 import Chainweb.ChainId
 import Chainweb.CutDB
 import Chainweb.Payload.PayloadStore

--- a/src/Chainweb/WebPactExecutionService.hs
+++ b/src/Chainweb/WebPactExecutionService.hs
@@ -16,6 +16,7 @@ import Control.Monad.Catch
 import qualified Data.HashMap.Strict as HM
 import qualified Data.Vector as V
 
+import Chainweb.BlockCreationTime
 import Chainweb.BlockHeader
 import Chainweb.BlockHeader.Genesis (emptyPayload)
 import Chainweb.ChainId

--- a/src/Chainweb/WebPactExecutionService/Types.hs
+++ b/src/Chainweb/WebPactExecutionService/Types.hs
@@ -13,6 +13,7 @@ import Pact.Types.Hash
 
 import Chainweb.BlockHash
 import Chainweb.BlockHeader
+import Chainweb.BlockHeight
 import Chainweb.ChainId
 import Chainweb.Mempool.Mempool (InsertError)
 import Chainweb.Miner.Pact

--- a/src/Chainweb/WebPactExecutionService/Types.hs
+++ b/src/Chainweb/WebPactExecutionService/Types.hs
@@ -11,6 +11,7 @@ import Data.Vector (Vector)
 import Pact.Types.Command
 import Pact.Types.Hash
 
+import Chainweb.BlockCreationTime
 import Chainweb.BlockHash
 import Chainweb.BlockHeader
 import Chainweb.BlockHeight

--- a/test/Chainweb/Test/CutDB.hs
+++ b/test/Chainweb/Test/CutDB.hs
@@ -53,9 +53,6 @@ import qualified Streaming.Prelude as S
 import Test.QuickCheck
 import Test.Tasty
 
-import Pact.Types.Command (CommandResult)
-import Pact.Types.Hash (Hash)
-
 -- internal modules
 
 import Chainweb.BlockCreationTime
@@ -494,5 +491,5 @@ fakePact = WebPactExecutionService $ PactExecutionService
   }
   where
     getFakeOutput (Transaction txBytes) = TransactionOutput txBytes
-    coinbase = CoinbaseOutput $ encodeToByteString (noCoinbase :: CommandResult Hash)
+    coinbase = noCoinbaseOutput
     fakeMiner = MinerData "fakeMiner"

--- a/test/Chainweb/Test/CutDB.hs
+++ b/test/Chainweb/Test/CutDB.hs
@@ -58,6 +58,7 @@ import Pact.Types.Hash (Hash)
 
 -- internal modules
 
+import Chainweb.BlockCreationTime
 import Chainweb.BlockHeader
 import Chainweb.BlockHeight
 import Chainweb.ChainId

--- a/test/Chainweb/Test/CutDB.hs
+++ b/test/Chainweb/Test/CutDB.hs
@@ -59,6 +59,7 @@ import Pact.Types.Hash (Hash)
 -- internal modules
 
 import Chainweb.BlockHeader
+import Chainweb.BlockHeight
 import Chainweb.ChainId
 import Chainweb.Cut
 import Chainweb.Cut.CutHashes

--- a/test/Chainweb/Test/Mempool/Consensus.hs
+++ b/test/Chainweb/Test/Mempool/Consensus.hs
@@ -36,6 +36,7 @@ import Pact.Types.Gas
 import Chainweb.BlockHash
 import Chainweb.BlockHeader
 import Chainweb.BlockHeaderDB
+import Chainweb.BlockWeight
 import Chainweb.ChainId
 import Chainweb.Crypto.MerkleLog hiding (header)
 import Chainweb.Difficulty (targetToDifficulty)

--- a/test/Chainweb/Test/Mempool/Consensus.hs
+++ b/test/Chainweb/Test/Mempool/Consensus.hs
@@ -33,6 +33,7 @@ import Test.Tasty.QuickCheck
 -- internal modules
 import Pact.Types.Gas
 
+import Chainweb.BlockCreationTime
 import Chainweb.BlockHash
 import Chainweb.BlockHeader
 import Chainweb.BlockHeaderDB

--- a/test/Chainweb/Test/MultiNode.hs
+++ b/test/Chainweb/Test/MultiNode.hs
@@ -74,6 +74,7 @@ import Test.Tasty.HUnit
 
 import Chainweb.BlockHash
 import Chainweb.BlockHeader
+import Chainweb.BlockHeight
 import Chainweb.Chainweb
 import Chainweb.Chainweb.CutResources
 import Chainweb.Chainweb.PeerResources

--- a/test/Chainweb/Test/Orphans/Internal.hs
+++ b/test/Chainweb/Test/Orphans/Internal.hs
@@ -25,6 +25,7 @@ import Test.QuickCheck.Gen (chooseAny)
 
 -- internal modules
 
+import Chainweb.BlockCreationTime
 import Chainweb.BlockHash
 import Chainweb.BlockHeader
 import Chainweb.BlockHeight

--- a/test/Chainweb/Test/Orphans/Internal.hs
+++ b/test/Chainweb/Test/Orphans/Internal.hs
@@ -27,6 +27,8 @@ import Test.QuickCheck.Gen (chooseAny)
 
 import Chainweb.BlockHash
 import Chainweb.BlockHeader
+import Chainweb.BlockHeight
+import Chainweb.BlockWeight
 import Chainweb.ChainId
 import Chainweb.Crypto.MerkleLog
 import Chainweb.Difficulty

--- a/test/Chainweb/Test/Pact/ChainData.hs
+++ b/test/Chainweb/Test/Pact/ChainData.hs
@@ -38,6 +38,7 @@ import Chainweb.BlockHash
 import Chainweb.BlockHeader
 import Chainweb.BlockHeader.Genesis
 import Chainweb.BlockHeaderDB hiding (withBlockHeaderDb)
+import Chainweb.BlockHeight
 import Chainweb.ChainId
 import Chainweb.Difficulty
 import Chainweb.Mempool.Mempool (MempoolPreBlockCheck)

--- a/test/Chainweb/Test/Pact/ChainData.hs
+++ b/test/Chainweb/Test/Pact/ChainData.hs
@@ -34,6 +34,7 @@ import Pact.ApiReq
 
 -- chainweb imports
 
+import Chainweb.BlockCreationTime
 import Chainweb.BlockHash
 import Chainweb.BlockHeader
 import Chainweb.BlockHeader.Genesis

--- a/test/Chainweb/Test/Pact/Checkpointer.hs
+++ b/test/Chainweb/Test/Pact/Checkpointer.hs
@@ -41,7 +41,7 @@ import Test.Tasty.HUnit
 -- internal imports
 
 import Chainweb.BlockHash (BlockHash(..), nullBlockHash)
-import Chainweb.BlockHeader (BlockHeight(..))
+import Chainweb.BlockHeight (BlockHeight(..))
 import Chainweb.MerkleLogHash (merkleLogHash)
 import Chainweb.Pact.Backend.ChainwebPactDb
 import Chainweb.Pact.Backend.InMemoryCheckpointer (initInMemoryCheckpointEnv)

--- a/test/Chainweb/Test/Pact/ModuleCacheOnRestart.hs
+++ b/test/Chainweb/Test/Pact/ModuleCacheOnRestart.hs
@@ -33,7 +33,7 @@ import Pact.Types.Runtime (mdModule,_MDModule,mHash)
 
 -- chainweb imports
 
-import Chainweb.BlockHeader
+import Chainweb.BlockCreationTime
 import Chainweb.BlockHeader.Genesis
 import Chainweb.BlockHeaderDB hiding (withBlockHeaderDb)
 import Chainweb.ChainId

--- a/test/Chainweb/Test/Pact/NoCoinbase.hs
+++ b/test/Chainweb/Test/Pact/NoCoinbase.hs
@@ -1,0 +1,38 @@
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+-- |
+-- Module: Chainweb.Test.Pact.NoCoinbase
+-- Copyright: Copyright © 2020 Kadena LLC.
+-- License: MIT
+-- Maintainer: Lars Kuhtz <lars@kadena.io>
+-- Stability: experimental
+--
+-- TODO
+--
+module Chainweb.Test.Pact.NoCoinbase
+( tests
+) where
+
+import Pact.Types.Command
+import Pact.Types.Hash
+
+import Test.Tasty.HUnit
+
+-- internal modules
+
+import Chainweb.Pact.NoCoinbase
+import Chainweb.Payload
+import Chainweb.Utils
+import Chainweb.Test.Utils
+
+tests :: ScheduledTest
+tests = ScheduledTest "Chainweb.Test.Pact.NoCoinbase" $
+    testCase "noCoinbaseOutput is consistent" test_noCoinbase
+
+test_noCoinbase :: Assertion
+test_noCoinbase =
+    noCoinbaseOutput
+    @=?
+    CoinbaseOutput (encodeToByteString (noCoinbase :: CommandResult Hash))

--- a/test/Chainweb/Test/Pact/PactInProcApi.hs
+++ b/test/Chainweb/Test/Pact/PactInProcApi.hs
@@ -46,6 +46,7 @@ import Pact.Parse
 import Pact.Types.ChainMeta
 import Pact.Types.Command
 
+import Chainweb.BlockCreationTime
 import Chainweb.BlockHeader
 import Chainweb.BlockHeader.Genesis
 import Chainweb.ChainId

--- a/test/Chainweb/Test/Pact/PactReplay.hs
+++ b/test/Chainweb/Test/Pact/PactReplay.hs
@@ -40,6 +40,7 @@ import Chainweb.BlockHash
 import Chainweb.BlockHeader
 import Chainweb.BlockHeader.Genesis
 import Chainweb.BlockHeaderDB hiding (withBlockHeaderDb)
+import Chainweb.BlockHeight
 import Chainweb.Difficulty
 import Chainweb.Miner.Core (HeaderBytes(..), TargetBytes(..), mine, usePowHash)
 import Chainweb.Miner.Pact

--- a/test/Chainweb/Test/Pact/PactReplay.hs
+++ b/test/Chainweb/Test/Pact/PactReplay.hs
@@ -36,6 +36,7 @@ import Pact.ApiReq
 
 -- chainweb imports
 
+import Chainweb.BlockCreationTime
 import Chainweb.BlockHash
 import Chainweb.BlockHeader
 import Chainweb.BlockHeader.Genesis

--- a/test/Chainweb/Test/Pact/SPV.hs
+++ b/test/Chainweb/Test/Pact/SPV.hs
@@ -69,6 +69,7 @@ import Pact.Types.Term
 
 import Chainweb.BlockHash
 import Chainweb.BlockHeader
+import Chainweb.BlockHeight
 import Chainweb.ChainId
 import Chainweb.Cut
 import Chainweb.CutDB

--- a/test/Chainweb/Test/Pact/TTL.hs
+++ b/test/Chainweb/Test/Pact/TTL.hs
@@ -36,6 +36,7 @@ import Pact.Types.ChainMeta
 
 import Chainweb.BlockHash
 import Chainweb.BlockHeader
+import Chainweb.BlockHeight
 import Chainweb.BlockHeader.Genesis
 import Chainweb.BlockHeaderDB hiding (withBlockHeaderDb)
 import Chainweb.Difficulty

--- a/test/Chainweb/Test/Pact/TTL.hs
+++ b/test/Chainweb/Test/Pact/TTL.hs
@@ -34,6 +34,7 @@ import Pact.Types.ChainMeta
 
 -- chainweb imports
 
+import Chainweb.BlockCreationTime
 import Chainweb.BlockHash
 import Chainweb.BlockHeader
 import Chainweb.BlockHeight

--- a/test/Chainweb/Test/Pact/TransactionTests.hs
+++ b/test/Chainweb/Test/Pact/TransactionTests.hs
@@ -47,6 +47,7 @@ import Pact.Types.SPV
 
 -- internal chainweb modules
 
+import Chainweb.BlockCreationTime
 import Chainweb.BlockHeader
 import Chainweb.BlockHeight
 import Chainweb.Miner.Pact

--- a/test/Chainweb/Test/Pact/TransactionTests.hs
+++ b/test/Chainweb/Test/Pact/TransactionTests.hs
@@ -25,7 +25,6 @@ import Control.Monad
 import Data.Aeson
 import Data.Aeson.Lens
 import Data.Foldable (for_, traverse_)
-import Data.Functor (void)
 import Data.Text (isInfixOf,unpack)
 import Data.Default
 import Data.Tuple.Strict (T2(..))
@@ -49,6 +48,7 @@ import Pact.Types.SPV
 -- internal chainweb modules
 
 import Chainweb.BlockHeader
+import Chainweb.BlockHeight
 import Chainweb.Miner.Pact
 import Chainweb.Pact.Templates
 import Chainweb.Pact.TransactionExec

--- a/test/Chainweb/Test/Pact/Utils.hs
+++ b/test/Chainweb/Test/Pact/Utils.hs
@@ -130,6 +130,7 @@ import Pact.Types.Util (toB16Text)
 import Chainweb.BlockHeader
 import Chainweb.BlockHeader.Genesis
 import Chainweb.BlockHeaderDB hiding (withBlockHeaderDb)
+import Chainweb.BlockHeight
 import Chainweb.ChainId
 import Chainweb.Logger
 import Chainweb.Miner.Pact

--- a/test/Chainweb/Test/Pact/Utils.hs
+++ b/test/Chainweb/Test/Pact/Utils.hs
@@ -127,6 +127,7 @@ import Pact.Types.Util (toB16Text)
 
 -- internal modules
 
+import Chainweb.BlockCreationTime
 import Chainweb.BlockHeader
 import Chainweb.BlockHeader.Genesis
 import Chainweb.BlockHeaderDB hiding (withBlockHeaderDb)

--- a/test/Chainweb/Test/Roundtrips.hs
+++ b/test/Chainweb/Test/Roundtrips.hs
@@ -29,6 +29,8 @@ import Test.QuickCheck.Instances ()
 
 import Chainweb.BlockHash
 import Chainweb.BlockHeader
+import Chainweb.BlockHeight
+import Chainweb.BlockWeight
 import Chainweb.ChainId
 import Chainweb.Difficulty
 import Chainweb.HostAddress

--- a/test/Chainweb/Test/Utils.hs
+++ b/test/Chainweb/Test/Utils.hs
@@ -150,6 +150,8 @@ import Chainweb.Logger (Logger)
 import Chainweb.BlockHeader
 import Chainweb.BlockHeader.Genesis (genesisBlockHeader)
 import Chainweb.BlockHeaderDB
+import Chainweb.BlockHeight
+import Chainweb.BlockWeight
 import Chainweb.ChainId
 import Chainweb.Crypto.MerkleLog hiding (header)
 import Chainweb.CutDB

--- a/test/Chainweb/Test/Utils.hs
+++ b/test/Chainweb/Test/Utils.hs
@@ -144,6 +144,7 @@ import Text.Printf (printf)
 
 -- internal modules
 
+import Chainweb.BlockCreationTime
 import Chainweb.BlockHeaderDB.RestAPI (HeaderStream(..))
 import Chainweb.Chainweb.MinerResources (MiningCoordination)
 import Chainweb.Logger (Logger)

--- a/test/ChainwebTests.hs
+++ b/test/ChainwebTests.hs
@@ -34,6 +34,7 @@ import qualified Chainweb.Test.Misc
 import qualified Chainweb.Test.Pact.ChainData
 import qualified Chainweb.Test.Pact.Checkpointer
 import qualified Chainweb.Test.Pact.ModuleCacheOnRestart
+import qualified Chainweb.Test.Pact.NoCoinbase
 import qualified Chainweb.Test.Pact.PactExec
 import qualified Chainweb.Test.Pact.PactInProcApi
 import qualified Chainweb.Test.Pact.PactReplay
@@ -91,6 +92,7 @@ pactTestSuite rdb = testGroupSch "Chainweb-Pact Tests"
         , Chainweb.Test.Pact.ModuleCacheOnRestart.tests
         , Chainweb.Test.Pact.TTL.tests
         , Chainweb.Test.Pact.RewardsTest.tests
+        , Chainweb.Test.Pact.NoCoinbase.tests
         ]
 
 suite :: RocksDb -> [ScheduledTest]

--- a/tools/chain2gexf/Gexf.hs
+++ b/tools/chain2gexf/Gexf.hs
@@ -38,6 +38,7 @@ import Text.XML.Generator
 
 import Chainweb.BlockHash
 import Chainweb.BlockHeader
+import Chainweb.BlockWeight
 import Chainweb.Difficulty
 import Chainweb.HostAddress
 import Chainweb.Time

--- a/tools/chain2gexf/Gexf.hs
+++ b/tools/chain2gexf/Gexf.hs
@@ -36,6 +36,7 @@ import Text.XML.Generator
 
 -- internal modules
 
+import Chainweb.BlockCreationTime
 import Chainweb.BlockHash
 import Chainweb.BlockHeader
 import Chainweb.BlockWeight

--- a/tools/db-checksum/CheckpointerDBChecksum.hs
+++ b/tools/db-checksum/CheckpointerDBChecksum.hs
@@ -44,7 +44,7 @@ import Text.Printf
 import Pact.Types.SQLite
 
 -- chainweb imports
-import Chainweb.BlockHeader
+import Chainweb.BlockHeight
 import Chainweb.Pact.Backend.Types
 import Chainweb.Pact.Backend.Utils hiding (callDb)
 import Chainweb.Pact.Service.Types

--- a/tools/header-dump/HeaderDump.hs
+++ b/tools/header-dump/HeaderDump.hs
@@ -95,6 +95,7 @@ import System.LogLevel
 -- internal modules
 
 import Chainweb.BlockHeader
+import Chainweb.BlockHeight
 import Chainweb.BlockHeaderDB
 import Chainweb.Logger
 import Chainweb.Miner.Pact

--- a/tools/standalone/Standalone/Utils.hs
+++ b/tools/standalone/Standalone/Utils.hs
@@ -51,6 +51,8 @@ import Pact.Types.Util hiding (unwrap)
 -- chainweb imports
 
 import Chainweb.BlockHeader
+import Chainweb.BlockHeight
+import Chainweb.BlockWeight
 import Chainweb.ChainId
 import Chainweb.Cut
 import Chainweb.CutDB

--- a/tools/txstream/TxStream.hs
+++ b/tools/txstream/TxStream.hs
@@ -64,6 +64,7 @@ import System.LogLevel
 -- internal modules
 
 import Chainweb.BlockHeader
+import Chainweb.BlockHeight
 import Chainweb.CutDB.RestAPI.Client
 import Chainweb.HostAddress
 import Chainweb.Logger


### PR DESCRIPTION
This cleans up the module dependency graph by moving some types into modules on their own.

This is preparatory work for some upcoming feature PRs.