### PR TITLE
Simplify Forking Logic

### DIFF
--- a/chainweb.cabal
+++ b/chainweb.cabal
@@ -259,6 +259,7 @@ library
         , Chainweb.Pact.Backend.SQLite.V2
         , Chainweb.Pact.Backend.Types
         , Chainweb.Pact.Backend.Utils
+        , Chainweb.Pact.Fork
         , Chainweb.Pact.NoCoinbase
         , Chainweb.Pact.PactService
         , Chainweb.Pact.RestAPI

--- a/src/Chainweb/BlockHeader.hs
+++ b/src/Chainweb/BlockHeader.hs
@@ -931,26 +931,30 @@ testBlockHeadersWithNonce n (ParentHeader p) = unfoldr (Just . (id &&& id) . f) 
 --
 isPastOrEqBlockTime :: Time Micros -> BlockHeader -> Bool
 isPastOrEqBlockTime t bh =
-  let (BlockCreationTime bt) = _blockCreationTime bh
-  in t >= bt
+    let (BlockCreationTime bt) = _blockCreationTime bh
+    in t >= bt
 {-# INLINE isPastOrEqBlockTime #-}
 
 -- | Test if a time is less than or equal to block creation time
 --
 isBeforeOrEqBlockTime :: Time Micros -> BlockHeader -> Bool
 isBeforeOrEqBlockTime t bh =
-  let (BlockCreationTime bt) = _blockCreationTime bh
-  in t <= bt
+    let (BlockCreationTime bt) = _blockCreationTime bh
+    in t <= bt
 {-# INLINE isBeforeOrEqBlockTime #-}
 
 -- | Test if a time is strictly after block creation time
 --
 isPastBlockTime :: Time Micros -> BlockHeader -> Bool
-isPastBlockTime t bh = not (isBeforeOrEqBlockTime t bh)
+isPastBlockTime t bh =
+    let (BlockCreationTime bt) = _blockCreationTime bh
+    in t > bt
 {-# INLINE isPastBlockTime #-}
 
 -- | Test if a time is before block creation time
 --
 isBeforeBlockTime :: Time Micros -> BlockHeader -> Bool
-isBeforeBlockTime t bh = not (isPastOrEqBlockTime t bh)
+isBeforeBlockTime t bh =
+  let (BlockCreationTime bt) = _blockCreationTime bh
+  in t < bt
 {-# INLINE isBeforeBlockTime #-}

--- a/src/Chainweb/BlockHeader.hs
+++ b/src/Chainweb/BlockHeader.hs
@@ -122,9 +122,6 @@ module Chainweb.BlockHeader
 
 -- * Block header time combinators
 , isPastBlockTime
-, isBeforeBlockTime
-, isPastOrEqBlockTime
-, isBeforeOrEqBlockTime
 ) where
 
 import Control.Arrow ((&&&))
@@ -927,22 +924,6 @@ testBlockHeadersWithNonce n (ParentHeader p) = unfoldr (Just . (id &&& id) . f) 
 -- -------------------------------------------------------------------------- --
 -- BlockHeader combinators
 
--- | Test if a time is greater than or equal to block creation time
---
-isPastOrEqBlockTime :: Time Micros -> BlockHeader -> Bool
-isPastOrEqBlockTime t bh =
-    let (BlockCreationTime bt) = _blockCreationTime bh
-    in t >= bt
-{-# INLINE isPastOrEqBlockTime #-}
-
--- | Test if a time is less than or equal to block creation time
---
-isBeforeOrEqBlockTime :: Time Micros -> BlockHeader -> Bool
-isBeforeOrEqBlockTime t bh =
-    let (BlockCreationTime bt) = _blockCreationTime bh
-    in t <= bt
-{-# INLINE isBeforeOrEqBlockTime #-}
-
 -- | Test if a time is strictly after block creation time
 --
 isPastBlockTime :: Time Micros -> BlockHeader -> Bool
@@ -950,11 +931,3 @@ isPastBlockTime t bh =
     let (BlockCreationTime bt) = _blockCreationTime bh
     in t > bt
 {-# INLINE isPastBlockTime #-}
-
--- | Test if a time is before block creation time
---
-isBeforeBlockTime :: Time Micros -> BlockHeader -> Bool
-isBeforeBlockTime t bh =
-  let (BlockCreationTime bt) = _blockCreationTime bh
-  in t < bt
-{-# INLINE isBeforeBlockTime #-}

--- a/src/Chainweb/BlockHeader.hs
+++ b/src/Chainweb/BlockHeader.hs
@@ -121,7 +121,7 @@ module Chainweb.BlockHeader
 , BlockHeaderCas
 
 -- * Block header time combinators
-, isPastBlockTime
+, isAfterBlockTime
 ) where
 
 import Control.Arrow ((&&&))
@@ -926,8 +926,8 @@ testBlockHeadersWithNonce n (ParentHeader p) = unfoldr (Just . (id &&& id) . f) 
 
 -- | Test if a time is strictly after block creation time
 --
-isPastBlockTime :: Time Micros -> BlockHeader -> Bool
-isPastBlockTime t bh =
+isAfterBlockTime :: Time Micros -> BlockHeader -> Bool
+isAfterBlockTime t bh =
     let (BlockCreationTime bt) = _blockCreationTime bh
     in t > bt
-{-# INLINE isPastBlockTime #-}
+{-# INLINE isAfterBlockTime #-}

--- a/src/Chainweb/Pact/Backend/Types.hs
+++ b/src/Chainweb/Pact/Backend/Types.hs
@@ -75,6 +75,7 @@ module Chainweb.Pact.Backend.Types
     , MemPoolAccess(..)
 
     , PactServiceException(..)
+    , WithCheckpointerResult(..)
     ) where
 
 import Control.Exception
@@ -327,3 +328,7 @@ instance Show PactServiceException where
              ]
 
 instance Exception PactServiceException
+
+data WithCheckpointerResult a
+    = Discard !a
+    | Save BlockHeader !a

--- a/src/Chainweb/Pact/Fork.hs
+++ b/src/Chainweb/Pact/Fork.hs
@@ -20,8 +20,6 @@ import Chainweb.Version
 data ForkType
     = EnableUserContracts
       -- ^ enable user contracts for non-genesis
-    | Vuln797Fix
-      -- ^ enable vuln797 fix
     | TxEnabled
       -- ^ check tx enabled date
 
@@ -36,10 +34,7 @@ forkingChange !bh !forkTy = case forkTy of
       _ -> True
 
     TxEnabled -> case txEnabledDate v of
-      Just end | end `isPastBlockTime` bh && notGenesis -> False
+      Just end | end `isPastBlockTime` bh -> False
       _ -> True
-
-    _ -> False
   where
-    !notGenesis = isNotGenesisBlockHeader bh
     !v = _blockChainwebVersion bh

--- a/src/Chainweb/Pact/Fork.hs
+++ b/src/Chainweb/Pact/Fork.hs
@@ -22,19 +22,26 @@ data ForkType
       -- ^ enable user contracts for non-genesis
     | TxEnabled
       -- ^ check tx enabled date
+    | Vuln797Fix
+      -- ^ check if vuln797 date
+    deriving Eq
 
-
+-- | Check whether the blocktime of a given header satisfies
+-- a given fork predicate dictated by the fork type
+--
 forkingChange
     :: BlockHeader
     -> ForkType
     -> Bool
 forkingChange !bh !forkTy = case forkTy of
     EnableUserContracts -> case userContractActivationDate v of
-      Just d | d `isPastBlockTime` bh -> False
+      Just d | d `isAfterBlockTime` bh -> False
       _ -> True
 
     TxEnabled -> case txEnabledDate v of
-      Just end | end `isPastBlockTime` bh -> False
+      Just end | end `isAfterBlockTime` bh -> False
       _ -> True
+
+    Vuln797Fix -> not $ vuln797FixDate v `isAfterBlockTime` bh
   where
     !v = _blockChainwebVersion bh

--- a/src/Chainweb/Pact/Fork.hs
+++ b/src/Chainweb/Pact/Fork.hs
@@ -32,7 +32,7 @@ forkingChange
     -> Bool
 forkingChange !bh !forkTy = case forkTy of
     EnableUserContracts -> case userContractActivationDate v of
-      Just d | d `isPastBlockTime` bh && notGenesis -> False
+      Just d | d `isPastBlockTime` bh -> False
       _ -> True
 
     TxEnabled -> case txEnabledDate v of

--- a/src/Chainweb/Pact/Fork.hs
+++ b/src/Chainweb/Pact/Fork.hs
@@ -1,0 +1,45 @@
+{-# LANGUAGE BangPatterns #-}
+-- |
+-- Module      :  Chainweb.Pact.Fork
+-- Copyright   :  Copyright © 2018-2020 Kadena LLC.
+-- License     :  (see the file LICENSE)
+-- Maintainer  :  Emily Pillmore <emily@kadena.io>
+-- Stability   :  experimental
+--
+-- Pact command execution and coin-contract transaction logic for Chainweb
+module Chainweb.Pact.Fork
+( forkingChange
+, ForkType(..)
+) where
+
+
+import Chainweb.BlockHeader
+import Chainweb.Version
+
+
+data ForkType
+    = EnableUserContracts
+      -- ^ enable user contracts for non-genesis
+    | Vuln797Fix
+      -- ^ enable vuln797 fix
+    | TxEnabled
+      -- ^ check tx enabled date
+
+
+forkingChange
+    :: BlockHeader
+    -> ForkType
+    -> Bool
+forkingChange !bh !forkTy = case forkTy of
+    EnableUserContracts -> case userContractActivationDate v of
+      Just d | d `isPastBlockTime` bh && notGenesis -> False
+      _ -> True
+
+    TxEnabled -> case txEnabledDate v of
+      Just end | end `isPastBlockTime` bh && notGenesis -> False
+      _ -> True
+
+    _ -> False
+  where
+    !notGenesis = isNotGenesisBlockHeader bh
+    !v = _blockChainwebVersion bh

--- a/src/Chainweb/Pact/PactService.hs
+++ b/src/Chainweb/Pact/PactService.hs
@@ -876,6 +876,7 @@ execNewBlock mpAccess parentHeader miner = go
     newblockRewindLimit = Just 8
 
     parentCreationTime = _blockCreationTime parentHeader
+
     doPreBlock pdbenv = do
       cp <- getCheckpointer
       psEnv <- ask

--- a/src/Chainweb/Pact/PactService.hs
+++ b/src/Chainweb/Pact/PactService.hs
@@ -1196,10 +1196,8 @@ execValidateBlock currHeader plData = do
         !notGenesis = isNotGenesisBlockHeader currHeader
         !plNonEmpty = not $ V.null $ _payloadDataTransactions plData
 
-    when (txEnabled && notGenesis && plNonEmpty) $
+    when (not txEnabled && notGenesis && plNonEmpty) $
       throwM . BlockValidationFailure . A.toJSON $ ObjectEncoded currHeader
-
-    liftIO $ putStrLn "HERE!"
 
     (T2 miner transactions) <- handle handleEx $ withBatch $ do
         rewindTo (Just reorgLimit) mb

--- a/src/Chainweb/Pact/TransactionExec.hs
+++ b/src/Chainweb/Pact/TransactionExec.hs
@@ -42,6 +42,7 @@ module Chainweb.Pact.TransactionExec
 , networkIdOf
 , gasSupplyOf
 , gasPriceOf
+, blockTimeOf
 
   -- * Utilities
 , buildExecParsedCode

--- a/src/Chainweb/Pact/TransactionExec.hs
+++ b/src/Chainweb/Pact/TransactionExec.hs
@@ -42,7 +42,6 @@ module Chainweb.Pact.TransactionExec
 , networkIdOf
 , gasSupplyOf
 , gasPriceOf
-, blockTimeOf
 
   -- * Utilities
 , buildExecParsedCode


### PR DESCRIPTION
This PR was requested to make forking logic explicit and to simplify our blocktime comparisons

N.B. There are no changes made to the vuln797 code in `TransactionExec.hs` because the tests break due to now depending on the blocktime of the parentheader instead of the public data.

I've left the code in so that we can incorporate it into future refactors and write a new test as a separate PR in the future