### PR TITLE
fix prettyprinter version to 1.6.0

### DIFF
--- a/chainweb.cabal
+++ b/chainweb.cabal
@@ -409,7 +409,7 @@ library
         , yet-another-logger >= 0.3.1
 
         -- this should eventually go into pact
-        , prettyprinter == 1.6.0
+        , prettyprinter < 1.6.1
 
     if flag(ed25519)
         cpp-options: -DWITH_ED25519=1

--- a/chainweb.cabal
+++ b/chainweb.cabal
@@ -408,6 +408,9 @@ library
         , yaml >= 0.11
         , yet-another-logger >= 0.3.1
 
+        -- this should eventually go into pact
+        , prettyprinter == 1.6.0
+
     if flag(ed25519)
         cpp-options: -DWITH_ED25519=1
     if flag(ghc-flags)


### PR DESCRIPTION
This should actually be fixed in pact. Until then we put this in chainweb as a temporary solution.

We add this to `chainweb.cabal` (as opposed to adding constraints to `cabal.project`, `overwrites.nix`, and `stack.yaml`), because this isn't about build dependencies, but about actual semantic correctness of the chainweb.