### PR TITLE
Pact bump for execution config flags, enforce-one fix

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -11,7 +11,7 @@ debug-info: True
 source-repository-package
     type: git
     location: https://github.com/kadena-io/pact.git
-    tag: cf220977a6b50a47cd446dad2e5e444f61689672
+    tag: 731a9c07dd7486dc8d5c1b11905ceb34d9bd8af0
 
 source-repository-package
     type: git
@@ -27,4 +27,3 @@ constraints:
       base-unicode-symbols < 0.2.4,
       megaparsec < 8,
       neat-interpolation < 0.4
-

--- a/project.nix
+++ b/project.nix
@@ -1,5 +1,5 @@
-{ pactRef ? "cf220977a6b50a47cd446dad2e5e444f61689672"
-, pactSha ? "1554vhka5l1v5caykmd2vq6zffpzpy2ipij6dnq89v50lcy71d3f"
+{ pactRef ? "731a9c07dd7486dc8d5c1b11905ceb34d9bd8af0"
+, pactSha ? "0gq0yngz69jxv4zxazclq3i5bwsics15f6z0ca5s7cmhg2jy5qbr"
 , system ? builtins.currentSystem
 }:
 

--- a/src/Chainweb/Pact/PactService.hs
+++ b/src/Chainweb/Pact/PactService.hs
@@ -665,7 +665,10 @@ attemptBuyGas miner (PactDbEnv' dbEnv) txs = do
 
         pd <- mkPublicData' (publicMetaOf cmd) ph
         spv <- use psSpvSupport
-        return $! TransactionEnv P.Transactional db l pd spv nid gp rk gl restrictiveExecutionConfig
+        let ec = mkExecutionConfig
+              [ P.FlagDisableModuleInstall
+              , P.FlagDisableHistoryInTransactionalMode ]
+        return $! TransactionEnv P.Transactional db l pd spv nid gp rk gl ec
       where
         !nid = networkIdOf cmd
         !rk = P.cmdToRequestKey cmd

--- a/src/Chainweb/Pact/TransactionExec.hs
+++ b/src/Chainweb/Pact/TransactionExec.hs
@@ -152,7 +152,10 @@ applyCmd logger pdbenv miner gasModel pd spv cmdIn mcache0 ecMod =
       runTransactionM cenv txst applyBuyGas
   where
     txst = TransactionState mcache0 mempty 0 Nothing (_geGasModel freeGasEnv)
-    executionConfigNoHistory = ExecutionConfig ecMod False
+
+    executionConfigNoHistory = mkExecutionConfig $
+      [ FlagDisableHistoryInTransactionalMode ] ++
+      if ecMod then [] else [ FlagDisableModuleInstall ]
     cenv = TransactionEnv Transactional pdbenv logger pd spv nid gasPrice
       requestKey (fromIntegral gasLimit) executionConfigNoHistory
 
@@ -213,7 +216,7 @@ applyGenesisCmd logger dbEnv pd spv cmd =
     nid = networkIdOf cmd
     rk = cmdToRequestKey cmd
     tenv = TransactionEnv Transactional dbEnv logger pd spv nid 0.0 rk 0
-           justInstallsExecutionConfig
+           def
     txst = TransactionState mempty mempty 0 Nothing (_geGasModel freeGasEnv)
 
     interp = initStateInterpreter $ initCapabilities [magic_GENESIS, magic_COINBASE]
@@ -223,7 +226,6 @@ applyGenesisCmd logger dbEnv pd spv cmd =
       case cr of
         Left e -> fatal $ "Genesis command failed: " <> sshow e
         Right r -> r <$ debug "successful genesis tx for request key"
-
 
 applyCoinbase
     :: ChainwebVersion
@@ -263,8 +265,11 @@ applyCoinbase v logger dbEnv (Miner mid mks) reward@(ParsedDecimal d) pd parentH
     throwCritical = fork1_3InEffect || enfCBFailure
     blockTime = blockTimeOf pd
 
+    ec = mkExecutionConfig
+      [ FlagDisableModuleInstall
+      , FlagDisableHistoryInTransactionalMode ]
     tenv = TransactionEnv Transactional dbEnv logger pd noSPVSupport
-           Nothing 0.0 rk 0 restrictiveExecutionConfig
+           Nothing 0.0 rk 0 ec
     txst = TransactionState mc mempty 0 Nothing (_geGasModel freeGasEnv)
     initState = setModuleCache mc $ initCapabilities [magic_COINBASE]
     chash = Pact.Hash (sshow $ _blockHash parentHeader)
@@ -321,7 +326,7 @@ applyLocal logger dbEnv gasModel pd spv cmdIn mc =
     gasPrice = gasPriceOf cmd
     gasLimit = gasLimitOf cmd
     tenv = TransactionEnv Local dbEnv logger pd spv nid gasPrice
-           rk (fromIntegral gasLimit) permissiveExecutionConfig
+           rk (fromIntegral gasLimit) def
     txst = TransactionState mc mempty 0 Nothing gasModel
     gas0 = initialGasOf (_cmdPayload cmdIn)
 
@@ -356,7 +361,7 @@ readInitModules logger dbEnv pd =
     nid = Nothing
     chash = pactInitialHash
     tenv = TransactionEnv Local dbEnv logger pd noSPVSupport nid 0.0
-           rk 0 permissiveExecutionConfig
+           rk 0 def
     txst = TransactionState mempty mempty 0 Nothing (_geGasModel freeGasEnv)
     interp = defaultInterpreter
 
@@ -409,7 +414,7 @@ applyUpgrades v parentHeader (BlockCreationTime currCreationTime) =
     applyTxs txsIO = do
       infoLog $ "Applying upgrade!"
       txs <- map (fmap payloadObj) <$> liftIO txsIO
-      local (set (txExecutionConfig . ecAllowModuleInstall) True) $
+      local (set txExecutionConfig def) $
         mapM_ applyTx txs
       mc <- use txCache
       return $ Just mc

--- a/src/Chainweb/Pact/Types.hs
+++ b/src/Chainweb/Pact/Types.hs
@@ -91,13 +91,10 @@ module Chainweb.Pact.Types
     -- * types
   , ModuleCache
 
-  -- * Execution config
-  , restrictiveExecutionConfig
-  , permissiveExecutionConfig
-  , justInstallsExecutionConfig
   -- * miscellaneous
   , defaultOnFatalError
   , defaultReorgLimit
+  , mkExecutionConfig
   ) where
 
 import Control.Exception (asyncExceptionFromException, asyncExceptionToException, throw)
@@ -110,6 +107,7 @@ import Control.Monad.State.Strict
 
 import Data.Aeson hiding (Error)
 import Data.HashMap.Strict (HashMap)
+import qualified Data.Set as S
 import Data.Text (pack, unpack, Text)
 import Data.Tuple.Strict (T2)
 import Data.Vector (Vector)
@@ -128,7 +126,7 @@ import Pact.Types.Gas
 import Pact.Types.Logger
 import Pact.Types.Names
 import Pact.Types.Persistence (ExecutionMode, TxLog)
-import Pact.Types.Runtime (ExecutionConfig(..), ModuleData)
+import Pact.Types.Runtime (ExecutionConfig(..), ExecutionFlag(..), ModuleData)
 import Pact.Types.SPV
 import Pact.Types.Term (PactId(..), Ref)
 
@@ -161,16 +159,8 @@ data PactDbStatePersist = PactDbStatePersist
     }
 makeLenses ''PactDbStatePersist
 
--- | No installs or history
-restrictiveExecutionConfig :: ExecutionConfig
-restrictiveExecutionConfig = ExecutionConfig False False
-
-permissiveExecutionConfig :: ExecutionConfig
-permissiveExecutionConfig = ExecutionConfig True True
-
--- | Only allow installs
-justInstallsExecutionConfig :: ExecutionConfig
-justInstallsExecutionConfig = ExecutionConfig True False
+mkExecutionConfig :: [ExecutionFlag] -> ExecutionConfig
+mkExecutionConfig = ExecutionConfig . S.fromList
 
 -- -------------------------------------------------------------------------- --
 -- Coinbase output utils

--- a/stack.yaml
+++ b/stack.yaml
@@ -35,7 +35,7 @@ extra-deps:
 
   # --- Custom Pins --- #
   - github: kadena-io/pact
-    commit: cf220977a6b50a47cd446dad2e5e444f61689672
+    commit: 731a9c07dd7486dc8d5c1b11905ceb34d9bd8af0
   - github: kadena-io/chainweb-storage
     commit: 17a5fb130926582eff081eeb1b94cb6c7097c67a
 

--- a/test/Chainweb/Test/Pact/Checkpointer.hs
+++ b/test/Chainweb/Test/Pact/Checkpointer.hs
@@ -193,7 +193,7 @@ checkpointerTest name initdata =
 
                   let h' = H.toUntypedHash (H.hash "" :: H.PactHash)
                       cmdenv = TransactionEnv Transactional pactdbenv _cpeLogger def
-                               noSPVSupport Nothing 0.0 (RequestKey h') 0 permissiveExecutionConfig
+                               noSPVSupport Nothing 0.0 (RequestKey h') 0 def
                       cmdst = TransactionState mempty mempty 0 Nothing (_geGasModel freeGasEnv)
 
                   evalTransactionM cmdenv cmdst $
@@ -206,7 +206,7 @@ checkpointerTest name initdata =
 
                   let h' = H.toUntypedHash (H.hash "" :: H.PactHash)
                       cmdenv = TransactionEnv Transactional pactdbenv _cpeLogger def
-                               noSPVSupport Nothing 0.0 (RequestKey h') 0 permissiveExecutionConfig
+                               noSPVSupport Nothing 0.0 (RequestKey h') 0 def
                       cmdst = TransactionState mempty mempty 0 Nothing (_geGasModel freeGasEnv)
 
                   evalTransactionM cmdenv cmdst $

--- a/test/Chainweb/Test/Pact/TransactionTests.hs
+++ b/test/Chainweb/Test/Pact/TransactionTests.hs
@@ -211,7 +211,7 @@ testCoinbase797DateFix = testCaseSteps "testCoinbase791Fix" $ \step -> do
 
       let h = H.toUntypedHash (H.hash "" :: H.PactHash)
           tenv = TransactionEnv Transactional pdb logger def
-            noSPVSupport Nothing 0.0 (RequestKey h) 0 permissiveExecutionConfig
+            noSPVSupport Nothing 0.0 (RequestKey h) 0 def
           txst = TransactionState mempty mempty 0 Nothing (_geGasModel freeGasEnv)
 
       CommandResult _ _ (PactResult pr) _ _ _ _ <- evalTransactionM tenv txst $!


### PR DESCRIPTION
Will leave forking config for after #915 goes in, so this just ups the pin and gets chainweb building.