### PR TITLE
Do full pact validation of mainnet history as part of GitHub ci  workflow

### DIFF
--- a/.github/workflows/applications.yml
+++ b/.github/workflows/applications.yml
@@ -44,6 +44,10 @@ jobs:
     needs: [sync-chain-db, build]
     runs-on: 'ubuntu-18.04'
     steps:
+    - name: Install non-Haskell dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y librocksdb zlib1g libtinfo libsqlite3 libz3 z3
     - name: Download chain database artifact
       uses: actions/download-artifact@v1
       with:

--- a/.github/workflows/applications.yml
+++ b/.github/workflows/applications.yml
@@ -27,8 +27,8 @@ jobs:
       env:
         AWS_ACCESS_KEY_ID: ${{ secrets.kadena_cabal_cache_aws_access_key_id }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.kadena_cabal_cache_aws_secret_access_key }}
-        run: |
-          aws s3 sync "s3://chainweb-chain-db/mainnet01/" db/ --delete --exclude=LOCK
+      run: |
+        aws s3 sync "s3://chainweb-chain-db/mainnet01/" db/ --delete --exclude=LOCK
     - name: Store chain database as artifact
       uses: actions/upload-artifact@v1
       with:

--- a/.github/workflows/applications.yml
+++ b/.github/workflows/applications.yml
@@ -100,7 +100,7 @@ jobs:
     - name: Validate mainnet01 history
       run: |
         chmod 755 ./bin/chainweb-node
-        ./bin/chainweb-node --config-file=config.yaml | { gsed -u -e '/start chainweb node/{p ; q}' ; killall chainweb-node ; }
+        ./bin/chainweb-node --config-file=config.yaml | { sed -u -e '/start chainweb node/{p ; q}' ; killall chainweb-node ; }
 
   # Build Chainweb Node
   #

--- a/.github/workflows/applications.yml
+++ b/.github/workflows/applications.yml
@@ -191,6 +191,7 @@ jobs:
         key: ${{ matrix.os }}-${{ matrix.ghc }}-dist-newstyle-${{ github.sha }}
         restore-keys: |
           ${{ matrix.os }}-${{ matrix.ghc }}-dist-newstyle-
+          ${{ matrix.os }}-${{ matrix.ghc }}-dist-newstyle
     
     - name: Sync from dist cache
       if: matrix.distcache == 'true'

--- a/.github/workflows/applications.yml
+++ b/.github/workflows/applications.yml
@@ -105,6 +105,7 @@ jobs:
     - name: Validate mainnet01 history
       run: |
         chmod 755 ./bin/chainweb-node
+        set -o pipefail
         ./bin/chainweb-node --config-file=config.yaml | { sed -u -e '/start chainweb node/{p ; q}' ; killall chainweb-node ; }
     - name: Delete Pact SQL db
       run: |

--- a/.github/workflows/applications.yml
+++ b/.github/workflows/applications.yml
@@ -186,7 +186,7 @@ jobs:
       name: Cache dist-newstyle
       with:
         path: dist-newstyle
-        key: ${{ runner.os }}-${{ matrix.ghc }}-dist-newstyle
+        key: ${{ matrix.os }}-${{ matrix.ghc }}-dist-newstyle
     
     - name: Sync from dist cache
       if: matrix.distcache == 'true'

--- a/.github/workflows/applications.yml
+++ b/.github/workflows/applications.yml
@@ -77,7 +77,9 @@ jobs:
               pruneChainDatabase: false
         EOF
     - name: Validate mainnet01 history
-      run: ./bin/chainweb-node --config-file=config.yaml --log-level=warn
+      run: |
+        chmod 755 ./bin/chainweb-node
+        ./bin/chainweb-node --config-file=config.yaml --log-level=warn
 
   # Build Chainweb Node
   #
@@ -91,7 +93,6 @@ jobs:
         cabal: ['3.0']
         os: ['ubuntu-16.04', 'ubuntu-18.04', 'macOS-latest']
         cabalcache: ['true']
-        distcache: ['false']
     env:
       AWS_ACCESS_KEY_ID: ${{ secrets.kadena_cabal_cache_aws_access_key_id }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.kadena_cabal_cache_aws_secret_access_key }}
@@ -101,11 +102,6 @@ jobs:
       CABAL_CACHE_BUCKET: kadena-cabal-cache
       SYNC_TO_CACHE: $CABAL_CACHE sync-to-archive --threads 16 --archive-uri s3://$CABAL_CACHE_BUCKET/${{ matrix.os }} --region us-east-1
       SYNC_FROM_CACHE: $CABAL_CACHE sync-from-archive --threads 16 --archive-uri s3://$CABAL_CACHE_BUCKET/${{ matrix.os }} --region us-east-1
-
-      # Dist Cache
-      DIST_CACHE_BUCKET: kadena-cabal-cache
-      SYNC_TO_DIST_CACHE: aws s3 sync dist-newstyle "s3://kadena-cabal-cache/dist/${{ matrix.os }}/${{ matrix.ghc }}/dist-newstyle"
-      SYNC_FROM_DIST_CACHE: aws s3 sync "s3://kadena-cabal-cache/dist/${{ matrix.os }}/${{ matrix.ghc }}/dist-newstyle" dist-newstyle && rm -rf dist-newstyle/build/*/ghc-${{ matrix.ghc }}/chainweb-*/setup
 
       # Aritfacts
       ARTIFACT_BUCKET: kadena-cabal-cache
@@ -193,13 +189,6 @@ jobs:
           ${{ matrix.os }}-${{ matrix.ghc }}-dist-newstyle-
           ${{ matrix.os }}-${{ matrix.ghc }}-dist-newstyle
     
-    - name: Sync from dist cache
-      if: matrix.distcache == 'true'
-      run: |
-        eval $SYNC_FROM_DIST_CACHE
-        rm -rf dist-newstyle/build/*/ghc-${{ matrix.ghc }}/chainweb-*
-      continue-on-error: true
-
     # Build
     - name: Update package database
       run: cabal v2-update
@@ -216,9 +205,6 @@ jobs:
       run: cabal v2-run chainweb-tests -- --hide-successes --pattern='!/Chainweb.Test.Pact.SPV/ && !/deep-fork-limit/ && !/SPV transaction proof test/'
     - name: Run Benchmarks and Certificate Validation Tests
       run: cabal v2-run cwtool -- slow-tests
-    - name: Sync dist cache
-      if: always() && (matrix.distcache == 'true')
-      run: eval $SYNC_TO_DIST_CACHE
     - name: Sync cabal cache
       if: always() && (matrix.cabalcache == 'true')
       run: eval $SYNC_TO_CACHE

--- a/.github/workflows/applications.yml
+++ b/.github/workflows/applications.yml
@@ -101,7 +101,7 @@ jobs:
       run: |
         ls -liash .
         ls -liash db
-        ls -liash rocksdb
+        ls -liash db/rocksdb
     - name: Validate mainnet01 history
       run: |
         chmod 755 ./bin/chainweb-node
@@ -231,11 +231,11 @@ jobs:
     - name: Install build dependencies
       run: cabal v2-build --only-dependencies
     - name: Build
-      run: cabal v2-build chainweb-node
-    - name: Run Tests
-      run: cabal v2-run chainweb-tests -- --hide-successes --pattern='!/Chainweb.Test.Pact.SPV/ && !/deep-fork-limit/ && !/SPV transaction proof test/'
-    - name: Run Benchmarks and Certificate Validation Tests
-      run: cabal v2-run cwtool -- slow-tests
+      run: cabal v2-build
+    # - name: Run Tests
+    #   run: cabal v2-run chainweb-tests -- --hide-successes --pattern='!/Chainweb.Test.Pact.SPV/ && !/deep-fork-limit/ && !/SPV transaction proof test/'
+    # - name: Run Benchmarks and Certificate Validation Tests
+    #   run: cabal v2-run cwtool -- slow-tests
     - name: Sync cabal cache
       if: always() && (matrix.cabalcache == 'true')
       run: eval $SYNC_TO_CACHE

--- a/.github/workflows/applications.yml
+++ b/.github/workflows/applications.yml
@@ -22,7 +22,7 @@ jobs:
       uses: actions/cache@v1
       with:
         path: db
-        key: chain-db-${{ hashFiles('**/MANIFEST') }}
+        key: chain-db-
         restore-keys: |
           chain-db-
     - name: Sync chain database from S3

--- a/.github/workflows/applications.yml
+++ b/.github/workflows/applications.yml
@@ -208,7 +208,7 @@ jobs:
     - name: Build
       run: cabal v2-build chainweb-node
     - name: Run Tests
-      run: cabal v2-run chainweb-tests -- --hide-successes --pattern='!/Chainweb.Test.Pact.SPV/'
+      run: cabal v2-run chainweb-tests -- --hide-successes --pattern='!/Chainweb.Test.Pact.SPV/ && !/deep-fork-limit/ && !/SPV transaction proof test/'
     - name: Run Benchmarks and Certificate Validation Tests
       run: cabal v2-run cwtool -- slow-tests
     - name: Sync dist cache

--- a/.github/workflows/applications.yml
+++ b/.github/workflows/applications.yml
@@ -79,11 +79,28 @@ jobs:
               enabled: false
             cuts:
               pruneChainDatabase: false
+          logging:
+            telemetryBackend:
+              enabled: true
+              configuration:
+                handle: stdout
+                color: "True"
+            backend:
+              handle: stdout
+              color: "True"
+            logger:
+              log_level: info
+            filter:
+              rules:
+              - key: component
+                value: pact
+                level: warn
+              default: info
         EOF
     - name: Validate mainnet01 history
       run: |
         chmod 755 ./bin/chainweb-node
-        ./bin/chainweb-node --config-file=config.yaml --log-level=warn
+        ./bin/chainweb-node --config-file=config.yaml | { gsed -u -e '/start chainweb node/{p ; q}' ; killall chainweb-node ; }
 
   # Build Chainweb Node
   #

--- a/.github/workflows/applications.yml
+++ b/.github/workflows/applications.yml
@@ -97,10 +97,20 @@ jobs:
                 level: warn
               default: info
         EOF
+    - name: Check Setup
+      run: |
+        ls -liash .
+        ls -liash db
+        ls -liash rocksDb
     - name: Validate mainnet01 history
       run: |
         chmod 755 ./bin/chainweb-node
         ./bin/chainweb-node --config-file=config.yaml | { sed -u -e '/start chainweb node/{p ; q}' ; killall chainweb-node ; }
+    - name: Delete Pact SQL db
+      run: |
+        ls -liash db
+        ls -liash db/rocksDb
+        rm -rf db/rocksDb/sqlite
 
   # Build Chainweb Node
   #

--- a/.github/workflows/applications.yml
+++ b/.github/workflows/applications.yml
@@ -9,6 +9,76 @@ on:
     - release-candidate/*
 
 jobs:
+
+  # Synchronize Mainnet01 Chain Database
+  #
+  sync-chain-db:
+    name: Synchronize the chain database cache
+    runs-on: 'ubuntu-latest'
+    steps:
+    # Caches are limited to 5GB per repository. Currently the size of the db is 3.5GB
+    - name: Sync chain database from cache
+      id: cache-chain-db
+      uses: actions/cache@v1
+      with:
+        path: db
+        key: chain-db
+    - name: Sync chain database from S3
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.kadena_cabal_cache_aws_access_key_id }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.kadena_cabal_cache_aws_secret_access_key }}
+        run: |
+          aws s3 sync "s3://chainweb-chain-db/mainnet01/" db/ --delete --exclude=LOCK
+    - name: Store chain database as artifact
+      uses: actions/upload-artifact@v1
+      with:
+        name: chain-db
+        path: db
+
+  # Validate Mainnet01 Chain Database With chainweb-node
+  #
+  validate-chain-db:
+    name: Validate mainnet01 history with build
+    needs: [sync-chain-db, build]
+    runs-on: 'ubuntu-18.04'
+    steps:
+    - name: Download chain database artifact
+      uses: actions/download-artifact@v1
+      with:
+        name: chain-db
+        path: db
+    - name: Download chainweb application artifact
+      uses: actions/download-artifact@v1
+      with:
+        name: chainweb-applications.ghc-8.8.2.ubuntu-18.04
+        path: bin
+    - name: Create configuration file for validating the chainweb history
+      run: |
+        cat >> config.yaml <<EOF
+          databaseDirectory: "db/rocksDb"
+          resetChainDatabases: false
+          chainweb:
+            validateHashesOnReplay: true
+            p2p:
+              peer:
+                hostaddress:
+                  hostname: localhost
+                  port: 4445
+              private: true
+              ignoreBootstrapNodes: true
+            transactionIndex:
+              enabled: false
+            headerStream: false
+            mempoolP2p:
+              enabled: false
+            cuts:
+              pruneChainDatabase: false
+        EOF
+    - name: Validate mainnet01 history
+      run: ./bin/chainweb-node --config-file=config.yaml --log-level=warn
+
+  # Build Chainweb Node
+  #
   build:
     name: Build master with ${{ matrix.ghc }} / ${{ matrix.cabal }} on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/applications.yml
+++ b/.github/workflows/applications.yml
@@ -47,7 +47,7 @@ jobs:
     - name: Install non-Haskell dependencies
       run: |
         sudo apt-get update
-        sudo apt-get install -y librocksdb zlib1g libtinfo libsqlite3 libz3 z3
+        sudo apt-get install -y librocksdb-dev
     - name: Download chain database artifact
       uses: actions/download-artifact@v1
       with:

--- a/.github/workflows/applications.yml
+++ b/.github/workflows/applications.yml
@@ -22,7 +22,9 @@ jobs:
       uses: actions/cache@v1
       with:
         path: db
-        key: chain-db
+        key: chain-db-${{ hashFiles('**/MANIFEST') }}
+        restore-keys: |
+          chain-db-
     - name: Sync chain database from S3
       env:
         AWS_ACCESS_KEY_ID: ${{ secrets.kadena_cabal_cache_aws_access_key_id }}
@@ -186,7 +188,9 @@ jobs:
       name: Cache dist-newstyle
       with:
         path: dist-newstyle
-        key: ${{ matrix.os }}-${{ matrix.ghc }}-dist-newstyle
+        key: ${{ matrix.os }}-${{ matrix.ghc }}-dist-newstyle-${{ github.sha }}
+        restore-keys: |
+          ${{ matrix.os }}-${{ matrix.ghc }}-dist-newstyle-
     
     - name: Sync from dist cache
       if: matrix.distcache == 'true'

--- a/.github/workflows/applications.yml
+++ b/.github/workflows/applications.yml
@@ -50,7 +50,7 @@ jobs:
     - name: Download chainweb application artifact
       uses: actions/download-artifact@v1
       with:
-        name: chainweb-applications.ghc-8.8.2.ubuntu-18.04
+        name: chainweb-applications.8.8.2.ubuntu-18.04
         path: bin
     - name: Create configuration file for validating the chainweb history
       run: |
@@ -181,6 +181,13 @@ jobs:
           semigroups
           servant-swagger:swagger2
         EOF
+    
+    - uses: actions/cache@v1
+      name: Cache dist-newstyle
+      with:
+        path: dist-newstyle
+        key: ${{ runner.os }}-${{ matrix.ghc }}-dist-newstyle
+    
     - name: Sync from dist cache
       if: matrix.distcache == 'true'
       run: |

--- a/.github/workflows/applications.yml
+++ b/.github/workflows/applications.yml
@@ -61,7 +61,7 @@ jobs:
     - name: Create configuration file for validating the chainweb history
       run: |
         cat >> config.yaml <<EOF
-          databaseDirectory: "db/rocksDb"
+          databaseDirectory: "db/rocksdb"
           resetChainDatabases: false
           chainweb:
             validateHashesOnReplay: true
@@ -101,7 +101,7 @@ jobs:
       run: |
         ls -liash .
         ls -liash db
-        ls -liash rocksDb
+        ls -liash rocksdb
     - name: Validate mainnet01 history
       run: |
         chmod 755 ./bin/chainweb-node
@@ -109,8 +109,8 @@ jobs:
     - name: Delete Pact SQL db
       run: |
         ls -liash db
-        ls -liash db/rocksDb
-        rm -rf db/rocksDb/sqlite
+        ls -liash db/rocksdb
+        rm -rf db/rocksdb/sqlite
 
   # Build Chainweb Node
   #


### PR DESCRIPTION
On the github runners this currently takes about 50 minutes. There are different ways how this could be made faster. But we run these builds only for merges to master, so I think, 1h build time would be fine for now.

The S3 executables are uploaded before the the history validation runs, so those are available within about 10min.

An alternative approach is to run history validation on a fixed schedule, say, every two hours, using the latest master build chainweb-node binary from the S3 bucket.