### PR TITLE
grandfather non-zero feature flags for block heights < 340000

### DIFF
--- a/chainweb.cabal
+++ b/chainweb.cabal
@@ -432,6 +432,7 @@ test-suite chainweb-tests
     main-is: ChainwebTests.hs
     other-modules:
         Chainweb.Test.BlockHeader.Genesis
+        Chainweb.Test.BlockHeader.Validation
         Chainweb.Test.BlockHeaderDB
         Chainweb.Test.CutDB
         Chainweb.Test.Mempool

--- a/src/Chainweb/BlockHeader.hs
+++ b/src/Chainweb/BlockHeader.hs
@@ -37,12 +37,6 @@ module Chainweb.BlockHeader
   ParentHeader(..)
 , ParentCreationTime(..)
 
--- * Validation Guards
---
--- $guards
-, slowEpochGuard
-, skipFeatureFlagValidationGuard
-
 -- * Block Payload Hash
 , BlockPayloadHash(..)
 , encodeBlockPayloadHash
@@ -171,70 +165,6 @@ import Numeric.AffineSpace
 import Text.Read (readEither)
 
 -- -------------------------------------------------------------------------- --
--- Guards for changes to validation rules
---
--- $guards
---
--- The guards in this section encode when changes to validation rules for data
--- on the chain become effective.
---
--- Only the following types are allowed as parameters for guards
---
--- * BlockHeader,
--- * ParentHeader,
--- * BlockCreationTime, and
--- * ParentCreationTime
---
--- The result is a simple 'Bool'.
---
--- Guards should have meaningful names and should be used in a way that all
--- places in the code base that depend on the guard should reference the
--- respective guard. That way all dependent code can be easily identified using
--- ide tools, like for instance @grep@.
---
--- Each guard should have a description that provides background for the change
--- and provides all information needed for maintaining the code or code that
--- depends on it.
---
-
--- | Turn off slow epochs (emergency DA) for blocks from 80,000 onwward.
---
--- Emergency DA is considered a miss-feature.
---
--- It's intended purpose is to prevent chain hopping attacks, where an attacker
--- temporarily adds a large amount of hash power, thus increasing the
--- difficulty. When the hash power is removed, the remaining hash power may not
--- be enough to reach the next block in reasonable time.
---
--- In practice, emergency DAs cause more problems than they solve. In
--- particular, they increase the chance of deep forks. Also they make the
--- behavior of the system unpredictable in states of emergency, when stability
--- is usually more important than throughput.
---
-slowEpochGuard :: ParentHeader -> Bool
-slowEpochGuard (ParentHeader p)
-    | Mainnet01 <- _chainwebVersion p = _blockHeight p < 80000
-    | otherwise = False
-{-# INLINE slowEpochGuard #-}
-
--- | Skip validation of feature flags for block heights up to 340000.
---
--- Unused feature flag bits are supposed to be set to 0. This was not enforced
--- in chainweb-node versions <= 1.5. There is a large number of blocks in the
--- history of mainnet before 2020-02-20, that have non-zero feature flags. In
--- order to prepare future use of fleature flag feature flag validation will
--- start at block height 340000.
---
--- This guard grandfathers the this behavior up to block height 340000.
---
--- Blockheight 340000 is expected to occur on mainnet01 on 2019-02-24.
---
-skipFeatureFlagValidationGuard :: BlockHeader -> Bool
-skipFeatureFlagValidationGuard hdr
-    | Mainnet01 <- _chainwebVersion hdr = _blockHeight hdr < 340000
-    | otherwise = True
-
--- -------------------------------------------------------------------------- --
 -- Nonce
 
 -- | FIXME: is 64 bit enough for the nonce. It seems that it may not be
@@ -347,7 +277,7 @@ powTarget
 powTarget p bct@(BlockCreationTime bt) = case effectiveWindow p of
     Nothing -> maxTarget
     Just w
-        | slowEpochGuard (ParentHeader p) && slowEpoch p bct ->
+        | slowEpochGuard ver (_blockHeight p) && slowEpoch p bct ->
             adjust ver w (t .-. _blockEpochStart p) (_blockTarget p)
         | isLastInEpoch p ->
             adjust ver w (t .-. _blockEpochStart p) (_blockTarget p)

--- a/src/Chainweb/BlockHeader.hs
+++ b/src/Chainweb/BlockHeader.hs
@@ -41,6 +41,7 @@ module Chainweb.BlockHeader
 --
 -- $guards
 , slowEpochGuard
+, skipFeatureFlagValidationGuard
 
 -- * Block Payload Hash
 , BlockPayloadHash(..)
@@ -215,6 +216,23 @@ slowEpochGuard (ParentHeader p)
     | Mainnet01 <- _chainwebVersion p = _blockHeight p < 80000
     | otherwise = False
 {-# INLINE slowEpochGuard #-}
+
+-- | Skip validation of feature flags for block heights up to 340000.
+--
+-- Unused feature flag bits are supposed to be set to 0. This was not enforced
+-- in chainweb-node versions <= 1.5. There is a large number of blocks in the
+-- history of mainnet before 2020-02-20, that have non-zero feature flags. In
+-- order to prepare future use of fleature flag feature flag validation will
+-- start at block height 340000.
+--
+-- This guard grandfathers the this behavior up to block height 340000.
+--
+-- Blockheight 340000 is expected to occur on mainnet01 on 2019-02-24.
+--
+skipFeatureFlagValidationGuard :: BlockHeader -> Bool
+skipFeatureFlagValidationGuard hdr
+    | Mainnet01 <- _chainwebVersion hdr = _blockHeight hdr < 340000
+    | otherwise = True
 
 -- -------------------------------------------------------------------------- --
 -- Nonce

--- a/src/Chainweb/BlockHeader/Validation.hs
+++ b/src/Chainweb/BlockHeader/Validation.hs
@@ -69,6 +69,7 @@ import Chainweb.ChainId
 import Chainweb.Difficulty
 import Chainweb.Time
 import Chainweb.Utils
+import Chainweb.Version
 
 -- -------------------------------------------------------------------------- --
 -- BlockHeader Validation
@@ -404,8 +405,11 @@ prop_block_current t b = BlockCreationTime t >= _blockCreationTime b
 
 prop_block_featureFlags :: BlockHeader -> Bool
 prop_block_featureFlags b
-    | skipFeatureFlagValidationGuard b = True
+    | skipFeatureFlagValidationGuard v h = True
     | otherwise = _blockFlags b == mkFeatureFlags
+  where
+    v = _chainwebVersion b
+    h = _blockHeight b
 
 -- -------------------------------------------------------------------------- --
 -- Inductive BlockHeader Properties

--- a/src/Chainweb/BlockHeader/Validation.hs
+++ b/src/Chainweb/BlockHeader/Validation.hs
@@ -243,7 +243,7 @@ validateIntrinsicM
     -> BlockHeader
         -- ^ The block header to be checked
     -> m ()
-validateIntrinsicM t e = unless (null $ failures)
+validateIntrinsicM t e = unless (null failures)
     $ throwM (ValidationFailure Nothing e failures)
   where
     failures = validateIntrinsic t e

--- a/src/Chainweb/BlockHeader/Validation.hs
+++ b/src/Chainweb/BlockHeader/Validation.hs
@@ -404,8 +404,8 @@ prop_block_current t b = BlockCreationTime t >= _blockCreationTime b
 
 prop_block_featureFlags :: BlockHeader -> Bool
 prop_block_featureFlags b
-    | skipFeatureFlagValidationGuard b = _blockFlags b == mkFeatureFlags
-    | otherwise = True
+    | skipFeatureFlagValidationGuard b = True
+    | otherwise = _blockFlags b == mkFeatureFlags
 
 -- -------------------------------------------------------------------------- --
 -- Inductive BlockHeader Properties

--- a/src/Chainweb/BlockHeader/Validation.hs
+++ b/src/Chainweb/BlockHeader/Validation.hs
@@ -227,7 +227,7 @@ validateBlockHeaderM
     -> BlockHeader
         -- ^ The block header to be checked
     -> m ()
-validateBlockHeaderM t p e = unless (null $ failures)
+validateBlockHeaderM t p e = unless (null failures)
     $ throwM (ValidationFailure (Just p) e failures)
   where
     failures = validateBlockHeader t p e
@@ -257,7 +257,7 @@ validateInductiveM
     -> BlockHeader
         -- ^ The block header to be checked
     -> m ()
-validateInductiveM p e = unless (null $ failures)
+validateInductiveM p e = unless (null failures)
     $ throwM (ValidationFailure Nothing e failures)
   where
     failures = validateInductive p e
@@ -403,7 +403,9 @@ prop_block_current :: Time Micros -> BlockHeader -> Bool
 prop_block_current t b = BlockCreationTime t >= _blockCreationTime b
 
 prop_block_featureFlags :: BlockHeader -> Bool
-prop_block_featureFlags b = _blockFlags b == mkFeatureFlags
+prop_block_featureFlags b
+    | skipFeatureFlagValidationGuard b = _blockFlags b == mkFeatureFlags
+    | otherwise = True
 
 -- -------------------------------------------------------------------------- --
 -- Inductive BlockHeader Properties

--- a/src/Chainweb/Version.hs
+++ b/src/Chainweb/Version.hs
@@ -701,5 +701,5 @@ skipFeatureFlagValidationGuard
         -- ^ height of header
     -> Bool
 skipFeatureFlagValidationGuard Mainnet01 h = h < 340000
-skipFeatureFlagValidationGuard _ _ = True
+skipFeatureFlagValidationGuard _ _ = False
 

--- a/test/Chainweb/Test/BlockHeader/Validation.hs
+++ b/test/Chainweb/Test/BlockHeader/Validation.hs
@@ -1,0 +1,146 @@
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+-- |
+-- Module: Chainweb.Test.BlockHeader.Validation
+-- Copyright: Copyright © 2020 Kadena LLC.
+-- License: MIT
+-- Maintainer: Lars Kuhtz <lars@kadena.io>
+-- Stability: experimental
+--
+-- Unit tests for BlockHeader validation rules
+--
+module Chainweb.Test.BlockHeader.Validation
+( tests
+) where
+
+import Control.Lens
+
+import Data.Aeson
+import Data.Bitraversable
+import Data.Foldable
+
+import Test.QuickCheck
+import Test.Tasty
+import Test.Tasty.HUnit
+
+-- internal modules
+
+import Chainweb.BlockHeader
+import Chainweb.BlockHeader.Genesis
+import Chainweb.BlockHeader.Validation
+import Chainweb.Test.Orphans.Internal ({- Arbitrary BlockHeader -})
+import Chainweb.Time
+import Chainweb.Utils
+import Chainweb.Version
+
+-- -------------------------------------------------------------------------- --
+-- Properties
+
+tests :: TestTree
+tests = testGroup "Chainweb.Test.Blockheader.Validation"
+    [ prop_featureFlag Mainnet01
+    , prop_featureFlag Testnet04
+    , prop_featureFlag Development
+    , prop_validateMainnet
+    ]
+
+-- -------------------------------------------------------------------------- --
+-- Rules are not trivial
+--
+-- There is an input for which the rule fails.
+--
+
+prop_featureFlag :: ChainwebVersion -> TestTree
+prop_featureFlag v = testCase ("Invalid feature flags fail validation for " <> sshow v) $ do
+    hdr <- (blockHeight .~ 400000)
+        . (blockFlags .~ fromJuste (decode "1"))
+        . (blockChainwebVersion .~ v)
+        <$> generate arbitrary
+    let r = prop_block_featureFlags hdr
+    assertBool
+        ("feature flag validation succeeded unexpectedly: " <> sshow  hdr)
+        (not r)
+
+-- -------------------------------------------------------------------------- --
+-- Rules are sound
+--
+-- The rule implements the correct property.
+--
+-- This is hard to test, since the rules themself are the respetive definition for
+-- soundness of block headers. Testing this essentially means to to implementing
+-- the rule in anther way.
+
+-- -------------------------------------------------------------------------- --
+-- Rules are consistent
+--
+-- The rule succeeds for existing block headers from immutable chainweb versions.
+--
+-- Test rules with a representative set of existing block headers.
+--
+-- * Geneiss blocks
+-- * mainnet01 history
+-- * New minded blocks
+
+prop_validateMainnet :: TestTree
+prop_validateMainnet = testCase "validate Mainnet01 BlockHeaders" $ do
+    now <- getCurrentTimeIntegral
+    traverse_ (f now) mainnet01Headers
+  where
+    f t (ParentHeader p, h) = case validateBlockHeader t p h of
+        [] -> return ()
+        errs -> assertFailure $ "Validation failed for mainnet BlockHeader: " <> sshow errs
+
+-- -------------------------------------------------------------------------- --
+-- Rules are applied
+--
+-- The rule is actually used.
+--
+-- Like “non-trivial” but called via higher level. This is non trivial, since
+-- we have to create headers that are correct up to properites relevant to a
+-- partiular rule. In paritcular the hashes (including proof of work hashes)
+-- would have to be valid.
+--
+
+-- -------------------------------------------------------------------------- --
+-- Tests for Rule Guards:
+--
+-- Required: there is an example in mainnet history where the guard is needed,
+-- i.e. the guarded rule fails.
+--
+-- Triggers: rule is applied, consistent, and soud after guard triggered
+-- (Equivalent to checking applied, consistent, sound + showing that trigger is
+-- effective)
+
+-- -------------------------------------------------------------------------- --
+-- A representative collection of Mainnet01 Headers pairs
+
+-- | A representative collection of BlockHeader from the existing mainnet01
+-- history
+--
+mainnet01Headers :: [(ParentHeader, BlockHeader)]
+mainnet01Headers = gens <> some
+  where
+    v = Mainnet01
+    f = bitraverse (fmap ParentHeader . decode . wrap) (decode . wrap)
+
+    -- Some BlockHeader from the existing mainnet01 history
+    some = fromJuste $ traverse f
+        [
+            ( "H3rGh41BFgB2dYQvypgFACg92VqS0_k716NKvao4RfW8a0Nyj1KUuoGqFV_3OXDCAwACAAAAeEynJU7e0IPfQXm53PPHDkjPq5J3ycf2SqJVxFcIXrcDAAAAyY-kayiK41qNuDkMN3p3mwE57QHm1Tcj8nd-lP2YyDwFAAAAQ4a9wEuRhggN59f0mgzljWW7tjfCQtqD68fZbmYuz-LEgt46tQRDXU98wWRlQl0BSVHI5X01nzE6NgcAAAAAAJt2iGmFIGBIqsZvGLpp2ajVU915fQ_Hxu2hZo9fEFEKAAAAAKkNF7J27u0RAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAoIYBAAAAAAAFAAAAF5am6cmYBQAAAAAAAAAAAFu19jecoQhbBKnxAbWQLr2tMlBv82LIqL1tzsjD4HeJ"
+            , "NZX2DMUA7v_au3swypgFAFu19jecoQhbBKnxAbWQLr2tMlBv82LIqL1tzsjD4HeJAwACAAAA1mtN-xxumd3H1HB3IHu-Baz4hPzhGIKJhXNZbXZ9zWsDAAAAuwkSBAu4bGfFnQgcr6bNbIbHsjtAbI3YZ2Whf9ek3PMFAAAAleDFg-L56CcqBd1Waek0nXQfuufTKQoJNosU4S8ol13Egt46tQRDXU98wWRlQl0BSVHI5X01nzE6NgcAAAAAAFG_dy06qOtH93eteXZnNrf7zXOZSefhxpAH1IZceu00AAAAAAzWH_71Ee4RAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAoYYBAAAAAAAFAAAAF5am6cmYBQAAAAAAAAAAAPEQhg0G_mOQpv_381FvmUpHVqtekGgmczG5Thtqoigx"
+            )
+        ,
+            ( "AFHBANxHkLyt2kf7v54FAByxfFrR-pBP8iMLDNKO0SSt-ntTEh1IVT2E4mSPkq02AwACAAAAfaGIEe7a-wGT8OdEXz9RvlzJVkJgmEPmzk42bzjQOi0GAAAAjFsgdB2riCtIs0j40vovGGfcFIZmKPnxEXEekcV28eUIAAAAQcKA2py0L5t1Z1u833Z93V5N4hoKv_7-ZejC_QKTCzTtgKwxXj4Eovf97ELmo_iBruVLoK_Yann5LQIAAAAAALFMJ1gcC8oKW90MW2xY07gN10bM2-GvdC7fDvKDDwAPBwAAAJkPwMVeS7ZkAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOdsEAAAAAAAFAAAAT3hhzb-eBQAAAGFSDbQAAJru7keLmw3rHfSVm9wkTHWQBBTwEPwEg8RA99vzMuj-"
+            , "AEbpAIzqpiins1r8v54FAJru7keLmw3rHfSVm9wkTHWQBBTwEPwEg8RA99vzMuj-AwACAAAAy7QSAHoIeFj0JXide_co-OaEzzYWbeZhAfphXI8-IR0GAAAAa-PzO_zUmk1yLOyt2kD3iI6cehKqQ_KdK8D6qZ-X6X4IAAAA79Vw2kqbVDHm9WDzksFwxZcmx5OJJNW-ge7jVa3HiHbtgKwxXj4Eovf97ELmo_iBruVLoK_Yann5LQIAAAAAAL701u70FOrdivm6quNUsKgfi2L8zYHeyOI0j2gfP16jBwAAANz0ZdfSwLZkAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOtsEAAAAAAAFAAAAT3hhzb-eBQAAAPvI7fkAAFFuYkCHZRcNl1k3-A1EZvyPxhiFKdHZwZRTqos57aiO"
+            )
+        ]
+
+    -- All genesis headers
+    gens = flip fmap (toList $ chainIds v) $ \cid ->
+        ( ParentHeader $ genesisBlockHeader v cid
+        , genesisBlockHeader v cid
+        )
+
+    wrap x = "\"" <> x <> "\""

--- a/test/ChainwebTests.hs
+++ b/test/ChainwebTests.hs
@@ -24,6 +24,7 @@ import qualified Chainweb.Difficulty (properties)
 import qualified Chainweb.HostAddress (properties)
 import qualified Chainweb.Sync.WebBlockHeaderStore.Test (properties)
 import qualified Chainweb.Test.BlockHeader.Genesis
+import qualified Chainweb.Test.BlockHeader.Validation
 import qualified Chainweb.Test.BlockHeaderDB
 import qualified Chainweb.Test.Mempool.Consensus
 import qualified Chainweb.Test.Mempool.InMem
@@ -116,6 +117,7 @@ suite rdb =
         , Chainweb.Test.Miner.Core.tests
         , Chainweb.Test.Misc.tests
         , Chainweb.Test.BlockHeader.Genesis.tests
+        , Chainweb.Test.BlockHeader.Validation.tests
         , testProperties "Chainweb.BlockHeaderDb.RestAPI.Server" Chainweb.Utils.Paging.properties
         , testProperties "Chainweb.HostAddress" Chainweb.HostAddress.properties
         , testProperties "Chainweb.Sync.WebBlockHeaderStore.Test" Chainweb.Sync.WebBlockHeaderStore.Test.properties


### PR DESCRIPTION
Currently master is broken for mainet01. We must merge either this PR or #920 to unbreak it.

This is a technical non-user facing fork.  It affects only miners which would have to migrate "buggy" miners before that block height.

We therefor avoid the extra complexity involved with basing it on a date and use a block height instead -- which is also easier to handle for miners.

The block height is chosen to give miners about 5 days after the release of 1.6 to adapt their mining clients as needed. It is also expected to occur on a Monday during US office hours.