### PR TITLE
Disable feature flag validation.

### DIFF
--- a/src/Chainweb/BlockHeader/Validation.hs
+++ b/src/Chainweb/BlockHeader/Validation.hs
@@ -403,7 +403,9 @@ prop_block_current :: Time Micros -> BlockHeader -> Bool
 prop_block_current t b = BlockCreationTime t >= _blockCreationTime b
 
 prop_block_featureFlags :: BlockHeader -> Bool
-prop_block_featureFlags b = _blockFlags b == mkFeatureFlags
+-- prop_block_featureFlags b = _blockFlags b == mkFeatureFlags
+prop_block_featureFlags _b = True
+    -- For now disable validation of feature flags.
 
 -- -------------------------------------------------------------------------- --
 -- Inductive BlockHeader Properties


### PR DESCRIPTION
Currently master is broken for the mainnet01 history.

We must merge either this PR or #919 in order to unbreak it.