### PR TITLE
[DO NOT MERGE] Track progress on 1.6 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # `chainweb-node` Changelog
 
+## 1.5 (2019-02-18)
+
+This version replaces all previous versions. Any prior version will stop working
+on **2019-02-20T00:00:00Z**. Node administrators must upgrade to this version
+before that date.
+
+This version will stop working on **TODO**.
+
+TODO
+
 ## 1.5 (2019-01-13)
 
 This version replaces all previous versions. Any prior version will stop working

--- a/chainweb.cabal
+++ b/chainweb.cabal
@@ -1,7 +1,7 @@
 cabal-version: 2.2
 
 name:         chainweb
-version:      1.5
+version:      1.6
 synopsis:     A Proof-of-Work Parallel-Chain Architecture for Massive Throughput
 description:  A Proof-of-Work Parallel-Chain Architecture for Massive Throughput.
 homepage:     https://github.com/kadena-io/chainweb

--- a/node/ChainwebNode.hs
+++ b/node/ChainwebNode.hs
@@ -491,7 +491,7 @@ pkgInfoScopes =
 -- -------------------------------------------------------------------------- --
 -- main
 
--- KILLSWITCH for version 1.4
+-- KILLSWITCH for version 1.5
 --
 killSwitchDate :: Maybe String
 killSwitchDate = Just "2020-02-20T00:00:00Z"


### PR DESCRIPTION
# Pull Requests:
* [ ] #921 [bump chainweb node version to 1.6]
    * [ ] code complete
    * [ ] approved
    * [ ] merged
* [ ] #919 [grandfather non-zero feature flags for block heights < 340000]
   * [x] merged
   * [ ] decide about final block height for the switch
    The final constant should be around 75% into the respective DA epoch.
* [ ] #920 [disable feature flag validation] (undoes effect of 919)
    * [ ] Decide if we want to take it
    * [x] code complete
    * [ ] update PR for recent master
    * [ ] approved

# Testing:

## Mainnet

* [x] tests for #919 
    * [x] complete catchup on mainnet01
    * [x] mainnet01 catchup with tigger height of 200000 gets stuck at 199900 with `The block has an invalid feature flag value`

* [x] tests for #920 
   * [x] complete catchup on mainnet01

* [ ] full mainnet01 catchup of final release candidate

## Unit Tests

* [ ] Pact validation of mainet01 history:
    * [ ] verify that GitHub-ci job `Validate mainnet01 history with build` finishes with something like <img width="965" alt="image" src="https://user-images.githubusercontent.com/1369810/74677192-8cdf8c80-516c-11ea-952d-f294bbccc15d.png">

    on master and release-candidate/1.6 builds (even though the job fails)

* [ ] Check that Gitbub-ci jobs are green for master and release/1.6 (except for the the `Validate mainnet01 history with build`, see above)

## Devnet

* [ ] deploy release candidate
* [ ] run full regression test suite