### PR TITLE
add --validate flag and output type none to header-dump

### DIFF
--- a/.github/workflows/applications.yml
+++ b/.github/workflows/applications.yml
@@ -17,14 +17,14 @@ jobs:
     runs-on: 'ubuntu-latest'
     steps:
     # Caches are limited to 5GB per repository. Currently the size of the db is 3.5GB
-    - name: Sync chain database from cache
-      id: cache-chain-db
-      uses: actions/cache@v1
-      with:
-        path: db
-        key: chain-db-
-        restore-keys: |
-          chain-db-
+    # - name: Sync chain database from cache
+    #   id: cache-chain-db
+    #   uses: actions/cache@v1
+    #   with:
+    #     path: db
+    #     key: chain-db-
+    #     restore-keys: |
+    #       chain-db-
     - name: Sync chain database from S3
       env:
         AWS_ACCESS_KEY_ID: ${{ secrets.kadena_cabal_cache_aws_access_key_id }}
@@ -36,7 +36,33 @@ jobs:
       with:
         name: chain-db
         path: db
-  
+
+  # Run benchmarks and slow tests
+  #
+  slow-tests:
+    name: Run slow tests and benchmarks
+    needs: [sync-chain-db, build]
+    runs-on: 'ubuntu-18.04'
+    steps:
+    - name: Install non-Haskell dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y librocksdb-dev
+    - name: Download chain database artifact
+      uses: actions/download-artifact@v1
+      with:
+        name: chain-db
+        path: db
+    - name: Download chainweb application artifact
+      uses: actions/download-artifact@v1
+      with:
+        name: chainweb-applications.8.8.2.ubuntu-18.04
+        path: bin
+    - name: Validate block header database
+      run: |
+        chmod 755 ./bin/cwtool
+        ./bin/cwtool slow-tests
+
   # Validate Mainnet01 Chain Database With chainweb-node
   #
   validate-header-db:
@@ -235,6 +261,10 @@ jobs:
         restore-keys: |
           ${{ matrix.os }}-${{ matrix.ghc }}-dist-newstyle-
           ${{ matrix.os }}-${{ matrix.ghc }}-dist-newstyle
+    - name: Delete old build artifacts from cache
+      run: |
+        rm -rf dist-newstyle/build/*/ghc-${{ matrix.ghc }}/chainweb-*/opt/build/*/chainweb-node
+        rm -rf dist-newstyle/build/*/ghc-${{ matrix.ghc }}/chainweb-*/opt/build/*/cwtool
 
     # Build
     - name: Update package database
@@ -248,10 +278,8 @@ jobs:
       run: cabal v2-build --only-dependencies
     - name: Build
       run: cabal v2-build
-    # - name: Run Tests
-    #   run: cabal v2-run chainweb-tests -- --hide-successes --pattern='!/Chainweb.Test.Pact.SPV/ && !/deep-fork-limit/ && !/SPV transaction proof test/'
-    # - name: Run Benchmarks and Certificate Validation Tests
-    #   run: cabal v2-run cwtool -- slow-tests
+    - name: Run Tests
+      run: cabal v2-run chainweb-tests -- --hide-successes --pattern='!/Chainweb.Test.Pact.SPV/ && !/deep-fork-limit/ && !/SPV transaction proof test/'
     - name: Sync cabal cache
       if: always() && (matrix.cabalcache == 'true')
       run: eval $SYNC_TO_CACHE

--- a/.github/workflows/applications.yml
+++ b/.github/workflows/applications.yml
@@ -36,6 +36,32 @@ jobs:
       with:
         name: chain-db
         path: db
+  
+  # Validate Mainnet01 Chain Database With chainweb-node
+  #
+  validate-header-db:
+    name: Validate mainnet01 block header db
+    needs: [sync-chain-db, build]
+    runs-on: 'ubuntu-18.04'
+    steps:
+    - name: Install non-Haskell dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y librocksdb-dev
+    - name: Download chain database artifact
+      uses: actions/download-artifact@v1
+      with:
+        name: chain-db
+        path: db
+    - name: Download chainweb application artifact
+      uses: actions/download-artifact@v1
+      with:
+        name: chainweb-applications.8.8.2.ubuntu-18.04
+        path: bin
+    - name: Validate block header database
+      run: |
+        chmod 755 ./bin/cwtool
+        ./bin/cwtool header-dump --database=db/rocksdb --chainweb-version=mainnet01 -o none --validate
 
   # Validate Mainnet01 Chain Database With chainweb-node
   #
@@ -97,21 +123,10 @@ jobs:
                 level: warn
               default: info
         EOF
-    - name: Check Setup
-      run: |
-        ls -liash .
-        ls -liash db
-        ls -liash db/rocksdb
     - name: Validate mainnet01 history
       run: |
         chmod 755 ./bin/chainweb-node
-        set -o pipefail
-        ./bin/chainweb-node --config-file=config.yaml | { sed -u -e '/start chainweb node/{p ; q}' ; killall chainweb-node ; }
-    - name: Delete Pact SQL db
-      run: |
-        ls -liash db
-        ls -liash db/rocksdb
-        rm -rf db/rocksdb/sqlite
+        ./bin/chainweb-node --config-file=config.yaml | { sed -u -e '/start chainweb node/{p;q0};/\[Error\]/{p;q1}'; x=$?; killall chainweb-node ; exit $x ; }
 
   # Build Chainweb Node
   #
@@ -211,7 +226,7 @@ jobs:
           semigroups
           servant-swagger:swagger2
         EOF
-    
+
     - uses: actions/cache@v1
       name: Cache dist-newstyle
       with:
@@ -220,7 +235,7 @@ jobs:
         restore-keys: |
           ${{ matrix.os }}-${{ matrix.ghc }}-dist-newstyle-
           ${{ matrix.os }}-${{ matrix.ghc }}-dist-newstyle
-    
+
     # Build
     - name: Update package database
       run: cabal v2-update
@@ -247,6 +262,7 @@ jobs:
         mkdir -p dist-newstyle/artifacts/applications
         mkdir -p dist-newstyle/artifacts/docs
         cp dist-newstyle/build/*/ghc-${{ matrix.ghc }}/chainweb-*/opt/build/*/chainweb-node dist-newstyle/artifacts/applications
+        cp dist-newstyle/build/*/ghc-${{ matrix.ghc }}/chainweb-*/opt/build/*/cwtool dist-newstyle/artifacts/applications
     - name: Publish applications
       uses: actions/upload-artifact@v1
       with:

--- a/.github/workflows/applications.yml
+++ b/.github/workflows/applications.yml
@@ -48,11 +48,6 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install -y librocksdb-dev
-    - name: Download chain database artifact
-      uses: actions/download-artifact@v1
-      with:
-        name: chain-db
-        path: db
     - name: Download chainweb application artifact
       uses: actions/download-artifact@v1
       with:

--- a/tools/header-dump/HeaderDump.hs
+++ b/tools/header-dump/HeaderDump.hs
@@ -71,6 +71,7 @@ import Data.CAS.RocksDB
 import qualified Data.CaseInsensitive as CI
 import Data.Functor.Of
 import qualified Data.HashSet as HS
+import qualified Data.List as L
 import Data.LogMessage
 import Data.Maybe
 import Data.Semigroup hiding (option)
@@ -95,6 +96,7 @@ import System.LogLevel
 -- internal modules
 
 import Chainweb.BlockHeader
+import Chainweb.BlockHeader.Validation
 import Chainweb.BlockHeight
 import Chainweb.BlockHeaderDB
 import Chainweb.Logger
@@ -102,6 +104,7 @@ import Chainweb.Miner.Pact
 import Chainweb.Payload
 import Chainweb.Payload.PayloadStore
 import Chainweb.Payload.PayloadStore.RocksDB
+import Chainweb.Time
 import Chainweb.TreeDB hiding (key)
 import Chainweb.Utils
 import Chainweb.Version
@@ -136,6 +139,7 @@ data Output
     | OutputPayload
     | OutputRawPayload
     | OutputAll
+    | OutputNone
     deriving (Show, Eq, Ord, Generic, Enum, Bounded)
 
 instance HasTextRepresentation Output where
@@ -149,6 +153,7 @@ instance HasTextRepresentation Output where
         "payload" -> return OutputPayload
         "raw-payload" -> return OutputRawPayload
         "all" -> return OutputAll
+        "none" -> return OutputNone
         o -> throwM $ DecodeException $ "unknown result type: " <> sshow o
 
     toText Header = "header"
@@ -160,6 +165,7 @@ instance HasTextRepresentation Output where
     toText OutputPayload = "payload"
     toText OutputRawPayload = "raw-payload"
     toText OutputAll = "all"
+    toText OutputNone = "none"
 
 instance FromJSON Output where
     parseJSON = parseJsonFromText "Output"
@@ -189,6 +195,7 @@ data Config = Config
     , _configStart :: !(Maybe (Min Natural))
     , _configEnd :: !(Maybe (Max Natural))
     , _configOutput :: !Output
+    , _configValidate :: !Bool
     }
     deriving (Show, Eq, Ord, Generic)
 
@@ -205,6 +212,7 @@ defaultConfig = Config
     , _configStart = Nothing
     , _configEnd = Nothing
     , _configOutput = Header
+    , _configValidate = False
     }
 
 instance ToJSON Config where
@@ -218,6 +226,7 @@ instance ToJSON Config where
         , "start" .= _configStart o
         , "end" .= _configEnd o
         , "output" .= _configOutput o
+        , "validate" .= _configValidate o
         ]
 
 instance FromJSON (Config -> Config) where
@@ -231,6 +240,7 @@ instance FromJSON (Config -> Config) where
         <*< configStart ..: "start" % o
         <*< configEnd ..: "end" % o
         <*< configOutput ..: "output" % o
+        <*< configValidate ..: "validate" % o
 
 pConfig :: MParser Config
 pConfig = id
@@ -264,6 +274,9 @@ pConfig = id
         <> short 'o'
         <> metavar (enumMetavar @Output)
         <> help "which component of the payload to output"
+    <*< configValidate .:: boolOption_
+        % long "validate"
+        <> help "Validate BlockHeaders in the Database"
 
 validateConfig :: ConfigValidation Config []
 validateConfig o = do
@@ -323,13 +336,13 @@ instance ToJSON a => ToJSON (ChainData a) where
 -- Print Transactions
 
 mainWithConfig :: Config -> IO ()
-mainWithConfig config = withLog $ \logger -> do
+mainWithConfig config = withLog $ \logger ->
     liftIO $ run config $ logger
         & addLabel ("version", toText $ _configChainwebVersion config)
         -- & addLabel ("chain", toText $ _configChainId config)
   where
     logconfig = Y.defaultLogConfig
-        & Y.logConfigLogger . Y.loggerConfigThreshold .~ (_configLogLevel config)
+        & Y.logConfigLogger . Y.loggerConfigThreshold .~ _configLogLevel config
         & Y.logConfigBackend . Y.handleBackendConfigHandle .~ _configLogHandle config
     withLog inner = Y.withHandleBackend_ logText (logconfig ^. Y.logConfigBackend)
         $ \backend -> Y.withLogger (logconfig ^. Y.logConfigLogger) backend inner
@@ -356,7 +369,7 @@ withBlockHeaders logger config inner = do
         let pdb = newPayloadDb rdb
         initializePayloadDb v pdb
         liftIO $ logg Info "start traversing block headers"
-        withChainDbsConcurrent rdb v cids start end $ inner pdb . void
+        withChainDbsConcurrent rdb v cids (_configValidate config) start end $ inner pdb . void
   where
     logg :: LogFunctionText
     logg = logFunction logger
@@ -376,6 +389,8 @@ run :: Logger l => Config -> l -> IO ()
 run config logger = withBlockHeaders logger config $ \pdb x -> x
     & progress logg
     & \s -> case _configOutput config of
+        OutputNone -> s
+            & S.effects
         Header -> s
             & S.map ObjectEncoded
             & S.map encodeJson
@@ -436,6 +451,53 @@ run config logger = withBlockHeaders logger config $ \pdb x -> x
     encodeJson
         | _configPretty config = T.decodeUtf8 . BL.toStrict . encodePretty
         | otherwise = encodeToText
+
+validate :: S.Stream (Of BlockHeader) IO () -> S.Stream (Of BlockHeader) IO ()
+validate s = do
+    now <- liftIO getCurrentTimeIntegral
+    s
+        & S.copy
+        & S.foldM_ (step now) (return initial) (\_ -> return ())
+  where
+    -- state: (height, parents, currents)
+    initial :: (BlockHeight, [BlockHeader], [BlockHeader])
+    initial = (0, [], [])
+
+    step
+        :: MonadIO m
+        => Time Micros
+        -> (BlockHeight, [BlockHeader], [BlockHeader])
+        -> BlockHeader
+        -> m (BlockHeight, [BlockHeader], [BlockHeader])
+    step now state c = liftIO $ do
+        let state' = update state c
+        val now state' c
+        return state'
+
+    update
+        :: (BlockHeight, [BlockHeader], [BlockHeader])
+        -> BlockHeader
+        -> (BlockHeight, [BlockHeader], [BlockHeader])
+    update (h, parents, currents) c
+        | isGenesisBlockHeader c = (0, [], [c])
+        | _blockHeight c == h = (h, parents, c : currents)
+        | _blockHeight c == (h + 1) = (h + 1, currents, [c])
+        | _blockHeight c < h = error "height invariant violation in enumeration of headers. Height of current header smaller than previous headers"
+        | otherwise = error "height invariant violation in enumeration of headers. Height of current header skips block height"
+
+    val
+        :: Time Micros
+        -> (BlockHeight, [BlockHeader], [BlockHeader])
+        -> BlockHeader
+        -> IO ()
+    val now (_, parents, _) c
+        | isGenesisBlockHeader c = validateBlockHeaderM now c c
+        | otherwise =
+            case L.find (\x -> _blockParent c == _blockHash x) parents of
+                Nothing -> error
+                    $ "missing parent header for block: " <> sshow c
+                    <> "\ncurrent parents: " <> sshow parents
+                Just p -> validateBlockHeaderM now p c
 
 -- -------------------------------------------------------------------------- --
 -- Tools
@@ -527,7 +589,7 @@ commandWithOutputsValue (c, o) = object
     , "payload" .= either
         (const $ String $ _cmdPayload c)
         (id @Value)
-        (eitherDecodeStrict' $ T.encodeUtf8 $ _cmdPayload $ c)
+        (eitherDecodeStrict' $ T.encodeUtf8 $ _cmdPayload c)
     , "output" .= o
     ]
 
@@ -538,7 +600,7 @@ commandValue c = object
     , "payload" .= either
         (const $ String $ _cmdPayload c)
         (id @Value)
-        (eitherDecodeStrict' $ T.encodeUtf8 $ _cmdPayload $ c)
+        (eitherDecodeStrict' $ T.encodeUtf8 $ _cmdPayload c)
     ]
 
 -- -------------------------------------------------------------------------- --
@@ -563,22 +625,27 @@ withChainDbsConcurrent
     :: RocksDb
     -> ChainwebVersion
     -> [ChainId]
+    -> Bool
+        -- ^ whether to validate
     -> Maybe MinRank
     -> Maybe MaxRank
     -> (S.Stream (Of BlockHeader) IO () -> IO a)
     -> IO a
-withChainDbsConcurrent rdb v cids start end f = go cids mempty
+withChainDbsConcurrent rdb v cids doValidation start end f = go cids mempty
   where
 
     -- This is not a very efficient way to paralleize and merge the streams
+    --
     go [] !s = f s
     go (cid:t) !s = withBlockHeaderDb rdb v cid $ \cdb ->
         entries cdb Nothing Nothing start end $ \x ->
             S.withBuffer buffer (S.writeStreamBasket x) $ \out ->
                 S.withStreamBasket out $ \y ->
-                    go t (() <$ S.mergeOn _blockHeight s y)
+                    go t (() <$ S.mergeOn _blockHeight s (y & val))
 
     buffer = S.bounded 4000
+
+    val = if doValidation then validate else id
 
 #if REMOTE_DB
 -- -------------------------------------------------------------------------- --


### PR DESCRIPTION
I'll plan to build an standalone database validation tool based on this, that would also include the functionality for validating the pact database and cuts.

For now, the fastest route to implement header validation for a db was to add it to the header-dump tool. It also makes sense to as a feature of this tool.