### PR TITLE
keep feature flag validation disabled

### DIFF
--- a/src/Chainweb/Version.hs
+++ b/src/Chainweb/Version.hs
@@ -683,23 +683,23 @@ slowEpochGuard Mainnet01 h = h < 80000
 slowEpochGuard _ _ = False
 {-# INLINE slowEpochGuard #-}
 
--- | Skip validation of feature flags for block heights up to 340000.
+-- | Skip validation of feature flags.
 --
--- Unused feature flag bits are supposed to be set to 0. This was not enforced
--- in chainweb-node versions <= 1.5. There is a large number of blocks in the
--- history of mainnet before 2020-02-20, that have non-zero feature flags. In
--- order to prepare future use of fleature flag feature flag validation will
--- start at block height 340000.
+-- Unused feature flag bits are supposed to be set to 0. This isn't enforced
+-- currently (chainweb-node versions <= 1.6). There is a large number of blocks
+-- in the history of mainnet before 2020-02-20, that have non-zero feature
+-- flags.
 --
--- This guard grandfathers the this behavior up to block height 340000.
---
--- Blockheight 340000 is expected to occur on mainnet01 on 2019-02-24.
+-- This guard permits the use of the last 64 bits of a block header as a nonce
+-- value for all blogs which pass this guard.
 --
 skipFeatureFlagValidationGuard
     :: ChainwebVersion
     -> BlockHeight
         -- ^ height of header
     -> Bool
-skipFeatureFlagValidationGuard Mainnet01 h = h < 340000
+skipFeatureFlagValidationGuard Mainnet01 _ = True
+skipFeatureFlagValidationGuard Development _ = True
+skipFeatureFlagValidationGuard Testnet04 _ = True
 skipFeatureFlagValidationGuard _ _ = False
 

--- a/test/Chainweb/Test/BlockHeader/Validation.hs
+++ b/test/Chainweb/Test/BlockHeader/Validation.hs
@@ -40,10 +40,10 @@ import Chainweb.Version
 
 tests :: TestTree
 tests = testGroup "Chainweb.Test.Blockheader.Validation"
-    [ prop_featureFlag Mainnet01
-    , prop_featureFlag Testnet04
-    , prop_featureFlag Development
-    , prop_validateMainnet
+    [ prop_validateMainnet
+    -- , prop_featureFlag Mainnet01
+    -- , prop_featureFlag Testnet04
+    -- , prop_featureFlag Development
     ]
 
 -- -------------------------------------------------------------------------- --
@@ -52,9 +52,12 @@ tests = testGroup "Chainweb.Test.Blockheader.Validation"
 -- There is an input for which the rule fails.
 --
 
+{-
+-- Feature flag validation is currently disabled on Mainnet. Uncomment this
+-- code once it is enabled.
 prop_featureFlag :: ChainwebVersion -> TestTree
 prop_featureFlag v = testCase ("Invalid feature flags fail validation for " <> sshow v) $ do
-    hdr <- (blockHeight .~ 400000)
+    hdr <- (blockHeight .~ TODO)
         . (blockFlags .~ fromJuste (decode "1"))
         . (blockChainwebVersion .~ v)
         <$> generate arbitrary
@@ -62,6 +65,7 @@ prop_featureFlag v = testCase ("Invalid feature flags fail validation for " <> s
     assertBool
         ("feature flag validation succeeded unexpectedly: " <> sshow  hdr)
         (not r)
+-}
 
 -- -------------------------------------------------------------------------- --
 -- Rules are sound

--- a/test/Chainweb/Test/BlockHeader/Validation.hs
+++ b/test/Chainweb/Test/BlockHeader/Validation.hs
@@ -30,6 +30,8 @@ import Test.Tasty.HUnit
 import Chainweb.BlockHeader
 import Chainweb.BlockHeader.Genesis
 import Chainweb.BlockHeader.Validation
+import Chainweb.BlockHeight
+import Chainweb.Graph
 import Chainweb.Test.Orphans.Internal ({- Arbitrary BlockHeader -})
 import Chainweb.Time
 import Chainweb.Utils
@@ -41,9 +43,7 @@ import Chainweb.Version
 tests :: TestTree
 tests = testGroup "Chainweb.Test.Blockheader.Validation"
     [ prop_validateMainnet
-    -- , prop_featureFlag Mainnet01
-    -- , prop_featureFlag Testnet04
-    -- , prop_featureFlag Development
+    , prop_featureFlag (Test petersonChainGraph) 10
     ]
 
 -- -------------------------------------------------------------------------- --
@@ -52,12 +52,9 @@ tests = testGroup "Chainweb.Test.Blockheader.Validation"
 -- There is an input for which the rule fails.
 --
 
-{-
--- Feature flag validation is currently disabled on Mainnet. Uncomment this
--- code once it is enabled.
-prop_featureFlag :: ChainwebVersion -> TestTree
-prop_featureFlag v = testCase ("Invalid feature flags fail validation for " <> sshow v) $ do
-    hdr <- (blockHeight .~ TODO)
+prop_featureFlag :: ChainwebVersion -> BlockHeight -> TestTree
+prop_featureFlag v h = testCase ("Invalid feature flags fail validation for " <> sshow v) $ do
+    hdr <- (blockHeight .~ h)
         . (blockFlags .~ fromJuste (decode "1"))
         . (blockChainwebVersion .~ v)
         <$> generate arbitrary
@@ -65,7 +62,6 @@ prop_featureFlag v = testCase ("Invalid feature flags fail validation for " <> s
     assertBool
         ("feature flag validation succeeded unexpectedly: " <> sshow  hdr)
         (not r)
--}
 
 -- -------------------------------------------------------------------------- --
 -- Rules are sound


### PR DESCRIPTION
Permanently disable validation of feature flags for `Mainnet01`, `Testnet04`, and `Development`. Validation is enabled for test chainweb versions.