### PR TITLE
Creation time fix [Phase 1]

### DIFF
--- a/src/Chainweb/BlockHeader.hs
+++ b/src/Chainweb/BlockHeader.hs
@@ -339,6 +339,19 @@ newtype ParentHeader = ParentHeader
     deriving (Show, Generic)
     deriving anyclass (NFData)
 
+
+instance HasChainId ParentHeader where
+    _chainId = _chainId . _parentHeader
+    {-# INLINE _chainId #-}
+
+instance HasChainwebVersion ParentHeader where
+    _chainwebVersion = _chainwebVersion . _parentHeader
+    {-# INLINE _chainwebVersion #-}
+
+instance HasChainGraph ParentHeader where
+    _chainGraph = _chainGraph . _parentHeader
+    {-# INLINE _chainGraph #-}
+
 -- -------------------------------------------------------------------------- --
 -- Block Header
 

--- a/src/Chainweb/Chainweb/MinerResources.hs
+++ b/src/Chainweb/Chainweb/MinerResources.hs
@@ -176,7 +176,7 @@ withMiningCoordination logger conf cdb inner
         HM.fromList <$> traverse (\(T2 cid bh) -> (cid,) . Just <$> getPayload bh m) cut
 
     getPayload :: ParentHeader -> Miner -> IO (T2 PayloadWithOutputs BlockCreationTime)
-    getPayload (ParentHeader parent) m = do
+    getPayload parent m = do
         creationTime <- BlockCreationTime <$> getCurrentTimeIntegral
         payload <- trace (logFunction logger) "Chainweb.Chainweb.MinerResources.withMiningCoordination.newBlock"
             () 1 (_pactNewBlock pact m parent creationTime)

--- a/src/Chainweb/Crypto/MerkleLog.hs
+++ b/src/Chainweb/Crypto/MerkleLog.hs
@@ -359,7 +359,7 @@ data MerkleLogEntries
         -> MerkleLogEntries u t b
         -> MerkleLogEntries u (h ': t) b
 
-    -- TODO: shold we support lazy lists/streams in the body or more
+    -- TODO: should we support lazy lists/streams in the body or more
     -- generally abstracting a store the may be backed by a persisted
     -- database? All we need is the ability to enumerate items in order. We
     -- may also consider support to lookup the index of an item for creating

--- a/src/Chainweb/Miner/Coordinator.hs
+++ b/src/Chainweb/Miner/Coordinator.hs
@@ -181,7 +181,7 @@ newWork logFun choice eminer pact tpw c = do
         <*> getAdjacentParents c p
 
     public :: ParentHeader -> Miner -> IO (Maybe (T2 CachedPayload BlockHashRecord))
-    public (ParentHeader p) miner = case getAdjacentParents c p of
+    public p miner = case getAdjacentParents c (_parentHeader p) of
         Nothing -> pure Nothing
         Just adj -> do
             creationTime <- BlockCreationTime <$> getCurrentTimeIntegral

--- a/src/Chainweb/Pact/Backend/ForkingBench.hs
+++ b/src/Chainweb/Pact/Backend/ForkingBench.hs
@@ -401,7 +401,7 @@ testRocksDb l = rocksDbNamespace (const prefix)
   where
     prefix = (<>) l . sshow <$> (randomIO @Word64)
 
-toTxCreationTime :: Time Integer -> TxCreationTime
+toTxCreationTime :: Integral a => Time a -> TxCreationTime
 toTxCreationTime (Time timespan) = case timeSpanToSeconds timespan of
           Seconds s -> TxCreationTime $ ParsedInteger s
 
@@ -607,7 +607,7 @@ makeMetaWithSender sender c =
 -- hardcoded sender (sender00)
 makeMeta :: ChainId -> IO PublicMeta
 makeMeta c = do
-    t <- toTxCreationTime <$> getCurrentTimeIntegral
+    t <- toTxCreationTime @Int <$> getCurrentTimeIntegral
     return $ PublicMeta
         {
           _pmChainId = Pact.ChainId $ chainIdToText c

--- a/src/Chainweb/Pact/Backend/ForkingBench.hs
+++ b/src/Chainweb/Pact/Backend/ForkingBench.hs
@@ -145,12 +145,12 @@ bench = C.bgroup "PactService" $
         name = "block-new" ++ (if validate then "-valid" else "") ++
                "[" ++ show txCount ++ "]"
 
-testMemPoolAccess :: IORef Int -> MVar (Map Account (NonEmpty SomeKeyPairCaps)) -> Time Integer -> MemPoolAccess
+testMemPoolAccess :: IORef Int -> MVar (Map Account (NonEmpty SomeKeyPairCaps)) -> Time Int -> MemPoolAccess
 testMemPoolAccess txsPerBlock accounts t = mempty
     { mpaGetBlock = \validate bh hash _header -> getTestBlock accounts t validate bh hash }
   where
 
-    setTime time = \pb -> pb { _pmCreationTime = toTxCreationTime time }
+    setTime time pb = pb { _pmCreationTime = toTxCreationTime time }
 
     getTestBlock mVarAccounts txOrigTime validate bHeight@(BlockHeight bh) hash
         | bh == 1 = do
@@ -401,7 +401,7 @@ testRocksDb l = rocksDbNamespace (const prefix)
   where
     prefix = (<>) l . sshow <$> (randomIO @Word64)
 
-toTxCreationTime :: Integral a => Time a -> TxCreationTime
+toTxCreationTime :: Time Int -> TxCreationTime
 toTxCreationTime (Time timespan) = case timeSpanToSeconds timespan of
           Seconds s -> TxCreationTime $ ParsedInteger s
 
@@ -607,7 +607,7 @@ makeMetaWithSender sender c =
 -- hardcoded sender (sender00)
 makeMeta :: ChainId -> IO PublicMeta
 makeMeta c = do
-    t <- toTxCreationTime @Int <$> getCurrentTimeIntegral
+    t <- toTxCreationTime <$> getCurrentTimeIntegral
     return $ PublicMeta
         {
           _pmChainId = Pact.ChainId $ chainIdToText c

--- a/src/Chainweb/Pact/Backend/Types.hs
+++ b/src/Chainweb/Pact/Backend/Types.hs
@@ -270,7 +270,8 @@ data Checkpointer = Checkpointer
     , _cpDiscard :: IO ()
       -- ^ discard pending block changes
     , _cpGetLatestBlock :: IO (Maybe (BlockHeight, BlockHash))
-      -- ^ get the checkpointer's idea of the latest block
+      -- ^ get the checkpointer's idea of the latest block. The block height is
+      -- is the height of the block of the block hash.
     , _cpBeginCheckpointerBatch :: IO ()
     , _cpCommitCheckpointerBatch :: IO ()
     , _cpDiscardCheckpointerBatch :: IO ()

--- a/src/Chainweb/Pact/PactService.hs
+++ b/src/Chainweb/Pact/PactService.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE BangPatterns #-}
-{-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE LambdaCase #-}

--- a/src/Chainweb/Pact/Service/BlockValidation.hs
+++ b/src/Chainweb/Pact/Service/BlockValidation.hs
@@ -41,7 +41,7 @@ import Chainweb.Payload
 import Chainweb.Transaction
 
 
-newBlock :: Miner -> BlockHeader -> BlockCreationTime -> PactQueue ->
+newBlock :: Miner -> ParentHeader -> BlockCreationTime -> PactQueue ->
             IO (MVar (Either PactException PayloadWithOutputs))
 newBlock mi bHeader creationTime reqQ = do
     !resultVar <- newEmptyMVar :: IO (MVar (Either PactException PayloadWithOutputs))

--- a/src/Chainweb/Pact/Service/Types.hs
+++ b/src/Chainweb/Pact/Service/Types.hs
@@ -85,10 +85,10 @@ data RequestMsg = NewBlockMsg NewBlockReq
 type PactExMVar t = MVar (Either PactException t)
 
 data NewBlockReq = NewBlockReq
-    { _newBlockHeader :: BlockHeader
-    , _newMiner :: Miner
+    { _newBlockHeader :: !ParentHeader
+    , _newMiner :: !Miner
     , _newCreationTime :: !BlockCreationTime
-    , _newResultVar :: PactExMVar PayloadWithOutputs
+    , _newResultVar :: !(PactExMVar PayloadWithOutputs)
     }
 instance Show NewBlockReq where show NewBlockReq{..} = show (_newBlockHeader, _newMiner)
 

--- a/src/Chainweb/Pact/TransactionExec.hs
+++ b/src/Chainweb/Pact/TransactionExec.hs
@@ -237,7 +237,7 @@ applyCoinbase
       -- ^ Miner reward
     -> PublicData
       -- ^ Contains block height, time, prev hash + metadata
-    -> BlockHeader
+    -> ParentHeader
       -- ^ parent header
     -> EnforceCoinbaseFailure
       -- ^ enforce coinbase failure or not
@@ -278,7 +278,7 @@ applyCoinbase v logger dbEnv (Miner mid mks) reward@(ParsedDecimal d) pd parentH
         -- but in some unit test runs the chain id in public data is empty. This is
         -- fine since coinbase is a special case.
 
-    chash = Pact.Hash $ encodeToByteString $ _blockHash parentHeader
+    chash = Pact.Hash $ encodeToByteString $ _blockHash $ _parentHeader parentHeader
         -- NOTE: it holds that @ _pdPrevBlockHash pd == encode _blockHash@
         -- NOTE: chash includes the /quoted/ text of the parent header.
 

--- a/src/Chainweb/Pact/Utils.hs
+++ b/src/Chainweb/Pact/Utils.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE NumericUnderscores #-}
 {-# LANGUAGE BangPatterns #-}
 -- |
 -- Module: Chainweb.Pact.Utils

--- a/src/Chainweb/Pact/Utils.hs
+++ b/src/Chainweb/Pact/Utils.hs
@@ -83,8 +83,8 @@ timingsCheck (BlockCreationTime txValidationTime) tx =
     ttl > 0
     && txValidationTime >= toMicrosFromSeconds 0
     && txOriginationTime >= 0
-    && toMicrosFromSeconds txOriginationTime < txValidationTime
-    && toMicrosFromSeconds (txOriginationTime + ttl) >= txValidationTime
+    && toMicrosFromSeconds txOriginationTime <= txValidationTime
+    && toMicrosFromSeconds (txOriginationTime + ttl) > txValidationTime
     && ttl <= maxTTL
   where
     (TTLSeconds ttl) = timeToLiveOf tx

--- a/src/Chainweb/Payload.hs
+++ b/src/Chainweb/Payload.hs
@@ -389,8 +389,6 @@ instance HasTextRepresentation MinerData where
 -- -------------------------------------------------------------------------- --
 -- Block Transactions
 
-
-
 -- | The block transactions
 --
 data BlockTransactions = BlockTransactions
@@ -729,7 +727,7 @@ newBlockPayload mi co s = blockPayload txs outs
 -- | This contains all non-redundant payload data for a block. It doesn't
 -- contain any data that can be recomputed.
 --
--- This data structure is used maintly to transfer payloads over the wire.
+-- This data structure is used mainly to transfer payloads over the wire.
 --
 data PayloadData = PayloadData
     { _payloadDataTransactions :: !(V.Vector Transaction)

--- a/src/Chainweb/Version.hs
+++ b/src/Chainweb/Version.hs
@@ -649,7 +649,7 @@ useCurrentHeaderCreationTimeForTxValidation
     :: ChainwebVersion
     -> BlockHeight
     -> Bool
-useCurrentHeaderCreationTimeForTxValidation Mainnet01 h = True
+useCurrentHeaderCreationTimeForTxValidation Mainnet01 _ = True
 useCurrentHeaderCreationTimeForTxValidation Development h = h < 2000
 useCurrentHeaderCreationTimeForTxValidation _ h = h <= 1
     -- For most chainweb versions there is a large gap between creation times of

--- a/src/Chainweb/WebPactExecutionService.hs
+++ b/src/Chainweb/WebPactExecutionService.hs
@@ -44,7 +44,7 @@ import Pact.Types.Hash
 
 data PactExecutionService = PactExecutionService
     { _pactValidateBlock :: BlockHeader -> PayloadData -> IO PayloadWithOutputs
-    , _pactNewBlock :: Miner -> BlockHeader -> BlockCreationTime -> IO PayloadWithOutputs
+    , _pactNewBlock :: Miner -> ParentHeader -> BlockCreationTime -> IO PayloadWithOutputs
     , _pactLocal :: ChainwebTransaction -> IO (Either PactException (CommandResult Hash))
     , _pactLookup
         :: Rewind
@@ -66,7 +66,7 @@ newtype WebPactExecutionService = WebPactExecutionService
 _webPactNewBlock
     :: WebPactExecutionService
     -> Miner
-    -> BlockHeader
+    -> ParentHeader
     -> BlockCreationTime
     -> IO PayloadWithOutputs
 _webPactNewBlock = _pactNewBlock . _webPactExecutionService

--- a/test/Chainweb/Test/CutDB.hs
+++ b/test/Chainweb/Test/CutDB.hs
@@ -407,7 +407,7 @@ tryMineForChain miner webPact cutDb c cid = do
             return $ Right (c', cid, outputs)
         Left e -> return $ Left e
   where
-    parent = c ^?! ixg cid -- parent to mine on
+    parent = ParentHeader $ c ^?! ixg cid -- parent to mine on
 
     payloadDb = view cutDbPayloadCas cutDb
     webDb = view cutDbWebBlockHeaderDb cutDb

--- a/test/Chainweb/Test/Pact/ChainData.hs
+++ b/test/Chainweb/Test/Pact/ChainData.hs
@@ -138,7 +138,7 @@ run genesisBlock iopdb iobhdb rr = do
           startHeight = fromIntegral $ _blockHeight start
           go = do
               r <- ask
-              pblock <- get
+              pblock <- gets ParentHeader
               n <- liftIO $ Nonce <$> readIORef ncounter
               ret@(T3 _ newblock _) <- liftIO $ mineBlock pblock n iopdb iobhdb r
               liftIO $ modifyIORef' ncounter succ
@@ -146,12 +146,12 @@ run genesisBlock iopdb iobhdb rr = do
               return ret
 
 mineBlock
-    :: BlockHeader
+    :: ParentHeader
     -> Nonce
     -> IO (PayloadDb HashMapCas)
     -> IO BlockHeaderDb
     -> IO PactQueue
-    -> IO (T3 BlockHeader BlockHeader PayloadWithOutputs)
+    -> IO (T3 ParentHeader BlockHeader PayloadWithOutputs)
 mineBlock parentHeader nonce iopdb iobhdb r = do
 
      -- assemble block without nonce and timestamp
@@ -172,7 +172,7 @@ mineBlock parentHeader nonce iopdb iobhdb r = do
               (_payloadWithOutputsPayloadHash payload)
               nonce
               creationTime
-              (ParentHeader parentHeader)
+              parentHeader
          hbytes = HeaderBytes . runPutS $ encodeBlockHeaderWithoutHash bh
          tbytes = TargetBytes . runPutS . encodeHashTarget $ _blockTarget bh
 

--- a/test/Chainweb/Test/Pact/ChainData.hs
+++ b/test/Chainweb/Test/Pact/ChainData.hs
@@ -79,7 +79,7 @@ tests = testGroupSch label
   where
     label = "Chainweb.Test.Pact.ChainData"
 
-chainDataTest :: T.Text -> IO (Time Integer) -> TestTree
+chainDataTest :: T.Text -> IO (Time Micros) -> TestTree
 chainDataTest t time =
     withRocksResource $ \rocksIO ->
     withPayloadDb $ \pdb ->
@@ -96,7 +96,7 @@ chainDataTest t time =
 
 getTestBlock
     :: T.Text
-    -> Time Integer
+    -> Time Micros
     -> MempoolPreBlockCheck ChainwebTransaction
     -> BlockHeight
     -> BlockHash
@@ -104,7 +104,7 @@ getTestBlock
 getTestBlock t txOrigTime _validate _bh _hash = do
     akp0 <- stockKey "sender00"
     kp0 <- mkKeyPairs [akp0]
-    let nonce = (<> t) . T.pack . show @(Time Integer) $ txOrigTime
+    let nonce = (<> t) . T.pack $ show txOrigTime
     txs <- mkTestExecTransactions "sender00" "0" kp0 nonce 10000 0.00000000001 3600 (toTxCreationTime txOrigTime) tx
     oks <- _validate _bh _hash txs
     unless (V.and oks) $ fail $ mconcat
@@ -226,7 +226,7 @@ data TestException = TestException
 
 instance Exception TestException
 
-testMemPoolAccess :: T.Text -> IO (Time Integer) -> MemPoolAccess
+testMemPoolAccess :: T.Text -> IO (Time Micros) -> MemPoolAccess
 testMemPoolAccess t iotime = mempty
     { mpaGetBlock = \validate bh hash _parentHeader -> do
         time <- f bh <$> iotime
@@ -235,5 +235,5 @@ testMemPoolAccess t iotime = mempty
   where
     -- tx origination times needed to be unique to ensure that the corresponding
     -- tx hashes are also unique.
-    f :: BlockHeight -> Time Integer -> Time Integer
+    f :: BlockHeight -> Time Micros -> Time Micros
     f b = add (scaleTimeSpan b millisecond)

--- a/test/Chainweb/Test/Pact/PactExec.hs
+++ b/test/Chainweb/Test/Pact/PactExec.hs
@@ -41,6 +41,7 @@ import Test.Tasty.HUnit
 
 -- internal modules
 
+import Chainweb.BlockHeader
 import Chainweb.BlockHeader.Genesis (genesisBlockHeader)
 import Chainweb.BlockHeaderDB (BlockHeaderDb)
 import Chainweb.Graph
@@ -417,13 +418,14 @@ execTest runPact request = _trEval request $ do
     cmdStrs <- mapM getPactCode $ _trCmds request
     d <- adminData
     trans <- goldenTestTransactions . V.fromList $ fmap (k d) cmdStrs
-    results <- runPact $ execTransactions (Just someTestVersionHeader) defaultMiner trans (EnforceCoinbaseFailure True) (CoinbaseUsePrecompiled True)
+    results <- runPact $ execTransactions (Just parentHeader) defaultMiner trans (EnforceCoinbaseFailure True) (CoinbaseUsePrecompiled True)
     let outputs = V.toList $ snd <$> _transactionPairs results
     return $ TestResponse
         (zip (_trCmds request) (toHashCommandResult <$> outputs))
         (toHashCommandResult $ _transactionCoinbase results)
   where
     k d c = PactTransaction c d
+    parentHeader = ParentHeader someTestVersionHeader
 
 
 
@@ -434,9 +436,10 @@ execTxsTest
     -> ScheduledTest
 execTxsTest runPact name (trans',check) = testCaseSch name (go >>= check)
   where
+    parentHeader = ParentHeader someTestVersionHeader
     go = do
       trans <- trans'
-      results' <- try $ runPact $ execTransactions (Just someTestVersionHeader) defaultMiner trans (EnforceCoinbaseFailure True) (CoinbaseUsePrecompiled True)
+      results' <- try $ runPact $ execTransactions (Just parentHeader) defaultMiner trans (EnforceCoinbaseFailure True) (CoinbaseUsePrecompiled True)
       case results' of
         Right results -> Right <$> do
           let outputs = V.toList $ snd <$> _transactionPairs results

--- a/test/Chainweb/Test/Pact/PactInProcApi.hs
+++ b/test/Chainweb/Test/Pact/PactInProcApi.hs
@@ -88,7 +88,7 @@ newBlockTest label reqIO = golden label $ do
     reqQ <- reqIO
     let genesisHeader = genesisBlockHeader testVersion cid
     let blockTime = Time $ secondsToTimeSpan $ Seconds $ succ 1000000
-    respVar <- newBlock noMiner genesisHeader (BlockCreationTime blockTime) reqQ
+    respVar <- newBlock noMiner (ParentHeader genesisHeader) (BlockCreationTime blockTime) reqQ
     goldenBytes "new-block" =<< takeMVar respVar
   where
     cid = someChainId testVersion
@@ -119,7 +119,7 @@ badlistNewBlockTest :: IO PactQueue -> TestTree
 badlistNewBlockTest reqIO = testCase "badlist-new-block-test" $ do
     reqQ <- reqIO
     expectBadlistException $ do
-        m <- newBlock noMiner genesisHeader blockTime reqQ
+        m <- newBlock noMiner (ParentHeader genesisHeader) blockTime reqQ
         takeMVar m >>= either throwIO (const (return ()))
   where
     cid = someChainId testVersion

--- a/test/Chainweb/Test/Pact/TTL.hs
+++ b/test/Chainweb/Test/Pact/TTL.hs
@@ -98,8 +98,8 @@ testTTL
     -> IO PactQueue
     -> Assertion
 testTTL genesisBlock iopdb iobhdb rr = do
-    (T3 _ newblock _) <- liftIO $ mineBlock genesisBlock (Nonce 1) iopdb iobhdb rr
-    expectException $ mineBlock newblock (Nonce 2) iopdb iobhdb rr
+    (T3 _ newblock _) <- liftIO $ mineBlock (ParentHeader genesisBlock) (Nonce 1) iopdb iobhdb rr
+    expectException $ mineBlock (ParentHeader newblock) (Nonce 2) iopdb iobhdb rr
   where
     expectException act = do
         m <- wrap `catch` h
@@ -176,12 +176,12 @@ defModule idx = [text| ;;
 
 
 mineBlock
-    :: BlockHeader
+    :: ParentHeader
     -> Nonce
     -> IO (PayloadDb HashMapCas)
     -> IO BlockHeaderDb
     -> IO PactQueue
-    -> IO (T3 BlockHeader BlockHeader PayloadWithOutputs)
+    -> IO (T3 ParentHeader BlockHeader PayloadWithOutputs)
 mineBlock parentHeader nonce iopdb iobhdb r = do
 
      -- assemble block without nonce and timestamp
@@ -195,7 +195,7 @@ mineBlock parentHeader nonce iopdb iobhdb r = do
               (_payloadWithOutputsPayloadHash payload)
               nonce
               creationTime
-              (ParentHeader parentHeader)
+              parentHeader
          hbytes = HeaderBytes . runPutS $ encodeBlockHeaderWithoutHash bh
          tbytes = TargetBytes . runPutS . encodeHashTarget $ _blockTarget bh
 

--- a/test/Chainweb/Test/Pact/TransactionTests.hs
+++ b/test/Chainweb/Test/Pact/TransactionTests.hs
@@ -209,7 +209,7 @@ testCoinbase797DateFix = testCaseSteps "testCoinbase791Fix" $ \step -> do
     doCoinbaseExploit pdb mc height localCmd precompile testResult = do
       let pd = PublicData def (int height) 0 ""
 
-      void $ applyCoinbase Mainnet01 logger pdb miner 0.1 pd (mkTestHeader $ height - 1)
+      void $ applyCoinbase Mainnet01 logger pdb miner 0.1 pd (mkTestParentHeader $ height - 1)
         (EnforceCoinbaseFailure True) (CoinbaseUsePrecompiled precompile) mc
 
       let h = H.toUntypedHash (H.hash "" :: H.PactHash)
@@ -234,15 +234,15 @@ testCoinbase797DateFix = testCaseSteps "testCoinbase791Fix" $ \step -> do
     -- | someBlockHeader is a bit slow for the vuln797Fix to trigger. So, instead
     -- of mining a full chain we fake the height.
     --
-    mkTestHeader :: BlockHeight -> BlockHeader
-    mkTestHeader h = (someBlockHeader (FastTimedCPM singleton) 10)
+    mkTestParentHeader :: BlockHeight -> ParentHeader
+    mkTestParentHeader h = ParentHeader $ (someBlockHeader (FastTimedCPM singleton) 10)
         { _blockHeight = h }
 
 
 testCoinbaseEnforceFailure :: Assertion
 testCoinbaseEnforceFailure = do
     (pdb,mc) <- loadCC
-    r <- try $ applyCoinbase toyVersion logger pdb miner 0.1 pubData someTestVersionHeader
+    r <- try $ applyCoinbase toyVersion logger pdb miner 0.1 pubData someParentHeader
       (EnforceCoinbaseFailure True) (CoinbaseUsePrecompiled False) mc
     case r of
       Left (e :: SomeException) ->
@@ -257,6 +257,7 @@ testCoinbaseEnforceFailure = do
     toInt64 (Time (TimeSpan (Micros m))) = m
     blockHeight' = 123
     logger = newLogger neverLog ""
+    someParentHeader = ParentHeader someTestVersionHeader
 
 
 testCoinbaseUpgradeDevnet :: V.ChainId -> BlockHeight -> Assertion
@@ -306,7 +307,7 @@ testCoinbaseUpgradeDevnet cid upgradeHeight = do
     pubData = PublicData def (int upgradeHeight) 0 ""
     logger = newLogger neverLog "" -- set to alwaysLog to debug
 
-    parentHeader = (someBlockHeader v upgradeHeight)
+    parentHeader = ParentHeader $ (someBlockHeader v upgradeHeight)
       { _blockChainwebVersion = v
       , _blockChainId = cid
       }

--- a/test/Chainweb/Test/Pact/Utils.hs
+++ b/test/Chainweb/Test/Pact/Utils.hs
@@ -598,7 +598,7 @@ withPactCtxSQLite v bhdbIO pdbIO gasModel f =
 withMVarResource :: a -> (IO (MVar a) -> TestTree) -> TestTree
 withMVarResource value = withResource (newMVar value) (const $ return ())
 
-withTime :: (IO (Time Integer) -> TestTree) -> TestTree
+withTime :: (IO (Time Micros) -> TestTree) -> TestTree
 withTime = withResource getCurrentTimeIntegral (const (return ()))
 
 mkKeyset :: Text -> [PublicKeyBS] -> Value
@@ -623,7 +623,7 @@ stockKey s = do
 decodeKey :: ByteString -> ByteString
 decodeKey = fst . B16.decode
 
-toTxCreationTime :: Time Integer -> TxCreationTime
+toTxCreationTime :: Integral a => Time a -> TxCreationTime
 toTxCreationTime (Time timespan) = case timeSpanToSeconds timespan of
           Seconds s -> TxCreationTime $ ParsedInteger s
 

--- a/test/Chainweb/Test/Pact/Utils.hs
+++ b/test/Chainweb/Test/Pact/Utils.hs
@@ -527,8 +527,8 @@ zeroNoncer = const (return $ Nonce 0)
 runCut :: ChainwebVersion -> TestBlockDb -> WebPactExecutionService -> GenBlockTime -> Noncer -> IO ()
 runCut v bdb pact genTime noncer =
   forM_ (chainIds v) $ \cid -> do
-    ph <- getParentTestBlockDb bdb cid
-    pout <- _webPactNewBlock pact noMiner ph (_blockCreationTime ph)
+    ph <- ParentHeader <$> getParentTestBlockDb bdb cid
+    pout <- _webPactNewBlock pact noMiner ph (_blockCreationTime $ _parentHeader ph)
     n <- noncer cid
     addTestBlockDb bdb n genTime cid pout
     h <- getParentTestBlockDb bdb cid


### PR DESCRIPTION
In the current code base the block creation time of the *current* header is used as reference for tx timing validation. The current time during pact validation is the block creation time of the *parent* header is used.

This PR provides the first step of resolving this inconsistency. The PR

* [x] makes it explicit throughout the code which header value is used as reference by labeling block headers with the `ParentHeader` newtype when the header is used as parent header in the respective context.

* [x] adds a validation guard for switching between using the *current* and the *parent* header as reference time for tx timing validation.

* [x] adjusts unit tests to be compatible with both behaviors (using the new behavior as default).

The line of changes from this PR is continued in #942
