### PR TITLE
Fix mempool highwater test

### DIFF
--- a/src/Chainweb/Mempool/InMem.hs
+++ b/src/Chainweb/Mempool/InMem.hs
@@ -25,7 +25,7 @@ module Chainweb.Mempool.InMem
 ------------------------------------------------------------------------------
 import Control.Applicative ((<|>))
 import Control.Concurrent.Async
-import Control.Concurrent.MVar (MVar, newMVar, withMVar, withMVarMasked)
+import Control.Concurrent.MVar
 import Control.DeepSeq
 import Control.Error.Util (hush)
 import Control.Exception (bracket, evaluate, mask_, throw)
@@ -597,11 +597,7 @@ getPendingInMem cfg nonce lock since callback = do
 
 ------------------------------------------------------------------------------
 clearInMem :: MVar (InMemoryMempoolData t) -> IO ()
-clearInMem lock = do
-    withMVarMasked lock $ \mdata -> do
-        writeIORef (_inmemPending mdata) mempty
-        writeIORef (_inmemRecentLog mdata) emptyRecentLog
-
+clearInMem lock = newInMemMempoolData >>= void . swapMVar lock
 
 ------------------------------------------------------------------------------
 emptyRecentLog :: RecentLog
@@ -679,4 +675,3 @@ pruneInternal mdata now = do
     -- keep transactions that expire in the future.
     flt pe = _inmemPeExpires pe > now
     pruneBadMap = HashMap.filter (> now)
-

--- a/test/Chainweb/Test/Mempool.hs
+++ b/test/Chainweb/Test/Mempool.hs
@@ -343,20 +343,22 @@ propHighWater
     -> IO (Either String ())
 propHighWater (txs0, txs1) _ mempool = runExceptT $ do
     liftIO $ insert txs0
-    hw <- liftIO $ getPending Nothing $ const (return ())
+    pendingOps0 <- liftIO $ newIORef []
+    hw <- liftIO $ getPending Nothing $ \v -> modifyIORef' pendingOps0 (v:)
+    p0s <- V.concat <$> (liftIO $ readIORef pendingOps0)
     liftIO $ insert txs1
     pendingOps <- liftIO $ newIORef []
-    void $ liftIO $ getPending (Just hw) $ \v -> modifyIORef' pendingOps (v:)
+    hw1 <- liftIO $ getPending (Just hw) $ \v -> modifyIORef' pendingOps (v:)
     allPending <- sort . V.toList . V.concat
                   <$> liftIO (readIORef pendingOps)
-    when (txdata /= allPending) $
-        let msg = concat [ "getPendingTransactions highwater failure: "
-                         , "expected new pending list:\n    "
-                         , show txdata
-                         , "\nbut got:\n    "
-                         , show allPending
-                         , "\nhw was: ", show hw
-                         , ", txs0 size: ", show (length txs0)
+    when (txdata /= allPending && snd hw1 /= (fromIntegral $ length txs0 + length txdata)) $
+        let msg = concat [ "highwater failure"
+                         , ", initial batch was ", show (length txs0)
+                         , ", retreived ", show (length p0s)
+                         , ", with highwater ", show (snd hw)
+                         , ". Second batch was ", show (length txdata)
+                         , " retreived ", show (length allPending)
+                         , ", with highwater ", show (snd hw1)
                          ]
         in fail msg
 


### PR DESCRIPTION
Issue was `mempoolClear` not clearing everything between tests (namely `_inmemCountPending` but also bad map) so quickcheck would intermittently overfill past `maxNumPending`.

This wouldn't affect production as `mempoolClear` is indicated as only being for testing (https://github.com/kadena-io/chainweb-node/blob/059ff64b4d8290ec1606a1d37ff0ff007e8e315f/src/Chainweb/Mempool/Mempool.hs#L270-L272)