### PR TITLE
Get rid of MonadFail from IO

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -27,3 +27,22 @@ constraints:
       base-unicode-symbols < 0.2.4,
       megaparsec < 8,
       neat-interpolation < 0.4
+
+-- GHC-8.8
+
+package pact
+    ghc-options: -Wwarn
+    haddock-options: --optghc=-Wwarn
+
+allow-newer:
+    *:sbv
+
+package vault
+    documentation: false
+
+-- Currently PR status
+source-repository-package
+    type: git
+    location: https://github.com/stepcut/ixset-typed
+    tag: 745634a16d34ff8cb3abf7d5b40fffca95ac36fc
+

--- a/src/Chainweb/Mempool/InMemTypes.hs
+++ b/src/Chainweb/Mempool/InMemTypes.hs
@@ -36,7 +36,7 @@ import qualified Data.Vector as V
 
 import GHC.Generics
 
-import Pact.Types.Gas (GasLimit(..), GasPrice(..))
+import Pact.Types.Gas (GasPrice(..))
 
 -- internal imports
 

--- a/src/Chainweb/Pact/Backend/Types.hs
+++ b/src/Chainweb/Pact/Backend/Types.hs
@@ -80,7 +80,6 @@ module Chainweb.Pact.Backend.Types
 import Control.Exception
 import Control.Exception.Safe hiding (bracket)
 import Control.Lens
-import Control.Monad.Fail
 import Control.Monad.Reader
 import Control.Monad.State.Strict
 
@@ -250,7 +249,6 @@ newtype BlockHandler p a = BlockHandler
                        , MonadMask
                        , MonadIO
                        , MonadReader (BlockDbEnv p)
-                       , MonadFail
                        )
 
 data PactDbEnv' = forall e. PactDbEnv' (PactDbEnv e)

--- a/src/Chainweb/Pact/PactService.hs
+++ b/src/Chainweb/Pact/PactService.hs
@@ -1187,7 +1187,7 @@ rewindTo rewindLimit = maybe rewindGenesis doRewind
     failOnTooLowRequestedHeight _ _ _ = return ()
 
 
-    failNonGenesisOnEmptyDb = fail "impossible: playing non-genesis block to empty DB"
+    failNonGenesisOnEmptyDb = error "impossible: playing non-genesis block to empty DB"
 
     playFork bhdb payloadDb parentHash lastHeader = do
         parentHeader <- ParentHeader <$!> lookupBlockHeader parentHash "rewindTo"

--- a/src/Chainweb/Pact/Types.hs
+++ b/src/Chainweb/Pact/Types.hs
@@ -101,7 +101,6 @@ module Chainweb.Pact.Types
 import Control.Exception (asyncExceptionFromException, asyncExceptionToException, throw)
 import Control.Lens hiding ((.=))
 import Control.Monad.Catch
-import Control.Monad.Fail
 import Control.Monad.Reader
 import Control.Monad.State.Strict
 
@@ -227,7 +226,6 @@ newtype TransactionM db a = TransactionM
       , MonadState TransactionState
       , MonadThrow, MonadCatch, MonadMask
       , MonadIO
-      , MonadFail
       )
 
 -- | Run a 'TransactionM' computation given some initial
@@ -375,7 +373,6 @@ newtype PactServiceM cas a = PactServiceM
     , MonadState PactServiceState
     , MonadThrow, MonadCatch, MonadMask
     , MonadIO
-    , MonadFail
     )
 
 -- | Run a 'PactServiceM' computation given some initial

--- a/src/Network/X509/SelfSigned.hs
+++ b/src/Network/X509/SelfSigned.hs
@@ -132,8 +132,7 @@ import Data.String (fromString)
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as T
 import Data.X509
-import Data.X509.Validation
-    (Fingerprint(..), ServiceID, ValidationCacheQueryCallback, getFingerprint)
+import Data.X509.Validation (Fingerprint(..), ServiceID, getFingerprint)
 
 import GHC.Generics
 import GHC.Stack

--- a/tools/run-nodes/RunNodes.hs
+++ b/tools/run-nodes/RunNodes.hs
@@ -11,7 +11,6 @@ module RunNodes ( main, runNodesOpts ) where
 import BasePrelude hiding (option, (%))
 import Chainweb.Graph (petersonChainGraph)
 import Chainweb.Version
-import Control.Concurrent (threadDelay)
 import Control.Concurrent.Async
 import Control.Error.Util (note)
 import qualified Data.Text as T


### PR DESCRIPTION
Fix incomplete pattern matches in `IO` and get the code base ready for GHC-8.8.