### PR TITLE
Better test mempool fixture; overhaul PactInProcAPI

### DIFF
--- a/src/Chainweb/Pact/Backend/Types.hs
+++ b/src/Chainweb/Pact/Backend/Types.hs
@@ -90,7 +90,6 @@ import Data.DList (DList)
 import Data.Hashable (Hashable)
 import Data.HashMap.Strict (HashMap)
 import Data.HashSet (HashSet)
-import Data.IORef
 import Data.Map.Strict (Map)
 import Data.Tuple.Strict
 import Data.Vector (Vector)

--- a/src/Chainweb/Pact/Backend/Types.hs
+++ b/src/Chainweb/Pact/Backend/Types.hs
@@ -73,7 +73,6 @@ module Chainweb.Pact.Backend.Types
 
       -- * mempool
     , MemPoolAccess(..)
-    , delegateMemPoolAccess
 
     , PactServiceException(..)
     ) where
@@ -314,17 +313,6 @@ instance Semigroup MemPoolAccess where
 instance Monoid MemPoolAccess where
   mempty = MemPoolAccess (\_ _ _ -> mempty) (const mempty) (const mempty) (const mempty)
 
--- | 'MemPoolAccess' that delegates all calls to the contents of provided `IORef`.
-delegateMemPoolAccess :: IORef MemPoolAccess -> MemPoolAccess
-delegateMemPoolAccess r = MemPoolAccess
-  { mpaGetBlock = \a b c d -> call mpaGetBlock $ \f -> f a b c d
-  , mpaSetLastHeader = \a -> call mpaSetLastHeader ($ a)
-  , mpaProcessFork = \a -> call mpaProcessFork ($ a)
-  , mpaBadlistTx = \a -> call mpaBadlistTx ($ a)
-  }
-  where
-    call :: (MemPoolAccess -> f) -> (f -> IO a) -> IO a
-    call f g = readIORef r >>= g . f
 
 data PactServiceException = PactServiceIllegalRewind
     { _attemptedRewindTo :: Maybe (BlockHeight, BlockHash)

--- a/test/Chainweb/Test/Pact/Utils.hs
+++ b/test/Chainweb/Test/Pact/Utils.hs
@@ -803,10 +803,10 @@ withPactCtxSQLite v bhdbIO pdbIO gasModel config f =
             }
 
 withMVarResource :: a -> (IO (MVar a) -> TestTree) -> TestTree
-withMVarResource value = withResource (newMVar value) (const $ return ())
+withMVarResource value = withResource (newMVar value) mempty
 
 withTime :: (IO (Time Micros) -> TestTree) -> TestTree
-withTime = withResource getCurrentTimeIntegral (const (return ()))
+withTime = withResource getCurrentTimeIntegral mempty
 
 mkKeyset :: Text -> [PublicKeyBS] -> Value
 mkKeyset p ks = object
@@ -835,7 +835,7 @@ toTxCreationTime (Time timespan) = case timeSpanToSeconds timespan of
           Seconds s -> TxCreationTime $ ParsedInteger s
 
 withPayloadDb :: (IO (PayloadDb HashMapCas) -> TestTree) -> TestTree
-withPayloadDb = withResource newPayloadDb (\_ -> return ())
+withPayloadDb = withResource newPayloadDb mempty
 
 
 -- | 'MemPoolAccess' that delegates all calls to the contents of provided `IORef`.
@@ -854,7 +854,7 @@ delegateMemPoolAccess r = MemPoolAccess
 withDelegateMempool
   :: (IO (IORef MemPoolAccess, MemPoolAccess) -> TestTree)
   -> TestTree
-withDelegateMempool = withResource start (const mempty)
+withDelegateMempool = withResource start mempty
   where
     start = (id &&& delegateMemPoolAccess) <$> newIORef mempty
 
@@ -881,7 +881,7 @@ withTestBlockDbTest
   :: ChainwebVersion -> (IO TestBlockDb -> TestTree) -> TestTree
 withTestBlockDbTest v a =
   withRocksResource $ \rdb ->
-  withResource (start rdb) (const $ return ()) a
+  withResource (start rdb) mempty a
   where
     start r = r >>= mkTestBlockDb v
 

--- a/test/Chainweb/Test/Pact/Utils.hs
+++ b/test/Chainweb/Test/Pact/Utils.hs
@@ -848,7 +848,7 @@ delegateMemPoolAccess r = MemPoolAccess
   }
   where
     call :: (MemPoolAccess -> f) -> (f -> IO a) -> IO a
-    call f g = readIORef r >>= \(n,m) -> putStrLn n >> g (f m)
+    call f g = readIORef r >>= \(n,m) -> putStrLn ("read: " ++ n) >> g (f m)
 
 -- | use a "delegate" which you can dynamically reset/modify
 withDelegateMempool
@@ -860,7 +860,7 @@ withDelegateMempool = withResource start (const mempty)
 
 -- | Set test mempool
 setMempool :: IO (IORef (String,MemPoolAccess)) -> (String,MemPoolAccess) -> IO ()
-setMempool refIO mp = refIO >>= flip writeIORef mp
+setMempool refIO mp@(n,_) = refIO >>= \r -> putStrLn ("write: " ++ n) >> writeIORef r mp
 
 withBlockHeaderDb
     :: IO RocksDb

--- a/test/Chainweb/Test/Utils.hs
+++ b/test/Chainweb/Test/Utils.hs
@@ -76,6 +76,8 @@ module Chainweb.Test.Utils
 , assertGe
 , assertLe
 , assertSatisfies
+, assertInfix
+, expectFailureContaining
 
 -- * Golden Tests
 , golden
@@ -111,7 +113,7 @@ import Data.Bytes.Put
 import qualified Data.ByteString as B
 import Data.Coerce (coerce)
 import Data.Foldable
-import Data.List (sortOn)
+import Data.List (sortOn,isInfixOf)
 import qualified Data.Text as T
 import Data.Tree
 import qualified Data.Tree.Lens as LT
@@ -734,6 +736,17 @@ assertSatisfies msg value predf
   | result = assertEqual msg True result
   | otherwise = assertFailure $ msg ++ ": " ++ show value
   where result = predf value
+
+-- | Assert that string rep of value contains contents.
+assertInfix :: Show a => String -> String -> a -> Assertion
+assertInfix msg contents value = assertSatisfies
+  (msg ++ ": should contain '" ++ contents ++ "'")
+  (show value) (isInfixOf contents)
+
+expectFailureContaining :: Show a => String -> String -> Either a r -> Assertion
+expectFailureContaining msg _ Right {} = assertFailure $ msg ++ ": expected failure"
+expectFailureContaining msg contents (Left e) = assertInfix msg contents e
+
 
 -- -------------------------------------------------------------------------- --
 -- Golden Testing


### PR DESCRIPTION
Gets rid of `adminData` and `goldenTestTransactions` in Pact test utils too