### PR TITLE
Fix creationTime Issue with new creation-time code

### DIFF
--- a/src/Chainweb/Mempool/InMem.hs
+++ b/src/Chainweb/Mempool/InMem.hs
@@ -234,7 +234,7 @@ addToBadListInMem lock tx = withMVarMasked lock $ \mdata -> do
     -- we don't have the expiry time here, so just use maxTTL
     now <- getCurrentTimeIntegral
     let (ParsedInteger mt) = maxTTL
-    let !endTime = add (secondsToTimeSpan $ Seconds mt) now
+    let !endTime = add (secondsToTimeSpan $ fromIntegral mt) now
     let !bad' = HashMap.insert tx endTime bad
     writeIORef (_inmemPending mdata) pnd'
     writeIORef (_inmemBadMap mdata) bad'

--- a/src/Chainweb/Pact/Backend/ForkingBench.hs
+++ b/src/Chainweb/Pact/Backend/ForkingBench.hs
@@ -67,7 +67,6 @@ import Text.Printf
 -- pact imports
 
 import Pact.ApiReq
-import Pact.Parse
 import Pact.Types.Capability
 import qualified Pact.Types.ChainId as Pact
 import Pact.Types.ChainMeta
@@ -97,6 +96,7 @@ import Chainweb.Pact.PactService
 import Chainweb.Pact.Service.BlockValidation
 import Chainweb.Pact.Service.PactQueue
 import Chainweb.Pact.Types
+import Chainweb.Pact.Utils (toTxCreationTime)
 import Chainweb.Payload
 import Chainweb.Payload.PayloadStore
 import Chainweb.Payload.PayloadStore.InMemory
@@ -400,9 +400,6 @@ testRocksDb l = rocksDbNamespace (const prefix)
   where
     prefix = (<>) l . sshow <$> (randomIO @Word64)
 
-toTxCreationTime :: Time Micros -> TxCreationTime
-toTxCreationTime (Time timespan) = case timeSpanToSeconds timespan of
-          Seconds s -> TxCreationTime $ ParsedInteger s
 
 assertNotLeft :: (MonadThrow m, Exception e) => Either e a -> m a
 assertNotLeft (Left l) = throwM l

--- a/src/Chainweb/Pact/PactService.hs
+++ b/src/Chainweb/Pact/PactService.hs
@@ -1404,9 +1404,9 @@ execPreInsertCheckReq txs = do
                 psState <- get
                 parentHeader <- ParentHeader <$!> lookupBlockHeader parentHash "execPreInsertCheckReq"
 
-                let parentTime = _blockCreationTime $ _parentHeader parentHeader
+                now <- liftIO $ getCurrentTimeIntegral
                 liftIO $ fmap Discard $ V.zipWith (>>)
-                    <$> validateChainwebTxs cp parentTime currHeight txs (runGas pdb psState psEnv)
+                    <$> validateChainwebTxs cp (BlockCreationTime now) currHeight txs (runGas pdb psState psEnv)
 
                     -- This code can be removed once the transition is complete and the guard
                     -- @useCurrentHeaderCreationTimeForTxValidation@ is false for all new blocks

--- a/src/Chainweb/Pact/PactService.hs
+++ b/src/Chainweb/Pact/PactService.hs
@@ -714,14 +714,16 @@ validateChainwebTxs
         -- This time is the creation time of the parent header for calls from
         -- newBlock. It is the creation time of the current header
         -- for block validation if
-        -- @useCurrentHeaderCreationTimeForTxValidation blockHeight@ true.
+        -- @useLegacyCreationTimeForTxValidation blockHeight@ true.
         --
+    -> Bool
+        -- ^ lenientCreationTime flag, see 'lenientTimeSlop' for details.
     -> BlockHeight
         -- ^ Current block height
     -> Vector ChainwebTransaction
     -> RunGas
     -> IO ValidateTxs
-validateChainwebTxs cp txValidationTime bh txs doBuyGas
+validateChainwebTxs cp txValidationTime lenientCreationTime bh txs doBuyGas
   | bh == 0 = pure $! V.map Right txs
   | V.null txs = pure V.empty
   | otherwise = go
@@ -742,7 +744,7 @@ validateChainwebTxs cp txValidationTime bh txs doBuyGas
 
     checkTimes :: ChainwebTransaction -> IO (Either InsertError ChainwebTransaction)
     checkTimes t
-        | timingsCheck txValidationTime $ fmap payloadObj t = return $ Right t
+        | timingsCheck txValidationTime lenientCreationTime $ fmap payloadObj t = return $ Right t
         | otherwise = return $ Left InsertErrorInvalidTime
 
     initTxList :: ValidateTxs
@@ -772,7 +774,7 @@ validateChainwebTxs cp txValidationTime bh txs doBuyGas
 -- This function covers the TTL compat for the (2.) and (3.) case.
 --
 -- This code can be removed once the transition is complete and the guard
--- @useCurrentHeaderCreationTimeForTxValidation@ is false for all new blocks
+-- @useLegacyCreationTimeForTxValidation@ is false for all new blocks
 -- of all chainweb versions.
 --
 validateLegacyTTL
@@ -816,8 +818,15 @@ validateLegacyTTL parentHeader txs
     -- little less than 3 minutes.
     --
     compatPeriod
-        | useCurrentHeaderCreationTimeForTxValidation v bh =  60 * 3
+        | useLegacyCreationTimeNewBlockOrInsert parentHeader = 60 * 3
         | otherwise = 0
+
+-- | Guard for new block or insert checks vs. parent block height + 1,
+-- whereas validate checks "current block height".
+useLegacyCreationTimeNewBlockOrInsert :: ParentHeader -> Bool
+useLegacyCreationTimeNewBlockOrInsert parentHeader =
+  useLegacyCreationTimeForTxValidation v bh
+  where
     v = _chainwebVersion parentHeader
     bh = succ $ _blockHeight $ _parentHeader parentHeader
 
@@ -945,11 +954,12 @@ execNewBlock mpAccess parentHeader miner = handle onTxFailure $ do
           validate bhi _bha txs = do
 
             let parentTime = _blockCreationTime $ _parentHeader parentHeader
+                lenientCreationTime = not $ useLegacyCreationTimeNewBlockOrInsert parentHeader
             results <- V.zipWith (>>)
-                <$> validateChainwebTxs cp parentTime bhi txs runDebitGas
+                <$> validateChainwebTxs cp parentTime lenientCreationTime bhi txs runDebitGas
 
                 -- This code can be removed once the transition is complete and the guard
-                -- @useCurrentHeaderCreationTimeForTxValidation@ is false for all new blocks
+                -- @useLegacyCreationTimeForTxValidation@ is false for all new blocks
                 -- of all chainweb versions.
                 --
                 <*> pure (validateLegacyTTL parentHeader txs)
@@ -1103,19 +1113,19 @@ playOneBlock currHeader plData pdbenv = do
     -- The legacy behavior is to use the creation time of the /current/ header.
     -- The new default behavior is to use the creation time of the /parent/ header.
     --
-    txValidationTime <- if
-        useCurrentHeaderCreationTimeForTxValidation v h || isGenesisBlockHeader currHeader
+    (txValidationTime,lenientCreationTime) <- if
+        useLegacyCreationTimeForTxValidation v h || isGenesisBlockHeader currHeader
       then
-        return $ _blockCreationTime currHeader
+        return (_blockCreationTime currHeader, False)
       else do
         -- FIXME don't do this twice. Instead store the parent header in the context
         -- (and don't use the current header at all)
         parentHeader <- ParentHeader <$!> lookupBlockHeader  (_blockParent currHeader) "playOneBlock"
-        return $! _blockCreationTime $ _parentHeader parentHeader
+        return (_blockCreationTime $ _parentHeader parentHeader, True)
 
     -- prop_tx_ttl_validate
     valids <- V.zip trans <$> liftIO
-      (validateChainwebTxs cp txValidationTime (_blockHeight currHeader) trans skipDebitGas)
+      (validateChainwebTxs cp txValidationTime lenientCreationTime (_blockHeight currHeader) trans skipDebitGas)
 
     case foldr handleValids [] valids of
       [] -> return ()
@@ -1404,12 +1414,13 @@ execPreInsertCheckReq txs = do
                 psState <- get
                 parentHeader <- ParentHeader <$!> lookupBlockHeader parentHash "execPreInsertCheckReq"
 
-                now <- liftIO $ getCurrentTimeIntegral
+                let parentTime = _blockCreationTime $ _parentHeader parentHeader
+                    lenientCreationTime = not $ useLegacyCreationTimeNewBlockOrInsert parentHeader
                 liftIO $ fmap Discard $ V.zipWith (>>)
-                    <$> validateChainwebTxs cp (BlockCreationTime now) currHeight txs (runGas pdb psState psEnv)
+                    <$> validateChainwebTxs cp parentTime lenientCreationTime currHeight txs (runGas pdb psState psEnv)
 
                     -- This code can be removed once the transition is complete and the guard
-                    -- @useCurrentHeaderCreationTimeForTxValidation@ is false for all new blocks
+                    -- @useLegacyCreationTimeForTxValidation@ is false for all new blocks
                     -- of all chainweb versions.
                     --
                     <*> pure (validateLegacyTTL parentHeader txs)

--- a/src/Chainweb/Pact/Utils.hs
+++ b/src/Chainweb/Pact/Utils.hs
@@ -82,11 +82,12 @@ timingsCheck (BlockCreationTime txValidationTime) tx =
     ttl > 0
     && txValidationTime >= timeFromSeconds 0
     && txOriginationTime >= 0
-    && timeFromSeconds txOriginationTime <= txValidationTime
+    && timeFromSeconds txOriginationTime <= lenientTxValidationTime
     && timeFromSeconds (txOriginationTime + ttl) > txValidationTime
     && ttl <= maxTTL
   where
     (TTLSeconds ttl) = timeToLiveOf tx
     timeFromSeconds = Time . secondsToTimeSpan . Seconds . fromIntegral
     (TxCreationTime txOriginationTime) = creationTimeOf tx
-
+    lenientTxValidationTime = add s30 txValidationTime
+    s30 = scaleTimeSpan (30 :: Int) second

--- a/src/Chainweb/Pact/Utils.hs
+++ b/src/Chainweb/Pact/Utils.hs
@@ -18,6 +18,8 @@ module Chainweb.Pact.Utils
     , maxTTL
     , timingsCheck
     , fromPactChainId
+    , lenientTimeSlop
+    , toTxCreationTime
     ) where
 
 import Data.Aeson
@@ -73,12 +75,14 @@ maxTTL = ParsedInteger $ 2 * 24 * 60 * 60
 timingsCheck
     :: BlockCreationTime
         -- ^ reference time for tx validation.
-        --  If @useCurrentHeaderCreationTimeForTxValidation blockHeight@
+        --  If @useLegacyCreationTimeForTxValidation blockHeight@
         --  this is the the creation time of the current block. Otherwise it
         --  is the creation time of the parent block header.
+    -> Bool
+        -- ^ use lenient creation time validation. See 'lenientTimeSlop' for details.
     -> Command (Payload PublicMeta ParsedCode)
     -> Bool
-timingsCheck (BlockCreationTime txValidationTime) tx =
+timingsCheck (BlockCreationTime txValidationTime) lenientCreationTime tx =
     ttl > 0
     && txValidationTime >= timeFromSeconds 0
     && txOriginationTime >= 0
@@ -89,5 +93,21 @@ timingsCheck (BlockCreationTime txValidationTime) tx =
     (TTLSeconds ttl) = timeToLiveOf tx
     timeFromSeconds = Time . secondsToTimeSpan . Seconds . fromIntegral
     (TxCreationTime txOriginationTime) = creationTimeOf tx
-    lenientTxValidationTime = add s30 txValidationTime
-    s30 = scaleTimeSpan (30 :: Int) second
+    lenientTxValidationTime
+      | lenientCreationTime = add (scaleTimeSpan lenientTimeSlop second) txValidationTime
+      | otherwise = txValidationTime
+
+-- | Validation "slop" to allow for a more lenient creation time check after
+-- @useLegacyCreationTimeForTxValidation@ is no longer true.
+-- Without this, transactions showing up in the interim between
+-- parent block issuance and new block creation can get rejected; the tradeoff reduces
+-- the accuracy of the tx creation time vs "blockchain time", but is better than e.g.
+-- incurring artificial latency to wait for a parent block that is acceptable for a tx.
+-- 95 seconds represents the 99th percentile of block arrival times.
+lenientTimeSlop :: Seconds
+lenientTimeSlop = 95
+
+
+toTxCreationTime :: Time Micros -> TxCreationTime
+toTxCreationTime (Time timespan) =
+  TxCreationTime $ ParsedInteger $ fromIntegral $ timeSpanToSeconds timespan

--- a/src/Chainweb/Time.hs
+++ b/src/Chainweb/Time.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE NumericUnderscores #-}
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE DeriveGeneric #-}
@@ -81,8 +82,13 @@ module Chainweb.Time
 -- * Math, constants
 , add
 , diff
+, invert
 , kilo
 , mega
+
+-- * Formats
+, parseTimeMicros
+, formatTimeMicros
 ) where
 
 import Control.DeepSeq
@@ -101,6 +107,7 @@ import Data.Ratio
 import qualified Data.Text as T
 import Data.Time
 import Data.Time.Clock.POSIX
+import Data.Time.Clock.System
 import Data.Word
 
 import GHC.Generics
@@ -192,19 +199,38 @@ epoch = Time (TimeSpan 0)
 
 timeMicrosQQ :: QuasiQuoter
 timeMicrosQQ = QuasiQuoter
-    { quoteExp   = posixExp utcIso8601
+    { quoteExp   = posixExp
     , quotePat   = const $ error "No quotePat defined for timeMicrosQQ"
     , quoteType  = const $ error "No quoteType defined for timeMicrosQQ"
     , quoteDec   = const $ error "No quoteDec defined for timeMicrosQQ"
     }
   where
-    utcIso8601 = "%Y-%m-%dT%H:%M:%S%Q"
-    posixExp :: String -> String -> ExpQ
-    posixExp format input =
-        let u = parseTimeOrError True defaultTimeLocale format input :: UTCTime
-            p = utcTimeToPOSIXSeconds u
-            t = Time $ TimeSpan $ round $ p * 1000000 :: Time Micros
-        in t `seq` [| t |]
+    posixExp :: String -> ExpQ
+    posixExp input = case parseTimeMicros input of
+      Nothing -> error $ "Invalid time string: " ++ show input
+      Just t -> t `seq` [| t |]
+
+-- | Format for 'timeMicrosQQ'
+utcIso8601 :: String
+utcIso8601 = "%Y-%m-%dT%H:%M:%S%Q"
+
+-- | Parse 'utcIso8601' format as 'Time'
+parseTimeMicros :: String -> Maybe (Time Micros)
+parseTimeMicros input = case parseTimeM True defaultTimeLocale utcIso8601 input of
+  Nothing -> Nothing
+  Just u ->
+    let p = utcTimeToPOSIXSeconds u
+        t = Time $ TimeSpan $ round $ p * 1000000 :: Time Micros
+    in Just t
+
+-- | Format 'Time' in 'utcIso8601'
+formatTimeMicros :: Integral a => Time a -> String
+formatTimeMicros tm = formatISO $ timeToUTCTime tm
+  where
+    epochUTCTime = UTCTime systemEpochDay 0
+    formatISO = formatTime defaultTimeLocale utcIso8601
+    timeToNominalDiffTime (Time (TimeSpan m)) = fromInteger (fromIntegral m `div` 1_000_000)
+    timeToUTCTime t = addUTCTime (timeToNominalDiffTime t) epochUTCTime
 
 -- | Adhering to `Time`, this is the current number of microseconds since the
 -- epoch.

--- a/src/Chainweb/Time.hs
+++ b/src/Chainweb/Time.hs
@@ -312,11 +312,11 @@ day = TimeSpan $ mega * 24 * 3600
 -- -------------------------------------------------------------------------- --
 -- Seconds
 
-newtype Seconds = Seconds Integer
+newtype Seconds = Seconds Int64
     deriving (Show, Eq, Ord, Generic)
     deriving anyclass (Hashable, NFData)
     deriving newtype (FromJSON, ToJSON)
-    deriving newtype (Num, Enum, Real)
+    deriving newtype (Num, Enum, Real, Integral)
 
 secondsToTimeSpan :: Num a => Seconds -> TimeSpan a
 secondsToTimeSpan (Seconds s) = scaleTimeSpan s second

--- a/src/Chainweb/Version.hs
+++ b/src/Chainweb/Version.hs
@@ -41,7 +41,7 @@ module Chainweb.Version
 , vuln797Fix
 , coinV2Upgrade
 , pactBackCompat_v16
-, useCurrentHeaderCreationTimeForTxValidation
+, useLegacyCreationTimeForTxValidation
 -- ** BlockHeader Validation Guards
 , slowEpochGuard
 , skipFeatureFlagValidationGuard
@@ -645,13 +645,13 @@ pactBackCompat_v16 _ _ = False
 -- dependency of `newBlock` on the creation time of the current header can be
 -- removed.
 --
-useCurrentHeaderCreationTimeForTxValidation
+useLegacyCreationTimeForTxValidation
     :: ChainwebVersion
     -> BlockHeight
     -> Bool
-useCurrentHeaderCreationTimeForTxValidation Mainnet01 _ = True
-useCurrentHeaderCreationTimeForTxValidation Development h = h < 2000
-useCurrentHeaderCreationTimeForTxValidation _ h = h <= 1
+useLegacyCreationTimeForTxValidation Mainnet01 _ = True
+useLegacyCreationTimeForTxValidation Development h = h < 2000
+useLegacyCreationTimeForTxValidation _ h = h <= 1
     -- For most chainweb versions there is a large gap between creation times of
     -- the genesis blocks and the corresponding first blocks.
     --
@@ -727,4 +727,3 @@ skipFeatureFlagValidationGuard Mainnet01 _ = True
 skipFeatureFlagValidationGuard Development _ = True
 skipFeatureFlagValidationGuard Testnet04 _ = True
 skipFeatureFlagValidationGuard _ _ = False
-

--- a/test/Chainweb/Test/Pact/TTL.hs
+++ b/test/Chainweb/Test/Pact/TTL.hs
@@ -9,39 +9,17 @@
 {-# LANGUAGE TypeFamilies #-}
 
 module Chainweb.Test.Pact.TTL
-( tests
--- * Utils
-, Ctx(..)
-, withTestPact
-, mineMany
-, mineBlock
-, doNewBlock
-, doValidateBlock
-, runOne
--- ** MemPoolAccess
-, modAt
-, modAtTtl
-, offset
-, offsetTtl
-, ttl
-, mems
-) where
+( tests ) where
 
 import Control.Concurrent.MVar
+import Control.Lens (set)
 import Control.Monad
 import Control.Monad.Catch
 
-import Data.Aeson
 import Data.CAS.HashMap
-import Data.Text (Text)
 import Data.Tuple.Strict
 import qualified Data.Vector as V
 
-import NeatInterpolation
-
-import Numeric.Natural
-
-import Pact.ApiReq
 import Pact.Types.ChainMeta
 
 import System.LogLevel
@@ -61,6 +39,7 @@ import Chainweb.Pact.Backend.Types
 import Chainweb.Pact.Service.BlockValidation
 import Chainweb.Pact.Service.PactQueue
 import Chainweb.Pact.Service.Types
+import Chainweb.Pact.Utils (lenientTimeSlop)
 import Chainweb.Payload
 import Chainweb.Payload.PayloadStore
 import Chainweb.Test.Pact.Utils
@@ -102,7 +81,8 @@ tests = ScheduledTest "Chainweb.Test.Pact.TTL" $
     withBlockHeaderDb rocksIO genblock $ \bdbIO ->
     testGroup "timing tests"
         [ withTestPact testVer pdbIO bdbIO testTxTime
-        , withTestPact testVer pdbIO bdbIO testTxTimeFail
+        , withTestPact testVer pdbIO bdbIO testTxTimeLenient
+        , withTestPact testVer pdbIO bdbIO testTxTimeFail1
         , withTestPact testVer pdbIO bdbIO testTxTimeFail2
         , withTestPact testVer pdbIO bdbIO testTtlTooLarge
         , withTestPact testVer pdbIO bdbIO testTtlSmall
@@ -112,7 +92,7 @@ tests = ScheduledTest "Chainweb.Test.Pact.TTL" $
         , withTestPact testVer pdbIO bdbIO testJustMadeItLarge
 
         -- This tests can be removed once the transition is complete and the guard
-        -- @useCurrentHeaderCreationTimeForTxValidation@ is false for all new blocks
+        -- @useLegacyCreationTimeForTxValidation@ is false for all new blocks
         -- of all chainweb versions.
         --
         , testGroup "mainnet transition to new timing checks"
@@ -129,6 +109,8 @@ tests = ScheduledTest "Chainweb.Test.Pact.TTL" $
 -- -------------------------------------------------------------------------- --
 -- Tests
 
+
+
 testTxTime :: IO Ctx -> TestTree
 testTxTime ctxIO =
     testCase "tx time of parent time and default ttl pass validation" $ do
@@ -136,11 +118,17 @@ testTxTime ctxIO =
         T2 hdr2 _ <- mineBlock ctxIO (offset 0) (ParentHeader hdr1) (Nonce 1) 1
         void $ mineBlock ctxIO (offset (-1)) (ParentHeader hdr2) (Nonce 2) 1
 
-testTxTimeFail :: IO Ctx -> TestTree
-testTxTimeFail ctxIO =
-    testCase "tx time of parent time + 1 and default ttl fails during new block validation" $ do
+testTxTimeLenient :: IO Ctx -> TestTree
+testTxTimeLenient ctxIO =
+    testCase "testTxTimeLenient: tx time of parent time + slop and default ttl succeeds during new block validation" $ do
         T2 hdr _ <- mineBlock ctxIO mempty (ParentHeader genblock) (Nonce 1) 1
-        assertDoPreBlockFailure $ doNewBlock ctxIO (offset 1) (ParentHeader hdr) (Nonce 2) 1
+        void $ doNewBlock ctxIO (offset lenientTimeSlop) (ParentHeader hdr) (Nonce 2) 1
+
+testTxTimeFail1 :: IO Ctx -> TestTree
+testTxTimeFail1 ctxIO =
+    testCase "testTxTimeFail1: tx time of parent time + slop + 1 and default ttl fails during new block validation" $ do
+        T2 hdr _ <- mineBlock ctxIO mempty (ParentHeader genblock) (Nonce 1) 1
+        assertDoPreBlockFailure $ doNewBlock ctxIO (offset (succ lenientTimeSlop)) (ParentHeader hdr) (Nonce 2) 1
 
 testTxTimeFail2 :: IO Ctx -> TestTree
 testTxTimeFail2 ctxIO =
@@ -156,7 +144,7 @@ testTtlTooLarge ctxIO =
 
 testTtlSmall :: IO Ctx -> TestTree
 testTtlSmall ctxIO =
-    testCase "small TTL passes validation" $ do
+    testCase "testTtlSmall: small TTL passes validation" $ do
         T2 hdr _ <- mineBlock ctxIO mempty (ParentHeader genblock) (Nonce 1) 1
         void $ doNewBlock ctxIO (ttl 5) (ParentHeader hdr) (Nonce 2) 1
 
@@ -187,10 +175,10 @@ testJustMadeItLarge ctxIO =
 -- -------------------------------------------------------------------------- --
 -- Mainnet transition to new timing checks
 --
--- @useCurrentHeaderCreationTimeForTxValidation@ is @True@.
+-- @useLegacyCreationTimeForTxValidation@ is @True@.
 --
 -- The tests in this section may be removed once the transition is complete and
--- the guard @useCurrentHeaderCreationTimeForTxValidation@ is false for all new
+-- the guard @useLegacyCreationTimeForTxValidation@ is false for all new
 -- blocks of all chainweb versions. Some tests actually must be removed.
 --
 
@@ -220,7 +208,7 @@ testExpiredTight2 ctxIO =
         assertDoPreBlockFailure $ doNewBlock ctxIO (offsetTtl (-1000) 1000) (ParentHeader hdr') (Nonce 2) 1
 
 -- This code must be removed once the transition is complete and the guard
--- @useCurrentHeaderCreationTimeForTxValidation@ is false for all new blocks
+-- @useLegacyCreationTimeForTxValidation@ is false for all new blocks
 -- of all chainweb versions.
 --
 testExpiredExtraTight :: IO Ctx -> TestTree
@@ -230,7 +218,7 @@ testExpiredExtraTight ctxIO =
         void $ doNewBlock ctxIO (offsetTtl (179 -1000) 1000) (ParentHeader hdr) (Nonce 2) 1
 
 -- This code must be removed once the transition is complete and the guard
--- @useCurrentHeaderCreationTimeForTxValidation@ is false for all new blocks
+-- @useLegacyCreationTimeForTxValidation@ is false for all new blocks
 -- of all chainweb versions.
 --
 testExpiredExtraTight2 :: IO Ctx -> TestTree
@@ -257,109 +245,43 @@ testJustMadeIt3 ctxIO =
 -- -------------------------------------------------------------------------- --
 -- Mempool Access
 
--- | Provide mempool access for the respective block height. Default is mempty.
--- The list starts with block height 1.
---
-mems :: [MemPoolAccess] -> MemPoolAccess
-mems l = mempty
-    { mpaGetBlock = \v bh -> case drop (int bh - 1) l of
-        [] -> mpaGetBlock mempty v bh
-        (h:_) -> mpaGetBlock h v bh
-    }
-
 -- Mempool access implementations that provide transactions with different
 -- values for creation time and TTL.
 
+-- | Use parent block time for tx creation time, change ttl.
 ttl :: Seconds -> MemPoolAccess
 ttl = modAtTtl id
 
+-- | Offset tx creation time relative to parent block time, use default ttl.
 offset :: Seconds -> MemPoolAccess
 offset = modAt . add . secondsToTimeSpan
 
+-- | Offset tx creation time relative to parent block time, AND set ttl.
 offsetTtl :: Seconds -> Seconds -> MemPoolAccess
-offsetTtl = modAtTtl . add . secondsToTimeSpan
+offsetTtl off ttl' = modAtTtl (add (secondsToTimeSpan off)) ttl'
 
--- at :: Time Micros -> MemPoolAccess
--- at =  modAt . const
-
+-- | Set tx creation time relative to parent block time, use default ttl.
 modAt :: (Time Micros -> Time Micros) -> MemPoolAccess
 modAt f = modAtTtl f defTtl
 
 modAtTtl :: (Time Micros -> Time Micros) -> Seconds -> MemPoolAccess
 modAtTtl f (Seconds t) = mempty
     { mpaGetBlock = \validate bh hash parentHeader -> do
-        akp0 <- stockKey sender
-        kp0 <- mkKeyPairs [akp0]
-        let nonce = sshow bh
-            txTime = toTxCreationTime $ f $ _bct $ _blockCreationTime parentHeader
-            tx = V.singleton $ PactTransaction (defModule nonce) (Just $ ksData nonce)
+        let txTime = toTxCreationTime $ f $ _bct $ _blockCreationTime parentHeader
             tt = TTLSeconds (int t)
-        -- putStrLn $ "\nmpaGetBlock:"
-        --     <> "\nparentTime: " <> sshow (_blockCreationTime parentHeader)
-        --     <> "\nheight: " <> sshow bh
-        --     <> "\ntxTime: " <> sshow txTime
-        outtxs <- mkTestExecTransactions sender "0" kp0 nonce 10_000 0.000_000_000_01 tt txTime tx
+        outtxs <- fmap V.singleton $ buildCwCmd
+          $ set cbCreationTime txTime
+          $ set cbTTL tt
+          $ set cbSigners [mkSigner' sender00 []]
+          $ mkCmd (sshow bh)
+          $ mkExec' "1"
+
         unlessM (and <$> validate bh hash outtxs) $ throwM DoPreBlockFailure
         return outtxs
     }
-  where
-    sender = "sender00"
-    ksData idx = object
-        [ ("k" <> idx) .= object
-            [ "keys" .= ([] :: [Text])
-            , "pred" .= String ">="
-            ]
-        ]
-
-    defModule :: Text -> Text
-    defModule idx = [text| ;;
-        (define-keyset 'k$idx (read-keyset 'k$idx))
-
-        (module m$idx 'k$idx
-
-        (defschema sch col:integer)
-
-        (deftable tbl:{sch})
-
-        (defun insertTbl (a i)
-            (insert tbl a { 'col: i }))
-
-        (defun updateTbl (a i)
-            (update tbl a { 'col: i}))
-
-        (defun readTbl ()
-            (sort (map (at 'col)
-            (select tbl (constantly true)))))
-
-        (defpact dopact (n)
-            (step { 'name: n, 'value: 1 })
-            (step { 'name: n, 'value: 2 }))
-
-        )
-        (create-table tbl)
-        (readTbl)
-        (insertTbl "a" 1)
-    |]
 
 -- -------------------------------------------------------------------------- --
 -- Block Validation
-
-mineMany
-    :: IO Ctx
-    -> MemPoolAccess
-    -> ParentHeader
-    -> Nonce
-    -> Seconds
-        -- ^ Block time
-    -> Natural
-    -> IO (T2 BlockHeader PayloadWithOutputs)
-mineMany ctxIO mempool parentHeader (Nonce nonce) s n = go (int n) parentHeader
-  where
-    go i h = do
-        T2 h' p <- mineBlock ctxIO mempool h (Nonce $ nonce + i) s
-        if i > 1
-            then go (i-1) $ ParentHeader h'
-            else return (T2 h' p)
 
 mineBlock
     :: IO Ctx
@@ -414,18 +336,9 @@ doValidateBlock
     -> IO ()
 doValidateBlock ctxIO header payload = do
     ctx <- ctxIO
-    _mv' <- validateBlock header (toPayloadData payload) $ _ctxQueue ctx
+    _mv' <- validateBlock header (payloadWithOutputsToPayloadData payload) $ _ctxQueue ctx
     addNewPayload (_ctxPdb ctx) payload
     insert (_ctxBdb ctx) header
-  where
-    toPayloadData :: PayloadWithOutputs -> PayloadData
-    toPayloadData d = PayloadData
-        { _payloadDataTransactions = fst <$> _payloadWithOutputsTransactions d
-        , _payloadDataMiner = _payloadWithOutputsMiner d
-        , _payloadDataPayloadHash = _payloadWithOutputsPayloadHash d
-        , _payloadDataTransactionsHash = _payloadWithOutputsTransactionsHash d
-        , _payloadDataOutputsHash = _payloadWithOutputsOutputsHash d
-        }
 
 -- -------------------------------------------------------------------------- --
 -- Misc Utils
@@ -472,11 +385,3 @@ withTestPact v pdbIO bdbIO test = withTemporaryDir $ \dirIO ->
 assertNotLeft :: (MonadThrow m, Exception e) => Either e a -> m a
 assertNotLeft (Left l) = throwM l
 assertNotLeft (Right r) = return r
-
-runOne :: (IO Ctx -> TestTree) -> IO ()
-runOne t = defaultMain $
-    withRocksResource $ \rocksIO ->
-    withPayloadDb $ \pdbIO ->
-    withBlockHeaderDb rocksIO genblock $ \bdbIO ->
-    withTestPact testVer pdbIO bdbIO $ \ctxIO ->
-    t ctxIO

--- a/test/Chainweb/Test/Pact/Utils.hs
+++ b/test/Chainweb/Test/Pact/Utils.hs
@@ -161,7 +161,6 @@ import Test.Tasty
 
 import Pact.ApiReq (ApiKeyPair(..), mkKeyPairs)
 import Pact.Gas
-import Pact.Parse
 import Pact.Types.Capability
 import qualified Pact.Types.ChainId as P
 import Pact.Types.ChainMeta
@@ -831,8 +830,7 @@ decodeKey :: ByteString -> ByteString
 decodeKey = fst . B16.decode
 
 toTxCreationTime :: Integral a => Time a -> TxCreationTime
-toTxCreationTime (Time timespan) = case timeSpanToSeconds timespan of
-          Seconds s -> TxCreationTime $ ParsedInteger s
+toTxCreationTime (Time timespan) = TxCreationTime $ fromIntegral $ timeSpanToSeconds timespan
 
 withPayloadDb :: (IO (PayloadDb HashMapCas) -> TestTree) -> TestTree
 withPayloadDb = withResource newPayloadDb mempty

--- a/tools/ea/Ea.hs
+++ b/tools/ea/Ea.hs
@@ -56,6 +56,7 @@ import Chainweb.Logger (genericLogger)
 import Chainweb.Miner.Pact (noMiner)
 import Chainweb.Pact.PactService
 import Chainweb.Pact.Types (defaultPactServiceConfig)
+import Chainweb.Pact.Utils (toTxCreationTime)
 import Chainweb.Payload.PayloadStore.InMemory
 import Chainweb.Time
 import Chainweb.Transaction
@@ -64,7 +65,6 @@ import Chainweb.Utils
 import Chainweb.Version (ChainwebVersion(..), someChainId)
 
 import Pact.ApiReq (mkApiReq)
-import Pact.Parse
 import Pact.Types.ChainMeta
 import Pact.Types.Command hiding (Payload)
 
@@ -183,9 +183,6 @@ mkChainwebTxs txFiles = do
   where
     setTxTime = set (cmdPayload . pMeta . pmCreationTime)
     setTTL = set (cmdPayload . pMeta . pmTTL)
-    toTxCreationTime :: Time Integer -> TxCreationTime
-    toTxCreationTime (Time timespan) = case timeSpanToSeconds timespan of
-      Seconds s -> TxCreationTime $ ParsedInteger s
 
 encodeJSON :: ToJSON a => a -> ByteString
 encodeJSON = BL.toStrict . encodePretty' (defConfig { confCompare = compare })


### PR DESCRIPTION
The current issue we face is, due to using parent time for transaction validation, the following scenario fails:

1. Parent time: 00:00:00
2. Tx time: 00:00:15
3. New block time: 00:00:30

The transaction will not be accepted, even though the tx time is fully valid. It is rejected in `timingsCheck`, specifically that the tx creation time is strictly before the `txValidationTime` (https://github.com/kadena-io/chainweb-node/blob/ea1c8d1c5759d79b455efb2c625320cd12aeebbf/src/Chainweb/Pact/Utils.hs#L85), in all three places:

- pre-insert check into mempool (txValidationTime == parentHeader time)
- new-block validation (txValidationTime == parentHeader time)
- validate-block validation (txValidationTime == parentHeader time)

This PR proposes the following solution:

1. Pre-insert check uses current time for `txValidationTime`
2. BOTH new-block and validate-block adds 30s leniency to the parent block `txValidationTime` time by 30s. (NB: this probably needs to be behind the legacy switch though for old blocks?)

The test that covers this is `mempoolCreationTimeTest` in `PactInProcAPI`. I have not fixed TTL test yet or other tests, as I want to review this approach first.
 

