### PR TITLE
compute epoch time based on parent header

### DIFF
--- a/src/Chainweb/Version.hs
+++ b/src/Chainweb/Version.hs
@@ -44,6 +44,7 @@ module Chainweb.Version
 , useLegacyCreationTimeForTxValidation
 -- ** BlockHeader Validation Guards
 , slowEpochGuard
+, oldTargetGuard
 , skipFeatureFlagValidationGuard
 
 -- * Typelevel ChainwebVersion
@@ -707,6 +708,20 @@ slowEpochGuard
 slowEpochGuard Mainnet01 h = h < 80000
 slowEpochGuard _ _ = False
 {-# INLINE slowEpochGuard #-}
+
+-- | Use the current block time for computing epoch start date and
+-- target.
+--
+-- When this guard is switched off, there will be a single epoch of just 119
+-- blocks. The target computation won't compensate for that, since the effects
+-- are marginal.
+--
+oldTargetGuard :: ChainwebVersion -> BlockHeight -> Bool
+oldTargetGuard Mainnet01 _ = True
+oldTargetGuard Testnet04 _ = True
+oldTargetGuard Development h = h < 2000
+oldTargetGuard _ _ = False
+{-# INLINE oldTargetGuard #-}
 
 -- | Skip validation of feature flags.
 --

--- a/src/Chainweb/Version.hs
+++ b/src/Chainweb/Version.hs
@@ -719,7 +719,7 @@ slowEpochGuard _ _ = False
 oldTargetGuard :: ChainwebVersion -> BlockHeight -> Bool
 oldTargetGuard Mainnet01 _ = True
 oldTargetGuard Testnet04 _ = True
-oldTargetGuard Development h = h < 2000
+oldTargetGuard Development h = h < 360
 oldTargetGuard _ _ = False
 {-# INLINE oldTargetGuard #-}
 


### PR DESCRIPTION
This shifts the computation of the epoch time back one block, so that the computation of the target doesn’t depend on the creation time of the current block.

Legacy behavior is guarded by `oldTargetGuard` and switched on for `Mainnet01` and `Testnet04`. It's on for `Development` for block `< 360`.

When the guard switches of there is one epoch that has only 119 blocks. There is no need to adjust target computation, because change in the overall epoch time are minimal.