### PR TITLE
Switch flags and nonce in Merke tree

### DIFF
--- a/.github/workflows/applications.yml
+++ b/.github/workflows/applications.yml
@@ -89,7 +89,7 @@ jobs:
           echo "Inconsistent genesis headers detected. Did you forget to run ea?" 1>&2
           exit 1
         fi
-        
+
   run-benchmarks:
     name: Run benchmarks
     needs: [build]

--- a/src/Chainweb/BlockHeader/Genesis.hs
+++ b/src/Chainweb/BlockHeader/Genesis.hs
@@ -185,7 +185,7 @@ genesisBlockHeader' v p ct@(BlockCreationTime t) n = fromLog mlog
     cid = _chainId p
 
     mlog = newMerkleLog
-        $ n
+        $ mkFeatureFlags
         :+: ct
         :+: genesisParentBlockHash v cid
         :+: genesisBlockTarget
@@ -195,7 +195,7 @@ genesisBlockHeader' v p ct@(BlockCreationTime t) n = fromLog mlog
         :+: BlockHeight 0
         :+: v
         :+: EpochStartTime t
-        :+: mkFeatureFlags
+        :+: n
         :+: MerkleLogBody (blockHashRecordToVector adjParents)
     adjParents = BlockHashRecord $ HM.fromList $
         (\c -> (c, genesisParentBlockHash v c)) <$> HS.toList (adjacentChainIds g p)

--- a/src/Chainweb/Crypto/MerkleLog.hs
+++ b/src/Chainweb/Crypto/MerkleLog.hs
@@ -564,15 +564,16 @@ bodySize = V.length . body
 
 -- | Compute the Merkle root hash for an instance of 'HasMerkleLog'.
 --
--- @merkleLogHash b@ computes the merkle tree, which is linear in the size of
--- the @b@. For large logs the hash or the full 'MerkleTree' should e cached.
+-- This computes the merkle log and forces the merkle tree, which is linear in
+-- the size of the @b@. For large logs the hash or the full 'MerkleTree' should
+-- be cached.
 --
 computeMerkleLogRoot
     :: forall u b
     . HasMerkleLog u b
     => b
     -> MerkleRoot (HashAlg u)
-computeMerkleLogRoot b = _merkleLogRoot @u (toLog @u b)
+computeMerkleLogRoot = merkleRoot . _merkleLogTree . toLog @u
 {-# INLINE computeMerkleLogRoot #-}
 
 -- -------------------------------------------------------------------------- --

--- a/src/Chainweb/MerkleUniverse.hs
+++ b/src/Chainweb/MerkleUniverse.hs
@@ -63,7 +63,7 @@ instance MerkleUniverse ChainwebHashTag where
     type MerkleTagVal ChainwebHashTag 'BlockHeightTag = 0x0003
     type MerkleTagVal ChainwebHashTag 'BlockWeightTag = 0x0004
     type MerkleTagVal ChainwebHashTag 'BlockPayloadHashTag = 0x0005
-    type MerkleTagVal ChainwebHashTag 'BlockNonceTag = 0x0006
+    type MerkleTagVal ChainwebHashTag 'FeatureFlagsTag = 0x0006
     type MerkleTagVal ChainwebHashTag 'BlockCreationTimeTag = 0x0007
     type MerkleTagVal ChainwebHashTag 'ChainwebVersionTag = 0x0008
     type MerkleTagVal ChainwebHashTag 'PowHashTag = 0x0009
@@ -76,7 +76,7 @@ instance MerkleUniverse ChainwebHashTag where
     type MerkleTagVal ChainwebHashTag 'MinerDataTag = 0x0017
     type MerkleTagVal ChainwebHashTag 'CoinbaseOutputTag = 0x0018
     type MerkleTagVal ChainwebHashTag 'EpochStartTimeTag = 0x0019
-    type MerkleTagVal ChainwebHashTag 'FeatureFlagsTag = 0x0020
+    type MerkleTagVal ChainwebHashTag 'BlockNonceTag = 0x00020
 
 instance IsMerkleLogEntry ChainwebHashTag Void where
     type Tag Void = 'VoidTag

--- a/src/Chainweb/SPV/CreateProof.hs
+++ b/src/Chainweb/SPV/CreateProof.hs
@@ -152,7 +152,7 @@ transactionProofPrefix i db payload = do
 
     -- 2. Payload proof
     let !proof = tree N.:| [headerTree_ @BlockTransactionsHash payload]
-    return $! (subj, proof)
+    return (subj, proof)
   where
     cas = _transactionDbBlockTransactions $ _transactionDb db
 
@@ -190,6 +190,7 @@ createTransactionOutputProof cutDb tcid scid bh i =
 
 
 -- | Version without CutDb dependency
+--
 createTransactionOutputProof_
     :: HasCallStack
     => PayloadCas cas
@@ -254,7 +255,7 @@ outputProofPrefix i db payload = do
 
     -- 2. Payload proof
     let !proof = tree N.:| [headerTree_ @BlockOutputsHash payload]
-    return $! (subj, proof)
+    return (subj, proof)
   where
     cas = _payloadCacheBlockOutputs $ _payloadCache db
 

--- a/test/Chainweb/Test/BlockHeader/Validation.hs
+++ b/test/Chainweb/Test/BlockHeader/Validation.hs
@@ -42,6 +42,8 @@ import Chainweb.Version
 tests :: TestTree
 tests = testGroup "Chainweb.Test.Blockheader.Validation"
     [ prop_validateMainnet
+    , prop_validateTestnet04
+    , prop_fail_validateTestnet04
     , prop_featureFlag (Test petersonChainGraph) 10
     ]
 
@@ -91,6 +93,15 @@ prop_validateMainnet = testCase "validate Mainnet01 BlockHeaders" $ do
         [] -> return ()
         errs -> assertFailure $ "Validation failed for mainnet BlockHeader: " <> sshow errs
 
+prop_validateTestnet04 :: TestTree
+prop_validateTestnet04 = testCase "validate Testnet04 BlockHeaders" $ do
+    now <- getCurrentTimeIntegral
+    traverse_ (f now) testnet04Headers
+  where
+    f t (p, h) = case validateBlockHeader t p h of
+        [] -> return ()
+        errs -> assertFailure $ "Validation failed for testnet04 BlockHeader: " <> sshow errs
+
 -- -------------------------------------------------------------------------- --
 -- Rules are applied
 --
@@ -101,6 +112,22 @@ prop_validateMainnet = testCase "validate Mainnet01 BlockHeaders" $ do
 -- partiular rule. In paritcular the hashes (including proof of work hashes)
 -- would have to be valid.
 --
+
+prop_fail_validateTestnet04 :: TestTree
+prop_fail_validateTestnet04 = testCase "validate invalid Testnet04 BlockHeaders" $ do
+    now <- getCurrentTimeIntegral
+    traverse_ (f now) testnet04InvalidHeaders
+  where
+    f t (p, h, expectedErrs) = case validateBlockHeader t p h of
+        [] -> assertFailure $ "Validation succeeded unexpectedly for testnet04 BlockHeader"
+        errs
+            | errs /= expectedErrs -> assertFailure
+                $ "Validation failed with expectedly errors for testnet04 BlockHeader"
+                <> ", expected: " <> sshow expectedErrs
+                <> ", actual: " <> sshow errs
+                <> ", parent: " <> sshow (_blockHash $ _parentHeader p)
+                <> ", header: " <> sshow (_blockHash h)
+        _ -> return () -- FIXME be more specific
 
 -- -------------------------------------------------------------------------- --
 -- Tests for Rule Guards:
@@ -143,3 +170,79 @@ mainnet01Headers = gens <> some
         )
 
     wrap x = "\"" <> x <> "\""
+
+testnet04Headers :: [(ParentHeader, BlockHeader)]
+testnet04Headers = gens <> some
+  where
+    v = Testnet04
+    f = bitraverse (fmap ParentHeader . decode . wrap) (decode . wrap)
+
+    -- Some BlockHeader from the existing testnet04 history
+    --
+    some = fromJuste $ traverse f
+        [
+            ( "UV8kAAAAAADFZ2HwFKIFAJ8hgfl2LV_uh846M6v-KHp6ZI3zNOpeObct-K0miL3cAwACAAAAPtJw9_WRladZJhKDhIEx1WgjkofJISyqBnMNNvDfV84DAAAAWWbE_Gg8T20vfB1m5mLM0NllvjvgMRWL8xhCocLZY8YFAAAA7Xlzumy_WTzT1ROEHzzgWeO8n0s2Gf9zUUZCTFhy3qcdkFWkKuxR9s23eB6QAmTYoypdZ7yQb1br40-e6wAAAL6LzuBDgWv0dp05UPLapBb2H4Y7BjA_tIiHRTAiEvLsAAAAABvmlwZDBgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFkMEAAAAAAAHAAAA8vSPcRSiBQAAAAAAAAAAALIlKMBoOzx3whNCrI2jyEJycC7wNqkYGZ90ZpAItzON"
+            , "tjsXAAAAAAC-IonwFKIFALIlKMBoOzx3whNCrI2jyEJycC7wNqkYGZ90ZpAItzONAwACAAAAyGznxkEiOfo6OHftd86_8aA8B55QaQSiD7f5insUMB4DAAAAPKSjwRZc6V_SJW1AbBwZcnkZ1WbRdKrtN4BnJ0q1RpkFAAAAJv6AJtHEaBuFZpIpdePX7s2uN8n7QhFvNPkX70uZduMdkFWkKuxR9s23eB6QAmTYoypdZ7yQb1br40-e6wAAAAFCpo3PF6aH1bHhB27DlDGt8aiyip06XzMWRcgUEHi2AAAAACMLrgdDBgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAF0MEAAAAAAAHAAAA8vSPcRSiBQAAAAAAAAAAALl0CaPBMj5a0QhuIKtJD6zYj1BxWuoKg-X8ASzosri7"
+            )
+        ,
+            ( "y4tiAAAAAAAHezeiFaIFACW5ko6NcfOLAWkPn_OvkFM96koE5tW3fWQwkCyT4afUAwACAAAAMakQZiB62qyknHkdlP0DLzjSpd1653qL8nB7rWJxHVwDAAAAm2G92tcXE2OzcjBFKspFjvArlZbl569wSOJzkUUF43sFAAAAvFp87JmhlHTDew_3ZdjnnC66wk3QyjMCU97aZu4NJlrks51YNN7Lha7sjUawYooNyn282AybfunTUycy3AAAAHr2DqwHXi_8tQqe7DnKDwT402x49iKC60WmjSmNKfA1AAAAAL9h5XhDBgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAe0MEAAAAAAAHAAAAmgYYOhWiBQAAAAAAAAAAAFsrsuyzBE9_xH67B7uDI9kiraA0zLkkzH3mgLTKrQCt"
+            , "l0PGAAAAAABmKWCkFaIFAFsrsuyzBE9_xH67B7uDI9kiraA0zLkkzH3mgLTKrQCtAwACAAAAfYN1Qs9Ua_QGfgpBcgeBZ0J6xhQ4XXlqv_gfYA-hOc0DAAAAsGNf8lbXT-HgPD-cFNdXSkD-ODvcY6ihMwvPbRjvj4cFAAAAzmducVsWbMyG6lvO8nQKcJnVh8cgrOS-gnbOMP9WxKvks51YNN7Lha7sjUawYooNyn282AybfunTUycy3AAAAGWxPTtpx32AN0mr4Ee3fQErWyEwQytnF9-OP4O280R8AAAAAPgBD3pDBgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfEMEAAAAAAAHAAAAmgYYOhWiBQAAAAAAAAAAAHYVlldEu5EIBSMHw-7F7xi8KYMv5SjvTjo1f1X-Gyol"
+            )
+        ]
+
+    -- All genesis headers
+    gens = flip fmap (toList $ chainIds v) $ \cid ->
+        ( ParentHeader $ genesisBlockHeader v cid
+        , genesisBlockHeader v cid
+        )
+
+    wrap x = "\"" <> x <> "\""
+
+testnet04InvalidHeaders :: [(ParentHeader, BlockHeader, [ValidationFailureType])]
+testnet04InvalidHeaders = some
+  where
+    f (p, h, e) = (,,)
+        <$> (fmap ParentHeader . decode . wrap) p
+        <*> (decode . wrap) h
+        <*> pure e
+
+    wrap x = "\"" <> x <> "\""
+
+    some = fromJuste $ traverse f
+        [
+            ( "UV8kAAAAAADFZ2HwFKIFAJ8hgfl2LV_uh846M6v-KHp6ZI3zNOpeObct-K0miL3cAwACAAAAPtJw9_WRladZJhKDhIEx1WgjkofJISyqBnMNNvDfV84DAAAAWWbE_Gg8T20vfB1m5mLM0NllvjvgMRWL8xhCocLZY8YFAAAA7Xlzumy_WTzT1ROEHzzgWeO8n0s2Gf9zUUZCTFhy3qcdkFWkKuxR9s23eB6QAmTYoypdZ7yQb1br40-e6wAAAL6LzuBDgWv0dp05UPLapBb2H4Y7BjA_tIiHRTAiEvLsAAAAABvmlwZDBgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFkMEAAAAAAAHAAAA8vSPcRSiBQAAAAAAAAAAALIlKMBoOzx3whNCrI2jyEJycC7wNqkYGZ90ZpAItzON"
+            , "ajsXAAAAAAC-IonwFKIFALIlKMBoOzx3whNCrI2jyEJycC7wNqkYGZ90ZpAItzONAwACAAAAyGznxkEiOfo6OHftd86_8aA8B55QaQSiD7f5insUMB4DAAAAPKSjwRZc6V_SJW1AbBwZcnkZ1WbRdKrtN4BnJ0q1RpkFAAAAJv6AJtHEaBuFZpIpdePX7s2uN8n7QhFvNPkX70uZduMdkFWkKuxR9s23eB6QAmTYoypdZ7yQb1br40-e6wAAAAFCpo3PF6aH1bHhB27DlDGt8aiyip06XzMWRcgUEHi2AAAAACMLrgdDBgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAF0MEAAAAAAAHAAAA8vSPcRSiBQAAAAAAAAAAALl0CaPBMj5a0QhuIKtJD6zYj1BxWuoKg-X8ASzosri7"
+            , [IncorrectHash, IncorrectPow]
+            )
+        ,
+            ( "y4tiAAAAAAAHezeiFaIFACW5ko6NcfOLAWkPn_OvkFM96koE5tW3fWQwkCyT4afUAwACAAAAMakQZiB62qyknHkdlP0DLzjSpd1653qL8nB7rWJxHVwDAAAAm2G92tcXE2OzcjBFKspFjvArlZbl569wSOJzkUUF43sFAAAAvFp87JmhlHTDew_3ZdjnnC66wk3QyjMCU97aZu4NJlrks51YNN7Lha7sjUawYooNyn282AybfunTUycy3AAAAHr2DqwHXi_8tQqe7DnKDwT402x49iKC60WmjSmNKfA1AAAAAL9h5XhDBgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAe0MEAAAAAAAHAAAAmgYYOhWiBQAAAAAAAAAAAFsrsuyzBE9_xH67B7uDI9kiraA0zLkkzH3mgLTKrQCt"
+            , "l0PGAAAAAABmKWCkFaIFAFsrsuyzBE9_xH67B7uDI9kiraA0zLkkzH3mgLTKrQCtAwACAAAAfYN1Qs9Ua_QGfgpBcgeBZ0J6xhQ4XXlqv_gfYA-hOc0DAAAAsGNf8lbXT-HgPD-cFNdXSkD-ODvcY6ihMwvPbRjvj4cFAAAAzmducVsWbMyG6lvO8nQKcJnVh8cgrOS-gnbOMP9WxKvks51YNN7Lha7sjUawYooNyn282AybfunTUycy3AAAAGWxPTtpx32AN0mr4Ee3fQErWyEwQytnF9-OP4O280R8AAAAAPgBD3pDBgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfEMEAAAAAAAHAAAAmgYYOhWiBQAAAAAAAAAAAHYVlldEu5EIBSMHw-7F7xi8KYMv5SjvTjo1f1X-Gyoa"
+            , [IncorrectHash]
+            )
+        ,
+            ( "l0PGAAAAAABmKWCkFaIFAFsrsuyzBE9_xH67B7uDI9kiraA0zLkkzH3mgLTKrQCtAwACAAAAfYN1Qs9Ua_QGfgpBcgeBZ0J6xhQ4XXlqv_gfYA-hOc0DAAAAsGNf8lbXT-HgPD-cFNdXSkD-ODvcY6ihMwvPbRjvj4cFAAAAzmducVsWbMyG6lvO8nQKcJnVh8cgrOS-gnbOMP9WxKvks51YNN7Lha7sjUawYooNyn282AybfunTUycy3AAAAGWxPTtpx32AN0mr4Ee3fQErWyEwQytnF9-OP4O280R8AAAAAPgBD3pDBgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfEMEAAAAAAAHAAAAmgYYOhWiBQAAAAAAAAAAAHYVlldEu5EIBSMHw-7F7xi8KYMv5SjvTjo1f1X-Gyol"
+            , "l0PGAAAAAABmKWCkFaIFAFsrsuyzBE9_xH67B7uDI9kiraA0zLkkzH3mgLTKrQCtAwACAAAAfYN1Qs9Ua_QGfgpBcgeBZ0J6xhQ4XXlqv_gfYA-hOc0DAAAAsGNf8lbXT-HgPD-cFNdXSkD-ODvcY6ihMwvPbRjvj4cFAAAAzmducVsWbMyG6lvO8nQKcJnVh8cgrOS-gnbOMP9WxKvks51YNN7Lha7sjUawYooNyn282AybfunTUycy3AAAAGWxPTtpx32AN0mr4Ee3fQErWyEwQytnF9-OP4O280R8AAAAAPgBD3pDBgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfEMEAAAAAAAHAAAAmgYYOhWiBQAAAAAAAAAAAHYVlldEu5EIBSMHw-7F7xi8KYMv5SjvTjo1f1X-Gyol"
+            , [IncorrectHeight, CreatedBeforeParent, IncorrectWeight]
+            )
+        ,
+            ( "y4tiAAAAAAAHezeiFaIFACW5ko6NcfOLAWkPn_OvkFM96koE5tW3fWQwkCyT4afUAwACAAAAMakQZiB62qyknHkdlP0DLzjSpd1653qL8nB7rWJxHVwDAAAAm2G92tcXE2OzcjBFKspFjvArlZbl569wSOJzkUUF43sFAAAAvFp87JmhlHTDew_3ZdjnnC66wk3QyjMCU97aZu4NJlrks51YNN7Lha7sjUawYooNyn282AybfunTUycy3AAAAHr2DqwHXi_8tQqe7DnKDwT402x49iKC60WmjSmNKfA1AAAAAL9h5XhDBgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAe0MEAAAAAAAHAAAAmgYYOhWiBQAAAAAAAAAAAFsrsuyzBE9_xH67B7uDI9kiraA0zLkkzH3mgLTKrQCt"
+            , "l0PGAAAAAABmKWCkFaIFAFsrsuyzBE9_xH67B7uDI9kiraA0zLkkzH3mgLTKrQCtAwACAAAAfYN1Qs9Ua_QGfgpBcgeBZ0J6xhQ4XXlqv_gfYA-hOc0DAAAAsGNf8lbXT-HgPD-cFNdXSkD-ODvcY6ihMwvPbRjvj4cFAAAAzmducVsWbMyG6lvO8nQKcJnVh8cgrOS-gnbOMP9WxKvks51YNN7Lha7sjUawYooNyn282AybfunTUycy3AAAAGWxPTtpx32AN0mr4Ee3fQErWyEwQytnF9-OP4O280R8AAAAAPgBD3pDBgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfEMEAAAAAAAHAAAAmgYAOhWiBQAAAAAAAAAAAHYVlldEu5EIBSMHw-7F7xi8KYMv5SjvTjo1f1X-Gyol"
+            , [IncorrectHash, IncorrectPow, IncorrectEpoch]
+            )
+        ,
+            ( "y4tiAAAAAAAHezeiFaIFACW5ko6NcfOLAWkPn_OvkFM96koE5tW3fWQwkCyT4afUAwACAAAAMakQZiB62qyknHkdlP0DLzjSpd1653qL8nB7rWJxHVwDAAAAm2G92tcXE2OzcjBFKspFjvArlZbl569wSOJzkUUF43sFAAAAvFp87JmhlHTDew_3ZdjnnC66wk3QyjMCU97aZu4NJlrks51YNN7Lha7sjUawYooNyn282AybfunTUycy3AAAAHr2DqwHXi_8tQqe7DnKDwT402x49iKC60WmjSmNKfA1AAAAAL9h5XhDBgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAe0MEAAAAAAAHAAAAmgYYOhWiBQAAAAAAAAAAAFsrsuyzBE9_xH67B7uDI9kiraA0zLkkzH3mgLTKrQCt"
+            , "l0PGAAAAAABmKWCkFaIFAFsrsuyzBE9_xH67B7uDI9kiraA0zLkkzH3mgLTKrQCtAwACAAAAfYN1Qs9Ua_QGfgpBcgeBZ0J6xhQ4XXlqv_gfYA-hOc0DAAAAsGNf8lbXT-HgPD-cFNdXSkD-ODvcY6ihMwvPbRjvj4cFAAAAzmducVsWbMyG6lvO8nQKcJnVh8cgrOS-gnbOMP9WxKvks51YNN7Lha7sjUawYooNyn282AybfunTUycy3AAAAGWxPTtpx32AN0mr4Ee3fQErWyEwQytnF9-OP4O280R8AAAAAPgBD3pDBgAAAAAAAAXAAAAAAAAAAAAAAAAAAAAAAAAAfEMEAAAAAAAHAAAAmgYAOhWiBQAAAAAAAAAAAHYVlldEu5EIBSMHw-7F7xi8KYMv5SjvTjo1f1X-Gyol"
+            , [IncorrectHash, IncorrectPow, IncorrectEpoch, IncorrectWeight]
+            )
+        ,
+            ( "y4tiAAAAAAAHezeiFaIFACW5ko6NcfOLAWkPn_OvkFM96koE5tW3fWQwkCyT4afUAwACAAAAMakQZiB62qyknHkdlP0DLzjSpd1653qL8nB7rWJxHVwDAAAAm2G92tcXE2OzcjBFKspFjvArlZbl569wSOJzkUUF43sFAAAAvFp87JmhlHTDew_3ZdjnnC66wk3QyjMCU97aZu4NJlrks51YNN7Lha7sjUawYooNyn282AybfunTUycy3AAAAHr2DqwHXi_8tQqe7DnKDwT402x49iKC60WmjSmNKfA1AAAAAL9h5XhDBgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAe0MEAAAAAAAHAAAAmgYYOhWiBQAAAAAAAAAAAFsrsuyzBE9_xH67B7uDI9kiraA0zLkkzH3mgLTKrQCt"
+            , "l0PGAAAAAABmKWCkFaIFAFsrsuyzBE9_xH67B7uDI9kiraA0zLkkzH3mgLTKrQCtAwACAAAAfYN1Qs9Ua_QGfgpBcgeBZ0J6xhQ4XXlqv_gfYA-hOc0DAAAAsGNf8lbXT-HgPD-cFNdXSkD-ODvcY6ihMwvPbRjvj4cFAAAAzmducVsWbMyG6lvO8nQKcJnVh8cgrOS-gnbOMP9WxKvks51YNN7Lha7sjUawYooNyn282AybfunTUycy3AAAAGWxPTtpx32AN0mr4Ee3fQErWyEwQytnF9-OP4O280R8AAAAAPgBD3pDBgAAAAAAAAXAAAAAAAAAAAAAAAAAAAAAAAAAfIMEAAAAAAAHAAAAmgYAOhWiBQAAAAAAAAAAAHYVlldEu5EIBSMHw-7F7xi8KYMv5SjvTjo1f1X-Gyol"
+            , [IncorrectHash, IncorrectPow, IncorrectHeight, IncorrectEpoch, IncorrectWeight]
+            )
+        ,
+            ( "y4tiAAAAAAAHezeiFaIFACW5ko6NcfOLAWkPn_OvkFM96koE5tW3fWQwkCyT4afUAwACAAAAMakQZiB62qyknHkdlP0DLzjSpd1653qL8nB7rWJxHVwDAAAAm2G92tcXE2OzcjBFKspFjvArlZbl569wSOJzkUUF43sFAAAAvFp87JmhlHTDew_3ZdjnnC66wk3QyjMCU97aZu4NJlrks51YNN7Lha7sjUawYooNyn282AybfunTUycy3AAAAHr2DqwHXi_8tQqe7DnKDwT402x49iKC60WmjSmNKfA1AAAAAL9h5XhDBgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAe0MEAAAAAAAHAAAAmgYYOhWiBQAAAAAAAAAAAFsrsuyzBE9_xH67B7uDI9kiraA0zLkkzH3mgLTKrQCt"
+            , "l0PGAAAAAABmKWCkFaIFAFsrsuyzBE9_xH67B7uDI9kiraA0zLkkzH3mgLTKrQCtAwACAAAAfYN1Qs9Ua_QGfgpBcgeBZ0J6xhQ4XXlqv_gfYA-hOc0DAAAAsGNf8lbXT-HgPD-cFNdXSkD-ODvcY6ihMwvPbRjvj4cFAAAAzmducVsWbMyG6lvO8nQKcJnVh8cgrOS-gnbOMP9WxKvks51ZNN7Lha7sjUawYooNyn282AybfunTUycy3AAAAGWxPTtpx32AN0mr4Ee3fQErWyEwQytnF9-OP4O280R8AAAAAPgBD3pDBgAAAAAAAAXAAAAAAAAAAAAAAAAAAAAAAAAAfIMEAAAAAAAHAAAAmgYAOhWiBQAAAAAAAAAAAHYVlldEu5EIBSMHw-7F7xi8KYMv5SjvTjo1f1X-Gyol"
+            , [IncorrectHash, IncorrectPow, IncorrectHeight, IncorrectTarget, IncorrectEpoch, IncorrectWeight]
+            )
+        ]
+

--- a/test/Chainweb/Test/Mempool/Consensus.hs
+++ b/test/Chainweb/Test/Mempool/Consensus.hs
@@ -333,7 +333,7 @@ header' h = do
     return
         . fromLog
         . newMerkleLog
-        $ nonce
+        $ mkFeatureFlags
             :+: t'
             :+: _blockHash h
             :+: target
@@ -343,7 +343,7 @@ header' h = do
             :+: succ (_blockHeight h)
             :+: v
             :+: epochStart (ParentHeader h) t'
-            :+: mkFeatureFlags
+            :+: nonce
             :+: MerkleLogBody mempty
    where
     BlockCreationTime t = _blockCreationTime h

--- a/test/Chainweb/Test/Orphans/Internal.hs
+++ b/test/Chainweb/Test/Orphans/Internal.hs
@@ -123,7 +123,7 @@ instance Arbitrary BlockHeader where
     arbitrary = fromLog . newMerkleLog <$> entries
       where
         entries
-            = liftA2 (:+:) (Nonce <$> chooseAny)
+            = liftA2 (:+:) arbitrary
             $ liftA2 (:+:) arbitrary
             $ liftA2 (:+:) arbitrary
             $ liftA2 (:+:) arbitrary
@@ -133,7 +133,7 @@ instance Arbitrary BlockHeader where
             $ liftA2 (:+:) (BlockHeight . int @Int . getPositive <$> arbitrary)
             $ liftA2 (:+:) arbitrary
             $ liftA2 (:+:) arbitrary
-            $ liftA2 (:+:) arbitrary
+            $ liftA2 (:+:) (Nonce <$> chooseAny)
             $ fmap MerkleLogBody arbitrary
 
 -- -------------------------------------------------------------------------- --

--- a/test/Chainweb/Test/Utils.hs
+++ b/test/Chainweb/Test/Utils.hs
@@ -361,7 +361,7 @@ header p = do
     return
         . fromLog
         . newMerkleLog
-        $ nonce
+        $ mkFeatureFlags
             :+: t'
             :+: _blockHash p
             :+: target
@@ -371,7 +371,7 @@ header p = do
             :+: succ (_blockHeight p)
             :+: v
             :+: epochStart (ParentHeader p) t'
-            :+: mkFeatureFlags
+            :+: nonce
             :+: MerkleLogBody mempty
    where
     BlockCreationTime t = _blockCreationTime p


### PR DESCRIPTION
This fixes #960. The former PR switched the names for feature flags and nonce. This was done in a way that the binary encoding and the Merkel root for old headers was unchanged.

However, the types of the Merkel tree entries guid the selection of leaf position of proof subject during proof creation. Thus proof creation would look for the subject in the wrong place in the tree.

This PR also switches the types of flags and nonce (and the tags in the MerkleUniverse) in the Merkel tree.