### PR TITLE
Hlint suggestions to ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,7 +37,6 @@ result-*
 public
 log
 report.html
-.hlint.yaml
 hlint.hs
 *.svg
 *.png

--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -1,0 +1,10 @@
+# HLint configuration file
+# https://github.com/ndmitchell/hlint
+##########################
+
+- ignore: {name: "Redundant multi-way if"}
+- ignore: {name: "Redundant do"}
+- ignore: {name: "Reduce duplication"}
+- ignore: {name: "Eta reduce"}
+- ignore: {name: "Parse error"}
+- ignore: {name: "Use camelCase"}


### PR DESCRIPTION
This reduces the output of `hlint` on our code base from 586 warnings to 421 (~30%).