### PR TITLE
Remove redundant stuff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # `chainweb-node` Changelog
 
+## Unreleased
+
+This version replaces all previous versions. Any prior version will stop working
+on **2020-04-30T00:00:00Z**. Node administrators must upgrade to this version
+before that date.
+
+*   Starting with block height 530500 the first eight bytes of each block must be
+    set to zero. (#974)
+
+*   The option to persist the peer database is removed (TODO). The functionality
+    was rarely used and can be simulated by using the peer REST API endpoints
+    along with the know peers configuration option.
+
 ## 1.7 (2019-03-26)
 
 This version replaces all previous versions. Any prior version will stop working

--- a/chainweb.cabal
+++ b/chainweb.cabal
@@ -363,7 +363,6 @@ library
         , random-bytestring >= 0.1
         , reflection >= 2.1
         , resourcet >= 1.2
-        , safeio >= 0.0
         , safe-exceptions >= 0.1
         , scheduler >= 1.4
         , semialign >= 1

--- a/chainweb.cabal
+++ b/chainweb.cabal
@@ -747,7 +747,6 @@ executable cwtool
         , safe-exceptions >= 0.1
         , servant-client >= 0.16
         , servant-client-core >= 0.16
-        , shelly >= 1.8
         , streaming >= 0.2.2
         , streaming-commons >= 0.2
         , streaming-concurrency >= 0.3.1.3

--- a/src/P2P/Node.hs
+++ b/src/P2P/Node.hs
@@ -683,9 +683,6 @@ startPeerDb nids conf = do
     !peerDb <- newEmptyPeerDb
     forM_ nids $ \nid ->
         peerDbInsertPeerInfoList_ True nid (_p2pConfigKnownPeers conf) peerDb
-    case _p2pConfigPeerDbFilePath conf of
-        Just dbFilePath -> loadIntoPeerDb dbFilePath peerDb
-        Nothing -> return ()
     return $ if _p2pConfigPrivate conf
         then makePeerDbPrivate peerDb
         else peerDb
@@ -693,9 +690,8 @@ startPeerDb nids conf = do
 -- | Stop a 'PeerDb', possibly persisting the db to a file.
 --
 stopPeerDb :: P2pConfiguration -> PeerDb -> IO ()
-stopPeerDb conf db = case _p2pConfigPeerDbFilePath conf of
-    Just dbFilePath -> storePeerDb dbFilePath db
-    Nothing -> return ()
+stopPeerDb _ _ = return ()
+{-# INLINE stopPeerDb #-}
 
 -- | Run a computation with a PeerDb
 --

--- a/test/Chainweb/Test/Orphans/Internal.hs
+++ b/test/Chainweb/Test/Orphans/Internal.hs
@@ -1,4 +1,7 @@
+{-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 
 {-# OPTIONS_GHC -fno-warn-orphans #-}
@@ -39,6 +42,9 @@ import Chainweb.Payload
 import Chainweb.PowHash
 import Chainweb.Utils
 import Chainweb.Version
+
+import P2P.Node.Configuration
+import P2P.Node.PeerDB
 
 -- -------------------------------------------------------------------------- --
 -- Utils
@@ -89,6 +95,29 @@ instance Arbitrary HashTarget where
 
 instance Arbitrary HashDifficulty where
     arbitrary = HashDifficulty <$> arbitrary
+
+-- -------------------------------------------------------------------------- --
+-- P2P
+
+instance Arbitrary P2pConfiguration where
+    arbitrary = P2pConfiguration
+        <$> arbitrary <*> arbitrary <*> arbitrary
+        <*> arbitrary <*> arbitrary <*> arbitrary
+        <*> arbitrary
+
+instance Arbitrary PeerEntry where
+    arbitrary = PeerEntry
+        <$> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary
+        <*> arbitrary
+
+instance Arbitrary HostAddressIdx where
+    arbitrary = hostAddressIdx <$> arbitrary
+    {-# INLINE arbitrary #-}
+
+deriving newtype instance Arbitrary LastSuccess
+deriving newtype instance Arbitrary SuccessiveFailures
+deriving newtype instance Arbitrary AddedTime
+deriving newtype instance Arbitrary ActiveSessionCount
 
 -- -------------------------------------------------------------------------- --
 -- Block Header

--- a/test/ChainwebTests.hs
+++ b/test/ChainwebTests.hs
@@ -59,7 +59,6 @@ import Data.CAS.RocksDB
 import qualified Data.PQueue.Test (properties)
 import qualified Data.Word.Encoding (properties)
 
-import qualified P2P.Node.PeerDB (properties)
 import qualified P2P.TaskQueue.Test (properties)
 
 main :: IO ()
@@ -118,7 +117,6 @@ suite rdb =
         , testProperties "Chainweb.BlockHeaderDb.RestAPI.Server" Chainweb.Utils.Paging.properties
         , testProperties "Chainweb.HostAddress" Chainweb.HostAddress.properties
         , testProperties "Chainweb.Sync.WebBlockHeaderStore.Test" Chainweb.Sync.WebBlockHeaderStore.Test.properties
-        , testProperties "P2P.Node.PeerDB" P2P.Node.PeerDB.properties
         , testProperties "P2P.TaskQueue.Test" P2P.TaskQueue.Test.properties
         , testProperties "Data.PQueue.Test" Data.PQueue.Test.properties
         , testProperties "Chainweb.Difficulty" Chainweb.Difficulty.properties

--- a/tools/run-nodes/RunNodes.hs
+++ b/tools/run-nodes/RunNodes.hs
@@ -16,7 +16,7 @@ import Control.Error.Util (note)
 import qualified Data.Text as T
 import Formatting
 import Options.Applicative
-import Shelly hiding (FilePath)
+import System.Process (callProcess)
 import System.Directory (executable, getPermissions)
 
 ---
@@ -62,7 +62,7 @@ pPassthrough = argument str
   (metavar "CHAINWEB-FLAGS" <> help "Native flags that a chainweb-node accepts")
 
 runNode :: Word8 -> Maybe FilePath -> Env -> IO ()
-runNode nid mconf (Env e ns v _ ps) = shelly $ run_ (fromText $ T.pack e) ops
+runNode nid mconf (Env e ns v _ ps) = callProcess e (T.unpack <$> ops)
   where
     ops :: [T.Text]
     ops = [ "--hostname=127.0.0.1"


### PR DESCRIPTION
* [x] peer db persistence was not used and is redundant
    * [x] along the way move some quick check stuff from chainweb library to chainweb-tests
* [x] replace use of shelly by `callProcess` from `System.Process`