### PR TITLE
get rid of reflection

### DIFF
--- a/chainweb.cabal
+++ b/chainweb.cabal
@@ -358,7 +358,6 @@ library
         , quickcheck-instances >= 0.3
         , random >= 1.1
         , random-bytestring >= 0.1
-        , reflection >= 2.1
         , resourcet >= 1.2
         , safe-exceptions >= 0.1
         , scheduler >= 1.4
@@ -509,7 +508,6 @@ test-suite chainweb-tests
         , quickcheck-instances >= 0.3
         , random >= 1.1
         , random-bytestring >= 0.1
-        , reflection >= 2.1
         , resource-pool >= 0.2
         , resourcet >= 1.2
         , retry >= 0.7
@@ -593,7 +591,6 @@ test-suite chainweb-tests
 --         , quickcheck-instances >= 0.3
 --         , random >= 1.1
 --         , random-bytestring >= 0.1
---         , reflection >= 2.1
 --         , resource-pool >= 0.2
 --         , resourcet >= 1.2
 --         , retry >= 0.7


### PR DESCRIPTION
The only remaining use of reflection was actually redundant. 

Most changes in this PR are just whitespace changes do to reindentation of a function body `test/Chainweb/Test/SPV.hs`. 