### PR TITLE
slow down startup of devnet

### DIFF
--- a/src/Chainweb/BlockHeader.hs
+++ b/src/Chainweb/BlockHeader.hs
@@ -285,6 +285,13 @@ powTarget p@(ParentHeader ph) bct
                 adjust ver w (t .-. _blockEpochStart ph) (_blockTarget ph)
             | isLastInEpoch ph ->
                 adjust ver w (t .-. _blockEpochStart ph) (_blockTarget ph)
+            | ver == Development && _blockHeight ph == 1 -> HashTarget (maxBound `div` 10000)
+                -- this is a special case for starting  new devnet. Using
+                -- maxtarget results in an two high block production and
+                -- consecutively orphans and network congestion. The consequence
+                -- are osciallations to take serval hundred blocks before the
+                -- system stabilizes. This code cools down initial block
+                -- production.
             | otherwise -> _blockTarget ph
   where
     t = EpochStartTime $ if oldTargetGuard ver (_blockHeight ph)
@@ -308,6 +315,12 @@ epochStart
 epochStart (ParentHeader p) (BlockCreationTime bt)
     | isLastInEpoch p && oldTargetGuard ver (_blockHeight p) = EpochStartTime bt
     | isLastInEpoch p = EpochStartTime (_bct $ _blockCreationTime p)
+    | ver == Development && _blockHeight p == 1 = EpochStartTime (_bct $ _blockCreationTime p)
+        -- this is a special case for starting a new devnet. The creation time
+        -- of the development genesis blocks way in the past which would cause
+        -- the first /and/ second epochs to be at max target. By using the first
+        -- block instead of the genesis block for computing the first epoch time
+        -- we slow down mining eariler.
     | otherwise = _blockEpochStart p
   where
     ver = _chainwebVersion p

--- a/src/Chainweb/Version.hs
+++ b/src/Chainweb/Version.hs
@@ -623,21 +623,18 @@ coinV2Upgrade Mainnet01 cid h
     | cid == unsafeChainId 8 = h == 140808
     | cid == unsafeChainId 9 = h == 140808
     | otherwise = error $ "invalid chain id " <> sshow cid
-coinV2Upgrade Development cid h
-    | cid == unsafeChainId 0 = h == 3
-    | otherwise = h == 4
 coinV2Upgrade _ _ 1 = True
 coinV2Upgrade _ _ _ = False
 
 -- | Preserve Pact bugs pre 1.6 chainweb version
 -- Mainnet 328000 ~ UTC Feb 20 15:36, EST Feb 20 10:56
 -- Devnet 1 hour of blocks
+--
 pactBackCompat_v16
   :: ChainwebVersion
   -> BlockHeight
   -> Bool
 pactBackCompat_v16 Mainnet01 h = h < 328000
-pactBackCompat_v16 Development h = h < 120
 pactBackCompat_v16 _ _ = False
 
 -- | If this is true the creation time of the current header is used for pact tx
@@ -653,8 +650,6 @@ useLegacyCreationTimeForTxValidation
     -> BlockHeight
     -> Bool
 useLegacyCreationTimeForTxValidation Mainnet01 h = h < 449940 -- ~ 2020-04-03T00:00:00Z
-useLegacyCreationTimeForTxValidation Testnet04 h = h < 286231 -- 2020-04-02T02:00:00Z
-useLegacyCreationTimeForTxValidation Development h = h < 150
 useLegacyCreationTimeForTxValidation _ h = h <= 1
     -- For most chainweb versions there is a large gap between creation times of
     -- the genesis blocks and the corresponding first blocks.
@@ -666,18 +661,13 @@ useLegacyCreationTimeForTxValidation _ h = h <= 1
 
 
 -- | Checks height after which module name fix in effect.
+--
 enableModuleNameFix
     :: ChainwebVersion
     -> BlockHeight
     -> Bool
-enableModuleNameFix v bh = case v of
-  Mainnet01 -> forHeight 448501 -- ~ 2020-04-02T12:00:00Z
-  Testnet04 -> forHeight 286110 -- ~ 2020-04-02T01:00:00Z
-  Development -> forHeight 100
-  _ -> forHeight 2
-  where
-    forHeight h = bh >= h
-
+enableModuleNameFix Mainnet01 bh = bh >= 448501 -- ~ 2020-04-02T12:00:00Z
+enableModuleNameFix _ bh = bh >= 2
 
 -- -------------------------------------------------------------------------- --
 -- Header Validation Guards
@@ -736,8 +726,6 @@ slowEpochGuard _ _ = False
 --
 oldTargetGuard :: ChainwebVersion -> BlockHeight -> Bool
 oldTargetGuard Mainnet01 h = h < 452820 -- ~ 2020-04-04T00:00:00Z
-oldTargetGuard Testnet04 h = h < 286352 -- ~ 2020-04-02T03:00:00Z
-oldTargetGuard Development h = h < 360
 oldTargetGuard _ _ = False
 {-# INLINE oldTargetGuard #-}
 
@@ -756,7 +744,6 @@ skipFeatureFlagValidationGuard
     -> BlockHeight
         -- ^ height of header
     -> Bool
-skipFeatureFlagValidationGuard Mainnet01 _ = True
-skipFeatureFlagValidationGuard Development _ = True
-skipFeatureFlagValidationGuard Testnet04 _ = True
+skipFeatureFlagValidationGuard Mainnet01 h = h < 530500  -- ~ 2020-05-01T00:00:xxZ
+skipFeatureFlagValidationGuard Development h = h < 140
 skipFeatureFlagValidationGuard _ _ = False


### PR DESCRIPTION
slow down start of devnet. This is currently based 1.7 for testing with devnet bootstrapped at 1.7. After testing it can be merged into master.