### PR TITLE
avoid use of Development in bench marks

### DIFF
--- a/src/Chainweb/Pact/Backend/ForkingBench.hs
+++ b/src/Chainweb/Pact/Backend/ForkingBench.hs
@@ -88,6 +88,7 @@ import Chainweb.BlockHeaderDB.Internal
 import Chainweb.BlockHeight
 import Chainweb.ChainId
 import Chainweb.Difficulty
+import Chainweb.Graph
 import Chainweb.Logger
 import Chainweb.Miner.Core
 import Chainweb.Miner.Pact
@@ -359,8 +360,7 @@ cid :: ChainId
 cid = someChainId testVer
 
 testVer :: ChainwebVersion
-testVer = Development
--- we might need to change the version to fastTimedCPM
+testVer = FastTimedCPM petersonChainGraph
 
 genesisBlock :: BlockHeader
 genesisBlock = genesisBlockHeader testVer cid


### PR DESCRIPTION
In order to make devnet start reliably we had to lower the initial target. Using a non-trivial target however, slows down benchmarks that use chainweb version `Development`.