### PR TITLE
Adds Rosetta's network endpoints

### DIFF
--- a/src/Chainweb/RestAPI.hs
+++ b/src/Chainweb/RestAPI.hs
@@ -239,7 +239,7 @@ someChainwebServer v dbs mr (HeaderStream hs) (Rosetta r) =
         <> PactAPI.somePactServers v pacts
         <> maybe mempty (Mining.someMiningServer v) mr
         <> maybe mempty (someHeaderStreamServer v) (bool Nothing cuts hs)
-        <> bool mempty (someRosettaServer v mempools) r
+        <> maybe mempty (bool mempty (someRosettaServer v mempools) r) cuts
   where
     payloads = _chainwebServerPayloadDbs dbs
     blocks = _chainwebServerBlockHeaderDbs dbs

--- a/src/Chainweb/RestAPI.hs
+++ b/src/Chainweb/RestAPI.hs
@@ -239,7 +239,8 @@ someChainwebServer v dbs mr (HeaderStream hs) (Rosetta r) =
         <> PactAPI.somePactServers v pacts
         <> maybe mempty (Mining.someMiningServer v) mr
         <> maybe mempty (someHeaderStreamServer v) (bool Nothing cuts hs)
-        <> maybe mempty (bool mempty (someRosettaServer v mempools) r) cuts
+        <> maybe mempty (bool mempty (someRosettaServer v mempools cutPeerDb) r) cuts
+        -- TODO: not sure if passing the correct PeerDb here
   where
     payloads = _chainwebServerPayloadDbs dbs
     blocks = _chainwebServerBlockHeaderDbs dbs

--- a/src/Chainweb/Rosetta/RestAPI.hs
+++ b/src/Chainweb/Rosetta/RestAPI.hs
@@ -90,52 +90,6 @@ data RosettaFailure
     | RosettaBadNetwork
     deriving (Enum, Bounded)
 
--- instance Enum RosettaFailure where
---   succ RosettaChainUnspecified = RosettaInvalidChain defChainIdErrMsg
---   succ (RosettaInvalidChain _) = RosettaMempoolBadTx
---   succ RosettaMempoolBadTx = RosettaInvalidBlockchainName defBlockchainNameErrMsg
---   succ RosettaUnparsableTx = RosettaInvalidTx
---   succ RosettaInvalidTx = errorWithoutStackTrace "Prelude.Enum.Bool.succ: bad argument"
-
---   pred RosettaInvalidTx = RosettaUnparsableTx
---   pred RosettaUnparsableTx = RosettaMismatchNetworkName defChainwebVerErrMsg defNetworkNameErrMsg
---   pred RosettaMempoolBadTx = RosettaInvalidChain defChainIdErrMsg
---   pred (RosettaInvalidChain _) = RosettaChainUnspecified
---   pred RosettaChainUnspecified = errorWithoutStackTrace "Prelude.Enum.Bool.pred: bad argument"
-
---   toEnum x
---     | x == 0 = RosettaChainUnspecified
---     | x == 1 = RosettaInvalidChain defChainIdErrMsg
---     | x == 2 = RosettaMempoolBadTx
---     | x == 3 = RosettaInvalidBlockchainName defBlockchainNameErrMsg
---     | x == 4 = RosettaMismatchNetworkName defChainwebVerErrMsg defNetworkNameErrMsg
---     | x == 5 = RosettaUnparsableTx
---     | x == 6 = RosettaInvalidTx
---     | otherwise = errorWithoutStackTrace "Prelude.Enum.().toEnum: bad argument"
-
---   fromEnum RosettaChainUnspecified = 0
---   fromEnum (RosettaInvalidChain _) = 1
---   fromEnum RosettaMempoolBadTx = 2
---   fromEnum RosettaUnparsableTx = 5
---   fromEnum RosettaInvalidTx = 6
-
--- -- NOTE: Must update when new rosetta errors are added
--- instance Bounded RosettaFailure where
---   minBound = RosettaChainUnspecified
---   maxBound = RosettaInvalidTx
-
--- defChainIdErrMsg :: Text
--- defChainIdErrMsg = "someInvalidChainId"
-
--- defBlockchainNameErrMsg :: Text
--- defBlockchainNameErrMsg = "someInvalidBlockchainName"
-
--- defChainwebVerErrMsg :: ChainwebVersion
--- defChainwebVerErrMsg = Mainnet01
-
--- defNetworkNameErrMsg :: Text
--- defNetworkNameErrMsg = "someInvalidNetworkName"
-
 -- TODO: Better grouping of rosetta error index
 rosettaError :: RosettaFailure -> RosettaError
 rosettaError RosettaChainUnspecified = RosettaError 0 "No SubNetwork (chain) specified" False

--- a/src/Chainweb/Rosetta/RestAPI.hs
+++ b/src/Chainweb/Rosetta/RestAPI.hs
@@ -81,7 +81,6 @@ data RosettaFailure
     = RosettaChainUnspecified
     | RosettaInvalidChain Text
     | RosettaMempoolBadTx
-    | RosettaNotSupported ChainwebVersion
     | RosettaInvalidBlockchainName Text
     | RosettaMismatchNetworkName ChainwebVersion Text
 
@@ -90,10 +89,8 @@ rosettaError :: RosettaFailure -> RosettaError
 rosettaError RosettaChainUnspecified = RosettaError 0 "No SubNetwork (chain) specified" False
 rosettaError (RosettaInvalidChain cid) = RosettaError 1 ("Invalid chain value: " <> cid) False
 rosettaError RosettaMempoolBadTx = RosettaError 2 "Transaction not present in mempool" False
-rosettaError (RosettaNotSupported v) = RosettaError 3
-  ("Rosetta not supported for chainweb node version: " <> chainwebVersionToText v) False
-rosettaError (RosettaInvalidBlockchainName a) = RosettaError 4 ("Invalid blockchain name: " <> a) False
-rosettaError (RosettaMismatchNetworkName v a) = RosettaError 5
+rosettaError (RosettaInvalidBlockchainName a) = RosettaError 3 ("Invalid blockchain name: " <> a) False
+rosettaError (RosettaMismatchNetworkName v a) = RosettaError 4
   ("Network name mismatch: expected " <> (chainwebVersionToText v) <> " but received " <> a) False
 
 throwRosetta :: RosettaFailure -> Handler a

--- a/src/Chainweb/Rosetta/RestAPI.hs
+++ b/src/Chainweb/Rosetta/RestAPI.hs
@@ -81,11 +81,14 @@ data RosettaFailure
     = RosettaChainUnspecified
     | RosettaInvalidChain Text
     | RosettaMempoolBadTx
+    | RosettaNotSupported ChainwebVersion
 
 rosettaError :: RosettaFailure -> RosettaError
 rosettaError RosettaChainUnspecified = RosettaError 0 "No SubNetwork (chain) specified" False
 rosettaError (RosettaInvalidChain cid) = RosettaError 1 ("Invalid chain value: " <> cid) False
 rosettaError RosettaMempoolBadTx = RosettaError 2 "Transaction not present in mempool" False
+rosettaError (RosettaNotSupported v) = RosettaError 3
+  ("Rosetta not supported for this chainweb node version: " <> chainwebVersionToText v) False
 
 throwRosetta :: RosettaFailure -> Handler a
 throwRosetta e = throwError err500 { errBody = encode $ rosettaError e }

--- a/src/Chainweb/Rosetta/RestAPI.hs
+++ b/src/Chainweb/Rosetta/RestAPI.hs
@@ -82,13 +82,19 @@ data RosettaFailure
     | RosettaInvalidChain Text
     | RosettaMempoolBadTx
     | RosettaNotSupported ChainwebVersion
+    | RosettaInvalidBlockchainName Text
+    | RosettaMismatchNetworkName ChainwebVersion Text
 
+-- TODO: Better grouping of rosetta error index
 rosettaError :: RosettaFailure -> RosettaError
 rosettaError RosettaChainUnspecified = RosettaError 0 "No SubNetwork (chain) specified" False
 rosettaError (RosettaInvalidChain cid) = RosettaError 1 ("Invalid chain value: " <> cid) False
 rosettaError RosettaMempoolBadTx = RosettaError 2 "Transaction not present in mempool" False
 rosettaError (RosettaNotSupported v) = RosettaError 3
-  ("Rosetta not supported for this chainweb node version: " <> chainwebVersionToText v) False
+  ("Rosetta not supported for chainweb node version: " <> chainwebVersionToText v) False
+rosettaError (RosettaInvalidBlockchainName a) = RosettaError 4 ("Invalid blockchain name: " <> a) False
+rosettaError (RosettaMismatchNetworkName v a) = RosettaError 5
+  ("Network name mismatch: expected " <> (chainwebVersionToText v) <> " but received " <> a) False
 
 throwRosetta :: RosettaFailure -> Handler a
 throwRosetta e = throwError err500 { errBody = encode $ rosettaError e }

--- a/src/Chainweb/Rosetta/RestAPI.hs
+++ b/src/Chainweb/Rosetta/RestAPI.hs
@@ -109,7 +109,7 @@ rosettaError RosettaMismatchNetworkName = RosettaError 6 "Invalid Chainweb netwo
 throwRosetta :: RosettaFailure -> Handler a
 throwRosetta e = throwError err500 { errBody = encode $ rosettaError e }
 
--- | Every Rosetta reqest that requires a `NetworkId` also requires a
+-- | Every Rosetta request that requires a `NetworkId` also requires a
 -- `SubNetworkId`, at least in the case of Chainweb.
 validateNetwork :: Monad m => ChainwebVersion -> NetworkId -> ExceptT RosettaFailure m ChainId
 validateNetwork v (NetworkId bc n msni) = do

--- a/src/Chainweb/Rosetta/RestAPI/Server.hs
+++ b/src/Chainweb/Rosetta/RestAPI/Server.hs
@@ -139,7 +139,7 @@ constructionSubmitH v ms (ConstructionSubmitReq net@(NetworkId _ _ msni) tx) =
         SubNetworkId n _ <- msni ?? RosettaChainUnspecified
         cmd <- command tx ?? RosettaUnparsableTx
         validated <- hoistEither . first (const RosettaInvalidTx) $ validateCommand cmd
-        mp <- (readMaybe (T.unpack n) >>= flip lookup ms) ?? RosettaInvalidChain
+        mp <- (readChainIdText v n >>= flip lookup ms) ?? RosettaInvalidChain
         let !vec = V.singleton validated
         liftIO (mempoolInsertCheck mp vec) >>= hoistEither . first (const RosettaInvalidTx)
         liftIO (mempoolInsert mp UncheckedInsert vec)
@@ -163,7 +163,7 @@ mempoolH v ms (MempoolReq net@(NetworkId _ _ msni)) =
     work = do
         validateNetwork v net
         SubNetworkId n _ <- msni ?? RosettaChainUnspecified
-        _ <- (readMaybe @ChainId (T.unpack n) >>= flip lookup ms) ?? RosettaInvalidChain
+        _ <- (readChainIdText v n >>= flip lookup ms) ?? RosettaInvalidChain
         error "not yet implemented"  -- TODO!
 
 mempoolTransactionH
@@ -190,7 +190,7 @@ mempoolTransactionH v ms mtr = runExceptT work >>= either throwRosetta pure
     work = do
         validateNetwork v net
         SubNetworkId n _ <- msni ?? RosettaChainUnspecified
-        mp <- (readMaybe (T.unpack n) >>= flip lookup ms) ?? RosettaInvalidChain
+        mp <- (readChainIdText v n >>= flip lookup ms) ?? RosettaInvalidChain
         lrs <- liftIO . mempoolLookup mp $ V.singleton th
         (lrs V.!? 0 >>= f) ?? RosettaMempoolBadTx
 


### PR DESCRIPTION
- [x] full `/network/list` endpoint
- [x] scaffolding for `network/options` endpoint
- [x] full `/network/status` endpoint

Follow-up work:
- [x] Make sure to validate the NetworkId in the relevant endpoint handlers.
- [ ] Make the version of the Rosetta API a variable in the Rosetta repo: https://github.com/kadena-io/rosetta/issues/7
- [x] ~~Potentially better structuring of the `RosettaFailure` type: Currently made a manual Enum/Bounded instance to iterate through it since `/network/options` requires a list of all possible errors the api will return.~~ EDIT: Colin made `RosettaFailure` all single constructor making the Enum and Bounded class derivable.
- [ ] Add in all `operation_statuses` the node allows for the `network/options` endpoint. Currently just an empty list.
- [ ] Add in all `operation_types` the node allows for the `network/options` endpoint. Currently just an empty list.