### PR TITLE
Unify PactService on parent header

### DIFF
--- a/src/Chainweb/Pact/PactService.hs
+++ b/src/Chainweb/Pact/PactService.hs
@@ -327,7 +327,7 @@ initializeCoinContract _logger v cid pwo = do
       setBlockData parentHeader
       withCheckpointer target "readContracts" $ \(PactDbEnv' pdbenv) -> do
         PactServiceEnv{..} <- ask
-        pd <- mkPublicData "readContracts" def
+        pd <- getTxContext def
         mc <- liftIO $ readInitModules (_cpeLogger _psCheckpointEnv) pdbenv pd
         psInitCache .= mc
         return $! Discard ()
@@ -1082,13 +1082,10 @@ logDebug = logg "DEBUG"
 -- parent hash, and spv support (using parent hash)
 --
 setBlockData :: ParentHeader -> PactServiceM cas ()
-setBlockData (ParentHeader bh) = do
-    psBlockHeight .= succ (_blockHeight bh)
-    psBlockTime .= _blockCreationTime bh
-    psParentHash .= (Just $ _blockParent bh)
-
-    bdb <- view psBlockHeaderDb
-    psSpvSupport .= pactSPV bdb (_blockHash bh)
+setBlockData ph@(ParentHeader bh) = do
+  psParentHeader .= ph
+  bdb <- view psBlockHeaderDb
+  psSpvSupport .= pactSPV bdb (_blockHash bh)
 
 -- | Execute a block -- only called in validate either for replay or for validating current block.
 --

--- a/src/Chainweb/Pact/TransactionExec.hs
+++ b/src/Chainweb/Pact/TransactionExec.hs
@@ -136,7 +136,7 @@ applyCmd
     -> GasModel
       -- ^ Gas model (pact Service config)
     -> TxContext
-      -- ^ Contains block height, time, prev hash + metadata
+      -- ^ tx metadata and parent header
     -> SPVSupport
       -- ^ SPV support (validates cont proofs)
     -> Command PayloadWithText
@@ -144,7 +144,7 @@ applyCmd
     -> ModuleCache
       -- ^ cached module state
     -> IO (T2 (CommandResult [TxLog Value]) ModuleCache)
-applyCmd v logger pdbenv miner gasModel pd spv cmdIn mcache0 =
+applyCmd v logger pdbenv miner gasModel txCtx spv cmdIn mcache0 =
     second _txCache <$!>
       runTransactionM cenv txst applyBuyGas
   where
@@ -155,7 +155,7 @@ applyCmd v logger pdbenv miner gasModel pd spv cmdIn mcache0 =
       : ( [ FlagOldReadOnlyBehavior | isPactBackCompatV16 ]
           ++ [ FlagPreserveModuleNameBug | not isModuleNameFix ] )
 
-    cenv = TransactionEnv Transactional pdbenv logger (ctxToPublicData pd) spv nid gasPrice
+    cenv = TransactionEnv Transactional pdbenv logger (ctxToPublicData txCtx) spv nid gasPrice
       requestKey (fromIntegral gasLimit) executionConfigNoHistory
 
     cmd = payloadObj <$> cmdIn
@@ -164,8 +164,9 @@ applyCmd v logger pdbenv miner gasModel pd spv cmdIn mcache0 =
     gasLimit = gasLimitOf cmd
     initialGas = initialGasOf (_cmdPayload cmdIn)
     nid = networkIdOf cmd
-    isModuleNameFix = enableModuleNameFix v $ succ $ _blockHeight $ ctxBlockHeader pd
-    isPactBackCompatV16 = pactBackCompat_v16 v $ succ $ _blockHeight $ ctxBlockHeader pd
+    currHeight = ctxCurrentBlockHeight txCtx
+    isModuleNameFix = enableModuleNameFix v currHeight
+    isPactBackCompatV16 = pactBackCompat_v16 v currHeight
 
     redeemAllGas r = do
       txGasUsed .= fromIntegral gasLimit
@@ -237,14 +238,14 @@ applyCoinbase
     -> ParsedDecimal
       -- ^ Miner reward
     -> TxContext
-      -- ^ Contains block height, time, prev hash + metadata
+      -- ^ tx metadata and parent header
     -> EnforceCoinbaseFailure
       -- ^ enforce coinbase failure or not
     -> CoinbaseUsePrecompiled
       -- ^ always enable precompilation
     -> ModuleCache
     -> IO (T2 (CommandResult [TxLog Value]) (Maybe ModuleCache))
-applyCoinbase v logger dbEnv (Miner mid mks) reward@(ParsedDecimal d) pd
+applyCoinbase v logger dbEnv (Miner mid mks) reward@(ParsedDecimal d) txCtx
   (EnforceCoinbaseFailure enfCBFailure) (CoinbaseUsePrecompiled enablePC) mc
   | fork1_3InEffect || enablePC = do
     let (cterm, cexec) = mkCoinbaseTerm mid mks reward
@@ -260,24 +261,15 @@ applyCoinbase v logger dbEnv (Miner mid mks) reward@(ParsedDecimal d) pd
     ec = mkExecutionConfig
       [ FlagDisableModuleInstall
       , FlagDisableHistoryInTransactionalMode ]
-    tenv = TransactionEnv Transactional dbEnv logger (ctxToPublicData pd) noSPVSupport
+    tenv = TransactionEnv Transactional dbEnv logger (ctxToPublicData txCtx) noSPVSupport
            Nothing 0.0 rk 0 ec
     txst = TransactionState mc mempty 0 Nothing (_geGasModel freeGasEnv)
     initState = setModuleCache mc $ initCapabilities [magic_COINBASE]
     rk = RequestKey chash
-    parentHeader = _tcParentHeader pd
+    parentHeader = _tcParentHeader txCtx
 
-    bh = succ $ _blockHeight $ ctxBlockHeader pd
-        -- NOTE generally it should hold that @bh == 1 + _blockHeight parentHeader@.
-        -- This isn't the case for some unit tests, that don't mine blocks in order
-        -- from the genesisblock but skip ahead using 'someTestVersionHeader'.
-
+    bh = ctxCurrentBlockHeight txCtx
     cid = V._chainId parentHeader
-        -- NOTE: generally should hold that
-        -- @cid == unsafeFromText $ P._chainId $ _pmChainId $ _pdPublicMeta pd@
-        -- but in some unit test runs the chain id in public data is empty. This is
-        -- fine since coinbase is a special case.
-
     chash = Pact.Hash $ encodeToByteString $ _blockHash $ _parentHeader parentHeader
         -- NOTE: it holds that @ _pdPrevBlockHash pd == encode _blockHash@
         -- NOTE: chash includes the /quoted/ text of the parent header.
@@ -314,7 +306,7 @@ applyLocal
     -> GasModel
       -- ^ Gas model (pact Service config)
     -> TxContext
-      -- ^ Contains block height, time, prev hash + metadata
+      -- ^ tx metadata and parent header
     -> SPVSupport
       -- ^ SPV support (validates cont proofs)
     -> Command PayloadWithText
@@ -322,7 +314,7 @@ applyLocal
     -> ModuleCache
     -> ExecutionConfig
     -> IO (CommandResult [TxLog Value])
-applyLocal logger dbEnv gasModel pd spv cmdIn mc execConfig =
+applyLocal logger dbEnv gasModel txCtx spv cmdIn mc execConfig =
     evalTransactionM tenv txst go
   where
     cmd = payloadObj <$> cmdIn
@@ -332,7 +324,7 @@ applyLocal logger dbEnv gasModel pd spv cmdIn mc execConfig =
     signers = _pSigners $ _cmdPayload cmd
     gasPrice = gasPriceOf cmd
     gasLimit = gasLimitOf cmd
-    tenv = TransactionEnv Local dbEnv logger (ctxToPublicData pd) spv nid gasPrice
+    tenv = TransactionEnv Local dbEnv logger (ctxToPublicData txCtx) spv nid gasPrice
            rk (fromIntegral gasLimit) execConfig
     txst = TransactionState mc mempty 0 Nothing gasModel
     gas0 = initialGasOf (_cmdPayload cmdIn)
@@ -344,7 +336,7 @@ applyLocal logger dbEnv gasModel pd spv cmdIn mc execConfig =
 
       case cr of
         Left e -> jsonErrorResult e "applyLocal"
-        Right r -> return $! r { _crMetaData = Just (toJSON $ ctxToPublicData pd) }
+        Right r -> return $! r { _crMetaData = Just (toJSON $ ctxToPublicData txCtx) }
 
     go = do
       em <- case _pPayload $ _cmdPayload cmd of
@@ -359,15 +351,15 @@ readInitModules
     -> PactDbEnv p
       -- ^ Pact db environment
     -> TxContext
-      -- ^ Contains block height, time, prev hash + metadata
+      -- ^ tx metadata and parent header
     -> IO ModuleCache
-readInitModules logger dbEnv pd =
+readInitModules logger dbEnv txCtx =
     evalTransactionM tenv txst go
   where
     rk = RequestKey chash
     nid = Nothing
     chash = pactInitialHash
-    tenv = TransactionEnv Local dbEnv logger (ctxToPublicData pd) noSPVSupport nid 0.0
+    tenv = TransactionEnv Local dbEnv logger (ctxToPublicData txCtx) noSPVSupport nid 0.0
            rk 0 def
     txst = TransactionState mempty mempty 0 Nothing (_geGasModel freeGasEnv)
     interp = defaultInterpreter

--- a/src/Chainweb/Pact/Types.hs
+++ b/src/Chainweb/Pact/Types.hs
@@ -350,9 +350,9 @@ ctxToPublicData :: TxContext -> PublicData
 ctxToPublicData ctx@(TxContext _ pm) = PublicData pm bh bt (toText hsh)
   where
     h = ctxBlockHeader ctx
-    BlockHeight bh = _blockHeight h
+    BlockHeight bh = succ $ _blockHeight h
     BlockCreationTime (Time (TimeSpan (Micros !bt))) = _blockCreationTime h
-    BlockHash hsh = _blockHash h
+    BlockHash hsh = _blockParent h
 
 
 ctxBlockHeader :: TxContext -> BlockHeader

--- a/test/Chainweb/Test/Pact/PactExec.hs
+++ b/test/Chainweb/Test/Pact/PactExec.hs
@@ -43,7 +43,6 @@ import Test.Tasty.HUnit
 
 -- internal modules
 
-import Chainweb.BlockHeader
 import Chainweb.BlockHeader.Genesis (genesisBlockHeader)
 import Chainweb.BlockHeaderDB (BlockHeaderDb)
 import Chainweb.Graph
@@ -473,14 +472,13 @@ execTest
 execTest runPact request = _trEval request $ do
     cmdStrs <- mapM getPactCode $ _trCmds request
     trans <- mkCmds cmdStrs
-    results <- runPact $ execTransactions (Just parentHeader) defaultMiner
+    results <- runPact $ execTransactions False defaultMiner
       trans (EnforceCoinbaseFailure True) (CoinbaseUsePrecompiled True)
     let outputs = V.toList $ snd <$> _transactionPairs results
     return $ TestResponse
         (zip (_trCmds request) (toHashCommandResult <$> outputs))
         (toHashCommandResult $ _transactionCoinbase results)
   where
-    parentHeader = ParentHeader someTestVersionHeader
     mkCmds cmdStrs =
       fmap V.fromList $ forM (zip cmdStrs [0..]) $ \(code,n :: Int) ->
       buildCwCmd $
@@ -500,10 +498,10 @@ execTxsTest
     -> ScheduledTest
 execTxsTest runPact name (trans',check) = testCaseSch name (go >>= check)
   where
-    parentHeader = ParentHeader someTestVersionHeader
     go = do
       trans <- trans'
-      results' <- try $ runPact $ execTransactions (Just parentHeader) defaultMiner trans (EnforceCoinbaseFailure True) (CoinbaseUsePrecompiled True)
+      results' <- try $ runPact $ execTransactions False defaultMiner trans
+        (EnforceCoinbaseFailure True) (CoinbaseUsePrecompiled True)
       case results' of
         Right results -> Right <$> do
           let outputs = V.toList $ snd <$> _transactionPairs results

--- a/test/Chainweb/Test/Pact/RemotePactTest.hs
+++ b/test/Chainweb/Test/Pact/RemotePactTest.hs
@@ -852,7 +852,7 @@ withNodes rdb n f = withResource start
     start :: IO (Async (), ClientEnv)
     start = do
         peerInfoVar <- newEmptyMVar
-        a <- async $ runTestNodes rdb Warn v n peerInfoVar
+        a <- async $ runTestNodes rdb Quiet v n peerInfoVar
         i <- readMVar peerInfoVar
         cwEnv <- getClientEnv $ getCwBaseUrl $ _hostAddressPort $ _peerAddr i
         return (a, cwEnv)

--- a/test/Chainweb/Test/Pact/TransactionTests.hs
+++ b/test/Chainweb/Test/Pact/TransactionTests.hs
@@ -49,6 +49,7 @@ import Pact.Types.SPV
 
 -- internal chainweb modules
 
+import Chainweb.BlockCreationTime
 import Chainweb.BlockHeader
 import Chainweb.BlockHeight
 import Chainweb.Miner.Pact
@@ -207,9 +208,9 @@ testCoinbase797DateFix = testCaseSteps "testCoinbase791Fix" $ \step -> do
 
   where
     doCoinbaseExploit pdb mc height localCmd precompile testResult = do
-      let pd = PublicData def (int height) 0 ""
+      let ctx = TxContext (mkTestParentHeader $ height - 1) def
 
-      void $ applyCoinbase Mainnet01 logger pdb miner 0.1 pd (mkTestParentHeader $ height - 1)
+      void $ applyCoinbase Mainnet01 logger pdb miner 0.1 ctx
         (EnforceCoinbaseFailure True) (CoinbaseUsePrecompiled precompile) mc
 
       let h = H.toUntypedHash (H.hash "" :: H.PactHash)
@@ -242,7 +243,7 @@ testCoinbase797DateFix = testCaseSteps "testCoinbase791Fix" $ \step -> do
 testCoinbaseEnforceFailure :: Assertion
 testCoinbaseEnforceFailure = do
     (pdb,mc) <- loadCC
-    r <- try $ applyCoinbase toyVersion logger pdb miner 0.1 pubData someParentHeader
+    r <- try $ applyCoinbase toyVersion logger pdb miner 0.1 (TxContext someParentHeader def)
       (EnforceCoinbaseFailure True) (CoinbaseUsePrecompiled False) mc
     case r of
       Left (e :: SomeException) ->
@@ -252,18 +253,18 @@ testCoinbaseEnforceFailure = do
       Right _ -> assertFailure "Coinbase did not fail for bad miner id"
   where
     miner = Miner (MinerId "") (MinerKeys $ mkKeySet [] "<")
-    pubData = PublicData def blockHeight' blockTime ""
-    blockTime = toInt64 [timeMicrosQQ| 2019-12-10T01:00:00.0 |]
-    toInt64 (Time (TimeSpan (Micros m))) = m
     blockHeight' = 123
     logger = newLogger neverLog ""
-    someParentHeader = ParentHeader someTestVersionHeader
+    someParentHeader = ParentHeader (someTestVersionHeader
+                       { _blockHeight = blockHeight'
+                       , _blockCreationTime = BlockCreationTime [timeMicrosQQ| 2019-12-10T01:00:00.0 |]
+                       })
 
 
 testCoinbaseUpgradeDevnet :: V.ChainId -> BlockHeight -> Assertion
 testCoinbaseUpgradeDevnet cid upgradeHeight = do
     (pdb,mc) <- loadScript "test/pact/coin-and-devaccts.repl"
-    r <- try $ applyCoinbase v logger pdb miner 0.1 pubData parentHeader
+    r <- try $ applyCoinbase v logger pdb miner 0.1 (TxContext parentHeader def)
       (EnforceCoinbaseFailure True) (CoinbaseUsePrecompiled False) mc
     case r of
       Left (e :: SomeException) -> assertFailure $ "upgrade coinbase failed: " ++ (sshow e)
@@ -304,11 +305,10 @@ testCoinbaseUpgradeDevnet cid upgradeHeight = do
 
     v = Development
     miner = Miner (MinerId "abcd") (MinerKeys $ mkKeySet [] "<")
-    pubData = PublicData def (int upgradeHeight) 0 ""
     logger = newLogger neverLog "" -- set to alwaysLog to debug
 
     parentHeader = ParentHeader $ (someBlockHeader v upgradeHeight)
       { _blockChainwebVersion = v
       , _blockChainId = cid
+      , _blockHeight = upgradeHeight
       }
-

--- a/test/Chainweb/Test/Pact/TransactionTests.hs
+++ b/test/Chainweb/Test/Pact/TransactionTests.hs
@@ -310,5 +310,5 @@ testCoinbaseUpgradeDevnet cid upgradeHeight = do
     parentHeader = ParentHeader $ (someBlockHeader v upgradeHeight)
       { _blockChainwebVersion = v
       , _blockChainId = cid
-      , _blockHeight = upgradeHeight
+      , _blockHeight = pred upgradeHeight
       }

--- a/test/Chainweb/Test/Pact/Utils.hs
+++ b/test/Chainweb/Test/Pact/Utils.hs
@@ -399,9 +399,9 @@ testPactCtxSQLite
 testPactCtxSQLite v cid bhdb pdb sqlenv config = do
     (dbSt,cpe) <- initRelationalCheckpointer' initBlockState sqlenv logger v
     let rs = readRewards v
-        t0 = BlockCreationTime $ Time (TimeSpan (Micros 0))
+        ph = ParentHeader $ genesisBlockHeader v cid
     !ctx <- TestPactCtx
-      <$!> newMVar (PactServiceState Nothing mempty 0 t0 Nothing noSPVSupport)
+      <$!> newMVar (PactServiceState Nothing mempty ph noSPVSupport)
       <*> pure (pactServiceEnv cpe rs)
     evalPactServiceM_ ctx (initialPayloadState dummyLogger v cid)
     return (ctx,dbSt)


### PR DESCRIPTION
Cleanup PactService state to simply track parent header, use new `TxContext` to pair this with `PublicMeta` from tx, `PublicData` only assembled at actual tx execution