### PR TITLE
Pact block history query

### DIFF
--- a/src/Chainweb/Pact/Backend/ChainwebPactDb.hs
+++ b/src/Chainweb/Pact/Backend/ChainwebPactDb.hs
@@ -25,7 +25,7 @@ module Chainweb.Pact.Backend.ChainwebPactDb
 , backendWriteUpdateBatch
 , createUserTable
 , vacuumDb
-, readHistoryResult
+, toTxLog
 ) where
 
 import Control.Applicative

--- a/src/Chainweb/Pact/Backend/ChainwebPactDb.hs
+++ b/src/Chainweb/Pact/Backend/ChainwebPactDb.hs
@@ -25,12 +25,13 @@ module Chainweb.Pact.Backend.ChainwebPactDb
 , backendWriteUpdateBatch
 , createUserTable
 , vacuumDb
+, readHistoryResult
 ) where
 
 import Control.Applicative
 import Control.Lens
 import Control.Monad
-import Control.Monad.Catch (throwM)
+import Control.Monad.Catch
 import Control.Monad.Reader
 import Control.Monad.State.Strict
 import Control.Monad.Trans.Maybe
@@ -523,29 +524,35 @@ doGetTxLog d txid = do
         pb <- use bsPendingBlock
         let deltas = (ptx ++ [pb]) >>= HashMap.elems . _pendingWrites >>= takeHead . DL.toList
         let ourDeltas = filter predicate deltas
-        mapM (\x -> toTxLog (Utf8 $ _deltaRowKey x) (_deltaData x)) ourDeltas
+        mapM (\x -> toTxLog d (Utf8 $ _deltaRowKey x) (_deltaData x)) ourDeltas
 
     readFromDb = do
         rows <- callDb "doGetTxLog" $ \db -> qry db stmt
           [ SInt (fromIntegral txid) ]
           [RText, RBlob]
-        forM rows $ \case
-            [SText key, SBlob value] -> toTxLog key value
+        liftIO $ readHistoryResult d rows
+    stmt = mconcat [ "SELECT rowkey, rowdata FROM ["
+                   , tableName
+                   , "] WHERE txid = ?"
+                   ]
+
+readHistoryResult :: (FromJSON v,FromJSON l) =>
+                     Domain k v -> [[SType]] -> IO [TxLog l]
+readHistoryResult d rows = forM rows $ \case
+            [SText key, SBlob value] -> toTxLog d key value
             err -> internalError $
-              "doGetTxLog: Expected single row with two columns as the \
+              "readHistoryResult: Expected single row with two columns as the \
               \result, got: " <> T.pack (show err)
 
-    toTxLog key value =
+toTxLog :: (MonadThrow m, FromJSON v, FromJSON l) =>
+           Domain k v -> Utf8 -> ByteString -> m (TxLog l)
+toTxLog d key value =
         case Data.Aeson.decodeStrict' value of
             Nothing -> internalError $
-              "doGetTxLog: Unexpected value, unable to deserialize log"
+              "toTxLog: Unexpected value, unable to deserialize log"
             Just v ->
               return $! TxLog (toS $ unwrap $ domainTableName d) (toS $ unwrap key) v
 
-    stmt = mconcat [ "SELECT rowkey, rowdata FROM ["
-                , tableName
-                , "] WHERE txid = ?"
-                ]
 
 unwrap :: Utf8 -> BS.ByteString
 unwrap (Utf8 str) = str

--- a/src/Chainweb/Pact/Backend/InMemoryCheckpointer.hs
+++ b/src/Chainweb/Pact/Backend/InMemoryCheckpointer.hs
@@ -67,6 +67,7 @@ initInMemoryCheckpointEnv loggers logger = do
                     , _cpGetBlockParent = doGetBlockParent inmem
                     , _cpRegisterProcessedTx = doRegisterSuccessful inmem
                     , _cpLookupProcessedTx = doLookupSuccessful inmem
+                    , _cpGetBlockHistory = undefined -- TODO
                 }
             , _cpeLogger = logger
             })

--- a/src/Chainweb/Pact/Backend/InMemoryCheckpointer.hs
+++ b/src/Chainweb/Pact/Backend/InMemoryCheckpointer.hs
@@ -67,7 +67,7 @@ initInMemoryCheckpointEnv loggers logger = do
                     , _cpGetBlockParent = doGetBlockParent inmem
                     , _cpRegisterProcessedTx = doRegisterSuccessful inmem
                     , _cpLookupProcessedTx = doLookupSuccessful inmem
-                    , _cpGetBlockHistory = undefined -- TODO
+                    , _cpGetBlockHistory = \_ _ -> error "unimplemented"
                 }
             , _cpeLogger = logger
             })

--- a/src/Chainweb/Pact/Backend/RelationalCheckpointer.hs
+++ b/src/Chainweb/Pact/Backend/RelationalCheckpointer.hs
@@ -27,6 +27,7 @@ import Data.ByteString (ByteString)
 import Data.Aeson hiding (encode,(.=))
 import qualified Data.DList as DL
 import Data.Foldable (toList,foldl')
+import Data.Int
 import qualified Data.Map.Strict as M
 import qualified Data.HashMap.Strict as HashMap
 import qualified Data.List as List
@@ -36,7 +37,7 @@ import Data.Tuple.Strict
 import qualified Data.Vector as V
 import qualified Data.Vector.Algorithms.Tim as TimSort
 
-import Database.SQLite3.Direct (Utf8(..))
+import Database.SQLite3.Direct
 
 import Prelude hiding (log)
 
@@ -290,11 +291,12 @@ doGetBlockHistory dbenv blockHeader d = runBlockEnv dbenv $ do
               sshow (bhi,bha)
         _ -> internalError $ "doGetBlockHistory: expected single-row int result, got " <> sshow r
 
+    queryHistory :: Database -> Utf8 -> Int64 -> Int64 -> IO [(TxId,TxLog Value)]
     queryHistory db tableName s e = do
       let sql = "SELECT txid, rowkey, rowdata FROM [" <> tableName <>
                 "] WHERE txid > ? AND txid <= ?"
       r <- qry db sql
-           [SInt $ fromIntegral s,SInt $ fromIntegral e]
+           [SInt s,SInt e]
            [RInt,RText,RBlob]
       forM r $ \case
         [SInt txid, SText key, SBlob value] -> (fromIntegral txid,) <$> toTxLog d key value

--- a/src/Chainweb/Pact/Backend/RelationalCheckpointer.hs
+++ b/src/Chainweb/Pact/Backend/RelationalCheckpointer.hs
@@ -22,6 +22,7 @@ import Control.Monad.IO.Class
 import Control.Monad.State (gets)
 
 import Data.ByteString (ByteString)
+import Data.Aeson (Value)
 import qualified Data.DList as DL
 import Data.Foldable (toList)
 import qualified Data.HashMap.Strict as HashMap
@@ -41,15 +42,17 @@ import Prelude hiding (log)
 import Pact.Interpreter (PactDbEnv(..))
 import Pact.Types.Hash (PactHash, TypedHash(..))
 import Pact.Types.Logger (Logger(..))
+import Pact.Types.Persistence
 import Pact.Types.SQLite
 
 -- chainweb
 import Chainweb.BlockHash
+import Chainweb.BlockHeader
 import Chainweb.BlockHeight
 import Chainweb.Pact.Backend.ChainwebPactDb
 import Chainweb.Pact.Backend.Types
 import Chainweb.Pact.Backend.Utils
-import Chainweb.Pact.Service.Types (internalError)
+import Chainweb.Pact.Service.Types
 import Chainweb.Version
 
 
@@ -90,6 +93,7 @@ initRelationalCheckpointer' bstate sqlenv loggr v = do
               , _cpGetBlockParent = doGetBlockParent db
               , _cpRegisterProcessedTx = doRegisterSuccessful db
               , _cpLookupProcessedTx = doLookupSuccessful db
+              , _cpGetBlockHistory = doGetBlockHistory db
               }
         , _cpeLogger = loggr
         })
@@ -256,3 +260,6 @@ doLookupSuccessful dbenv (TypedHash hash) = runBlockEnv dbenv $ do
         !hsh <- either fail return $ Data.Serialize.decode blob
         return $! T2 (fromIntegral h) hsh
     go _ = fail "impossible"
+
+doGetBlockHistory :: Db -> BlockHeader -> IO (BlockTxHistory (TxLog Value))
+doGetBlockHistory dbenv bh = undefined

--- a/src/Chainweb/Pact/Backend/Types.hs
+++ b/src/Chainweb/Pact/Backend/Types.hs
@@ -112,6 +112,7 @@ import Chainweb.BlockHash
 import Chainweb.BlockHeader
 import Chainweb.BlockHeight
 import Chainweb.Mempool.Mempool (MempoolPreBlockCheck)
+import Chainweb.Pact.Service.Types
 import Chainweb.Transaction
 
 
@@ -281,6 +282,7 @@ data Checkpointer = Checkpointer
 
       -- TODO: this would be nicer as a batch lookup :(
     , _cpLookupProcessedTx :: !(P.PactHash -> IO (Maybe (T2 BlockHeight BlockHash)))
+    , _cpGetBlockHistory :: !(BlockHeader -> IO (BlockTxHistory (TxLog Value)))
     }
 
 data CheckpointEnv = CheckpointEnv

--- a/src/Chainweb/Pact/Backend/Types.hs
+++ b/src/Chainweb/Pact/Backend/Types.hs
@@ -11,6 +11,7 @@
 {-# LANGUAGE StrictData #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 
 -- |
 -- Module: Chainweb.Pact.Backend.Types
@@ -105,7 +106,8 @@ import Pact.Persist.SQLite (Pragma(..), SQLiteConfig(..))
 import Pact.PersistPactDb (DbEnv(..))
 import qualified Pact.Types.Hash as P
 import Pact.Types.Logger (Logger(..), Logging(..))
-import Pact.Types.Runtime (PactDb,TxId,TableName,TxLog,ExecutionMode)
+import Pact.Types.Persistence
+import Pact.Types.Runtime (TableName)
 
 -- internal modules
 import Chainweb.BlockHash
@@ -282,7 +284,8 @@ data Checkpointer = Checkpointer
 
       -- TODO: this would be nicer as a batch lookup :(
     , _cpLookupProcessedTx :: !(P.PactHash -> IO (Maybe (T2 BlockHeight BlockHash)))
-    , _cpGetBlockHistory :: !(BlockHeader -> IO (BlockTxHistory (TxLog Value)))
+    , _cpGetBlockHistory :: !(
+        forall k v . (FromJSON v) => BlockHeader -> Domain k v -> IO BlockTxHistory)
     }
 
 data CheckpointEnv = CheckpointEnv

--- a/src/Chainweb/Pact/PactService.hs
+++ b/src/Chainweb/Pact/PactService.hs
@@ -32,6 +32,7 @@ module Chainweb.Pact.PactService
     , execLocal
     , execLookupPactTxs
     , execPreInsertCheckReq
+    , execBlockTxHistory
     , initPactService
     , readCoinAccount
     , readAccountBalance
@@ -387,6 +388,10 @@ serviceRequests logFn memPoolAccess reqQ = do
                     tryOne "execPreInsertCheckReq" resultVar $
                     V.map (() <$) <$> execPreInsertCheckReq txs
                 go
+            BlockTxHistoryMsg (BlockTxHistoryReq bh resultVar) -> do
+              trace logFn "Chainweb.Pact.PactService.execBlockTxHistory" bh 1 $
+                tryOne "execBlockTxHistory" resultVar $
+                execBlockTxHistory bh
 
     toPactInternalError e = Left $ PactInternalError $ T.pack $ show e
 
@@ -1380,6 +1385,11 @@ debugResult msg result =
     trunc t | T.length t < limit = t
             | otherwise = T.take limit t <> " [truncated]"
     limit = 5000
+
+execBlockTxHistory :: BlockHeader -> PactServiceM cas (BlockTxHistory (P.TxLog A.Value))
+execBlockTxHistory bh = do
+  !cp <- getCheckpointer
+  liftIO $ _cpGetBlockHistory cp bh
 
 execPreInsertCheckReq
     :: PayloadCasLookup cas

--- a/src/Chainweb/Pact/PactService.hs
+++ b/src/Chainweb/Pact/PactService.hs
@@ -388,10 +388,10 @@ serviceRequests logFn memPoolAccess reqQ = do
                     tryOne "execPreInsertCheckReq" resultVar $
                     V.map (() <$) <$> execPreInsertCheckReq txs
                 go
-            BlockTxHistoryMsg (BlockTxHistoryReq bh resultVar) -> do
+            BlockTxHistoryMsg (BlockTxHistoryReq bh d resultVar) -> do
               trace logFn "Chainweb.Pact.PactService.execBlockTxHistory" bh 1 $
                 tryOne "execBlockTxHistory" resultVar $
-                execBlockTxHistory bh
+                execBlockTxHistory bh d
 
     toPactInternalError e = Left $ PactInternalError $ T.pack $ show e
 
@@ -1386,10 +1386,10 @@ debugResult msg result =
             | otherwise = T.take limit t <> " [truncated]"
     limit = 5000
 
-execBlockTxHistory :: BlockHeader -> PactServiceM cas (BlockTxHistory (P.TxLog A.Value))
-execBlockTxHistory bh = do
+execBlockTxHistory :: BlockHeader -> Domain' -> PactServiceM cas BlockTxHistory
+execBlockTxHistory bh (Domain' d) = do
   !cp <- getCheckpointer
-  liftIO $ _cpGetBlockHistory cp bh
+  liftIO $ _cpGetBlockHistory cp bh d
 
 execPreInsertCheckReq
     :: PayloadCasLookup cas

--- a/src/Chainweb/Pact/Service/BlockValidation.hs
+++ b/src/Chainweb/Pact/Service/BlockValidation.hs
@@ -18,16 +18,19 @@ module Chainweb.Pact.Service.BlockValidation
 , local
 , lookupPactTxs
 , pactPreInsertCheck
+, pactBlockTxHistory
 ) where
 
 
 import Control.Concurrent.MVar.Strict
 
+import Data.Aeson
 import Data.Tuple.Strict
 import Data.Vector (Vector)
 
 import Pact.Types.Command
 import Pact.Types.Hash
+import Pact.Types.Persistence
 
 import Chainweb.BlockHash
 import Chainweb.BlockHeader
@@ -96,3 +99,14 @@ pactPreInsertCheck txs reqQ = do
     let !msg = PreInsertCheckMsg req
     addRequest reqQ msg
     return resultVar
+
+pactBlockTxHistory
+  :: BlockHeader
+  -> PactQueue
+  -> IO (MVar (Either PactException (BlockTxHistory (TxLog Value))))
+pactBlockTxHistory bh reqQ = do
+  resultVar <- newEmptyMVar
+  let !req = BlockTxHistoryReq bh resultVar
+  let !msg = BlockTxHistoryMsg req
+  addRequest reqQ msg
+  return resultVar

--- a/src/Chainweb/Pact/Service/BlockValidation.hs
+++ b/src/Chainweb/Pact/Service/BlockValidation.hs
@@ -24,13 +24,11 @@ module Chainweb.Pact.Service.BlockValidation
 
 import Control.Concurrent.MVar.Strict
 
-import Data.Aeson
 import Data.Tuple.Strict
 import Data.Vector (Vector)
 
 import Pact.Types.Command
 import Pact.Types.Hash
-import Pact.Types.Persistence
 
 import Chainweb.BlockHash
 import Chainweb.BlockHeader
@@ -102,11 +100,12 @@ pactPreInsertCheck txs reqQ = do
 
 pactBlockTxHistory
   :: BlockHeader
+  -> Domain'
   -> PactQueue
-  -> IO (MVar (Either PactException (BlockTxHistory (TxLog Value))))
-pactBlockTxHistory bh reqQ = do
+  -> IO (MVar (Either PactException BlockTxHistory))
+pactBlockTxHistory bh d reqQ = do
   resultVar <- newEmptyMVar
-  let !req = BlockTxHistoryReq bh resultVar
+  let !req = BlockTxHistoryReq bh d resultVar
   let !msg = BlockTxHistoryMsg req
   addRequest reqQ msg
   return resultVar

--- a/src/Chainweb/Pact/Service/Types.hs
+++ b/src/Chainweb/Pact/Service/Types.hs
@@ -91,7 +91,7 @@ instance Exception PactException
 
 -- | Gather tx logs for a block. Not intended
 -- for public API use; ToJSONs are for logging output.
-newtype BlockTxHistory = BlockTxHistory { _blockTxHistory :: Vector (TxLog Value) }
+newtype BlockTxHistory = BlockTxHistory { _blockTxHistory :: Vector (TxId,[TxLog Value]) }
   deriving (Eq,Generic)
 instance ToJSON BlockTxHistory
 instance FromJSON BlockTxHistory

--- a/src/Chainweb/WebPactExecutionService.hs
+++ b/src/Chainweb/WebPactExecutionService.hs
@@ -80,6 +80,7 @@ data PactExecutionService = PactExecutionService
         Domain' ->
         IO (Either PactException BlockTxHistory)
         )
+      -- ^ Obtain all transaction history in block for specified table/domain.
     }
 
 -- | Newtype to indicate "routing"/multi-chain service.

--- a/test/Chainweb/Test/CutDB.hs
+++ b/test/Chainweb/Test/CutDB.hs
@@ -478,8 +478,9 @@ fakePact = WebPactExecutionService $ PactExecutionService
             $ (\x -> (x, getFakeOutput x)) <$> payloadDat
 
   , _pactLocal = \_t -> error "Unimplemented"
-  , _pactLookup = error "Unimplemented"
-  , _pactPreInsertCheck = error "_pactPreInsertCheck: unimplemented"
+  , _pactLookup = \_ _ -> error "Unimplemented"
+  , _pactPreInsertCheck = \_ _ -> error "Unimplemented"
+  , _pactBlockTxHistory = \_ _ -> error "Unimplemented"
   }
   where
     getFakeOutput (Transaction txBytes) = TransactionOutput txBytes

--- a/test/Chainweb/Test/Pact/PactInProcApi.hs
+++ b/test/Chainweb/Test/Pact/PactInProcApi.hs
@@ -42,6 +42,7 @@ import Pact.Parse
 import Pact.Types.ChainMeta
 import Pact.Types.Command
 import Pact.Types.Hash
+import Pact.Types.Persistence
 
 import Chainweb.BlockCreationTime
 import Chainweb.BlockHeader
@@ -79,6 +80,7 @@ tests = ScheduledTest testName $ go
          , test Warn $ goldenNewBlock "empty-block-tests" mempty
          , test Warn $ newBlockAndValidate
          , test Warn $ newBlockRewindValidate
+         , test Quiet $ getHistory
          , test Quiet $ badlistNewBlockTest
          , test Warn $ mempoolCreationTimeTest
          , test Warn $ moduleNameFork
@@ -120,6 +122,17 @@ newBlockAndValidate refIO reqIO = testCase "newBlockAndValidate" $ do
   (q,bdb) <- reqIO
   setMempool refIO goldenMemPool
   void $ runBlock q bdb second "newBlockAndValidate"
+
+
+getHistory :: IO (IORef MemPoolAccess) -> IO (PactQueue,TestBlockDb) -> TestTree
+getHistory refIO reqIO = testCase "getHistory" $ do
+  (q,bdb) <- reqIO
+  setMempool refIO goldenMemPool
+  void $ runBlock q bdb second "getHistory"
+  h <- getParentTestBlockDb bdb cid
+  mv <- pactBlockTxHistory h (Domain' (UserTables "coin_coin-table")) q
+  readMVar mv >>= print
+  -- TODO need full datastructure
 
 newBlockRewindValidate :: IO (IORef MemPoolAccess) -> IO (PactQueue,TestBlockDb) -> TestTree
 newBlockRewindValidate mpRefIO reqIO = testCase "newBlockRewindValidate" $ do

--- a/test/Chainweb/Test/Pact/PactInProcApi.hs
+++ b/test/Chainweb/Test/Pact/PactInProcApi.hs
@@ -134,13 +134,16 @@ getHistory refIO reqIO = testCase "getHistory" $ do
   (BlockTxHistory hist) <- forSuccess "getHistory" (return mv)
   -- just check first one here
   assertEqual "check first entry of history"
-    (10,[TxLog "coin_coin-table" "sender00"
-         (object
-          [
-            "guard" .= object [ "pred" .= ("keys-all" :: T.Text),
-                                "keys" .= ["368820f80c324bbc7c2b0610688a7da43e39f91d118732671cd9c7500ff43cca" :: T.Text] ]
-          , "balance" .= (Number 9.99999e7)
-          ])])
+    (10,
+     [TxLog "coin_coin-table" "sender00"
+      (object
+       [ "guard" .= object
+         [ "pred" .= ("keys-all" :: T.Text)
+         , "keys" .=
+           ["368820f80c324bbc7c2b0610688a7da43e39f91d118732671cd9c7500ff43cca" :: T.Text]
+         ]
+       , "balance" .= (Number 9.99999e7)
+       ])])
     (V.head hist)
   -- and transaction txids
   assertEqual "check txids"

--- a/test/Chainweb/Test/Pact/TransactionTests.hs
+++ b/test/Chainweb/Test/Pact/TransactionTests.hs
@@ -95,7 +95,7 @@ tests = testGroup "Chainweb.Test.Pact.TransactionTests"
 
 ccReplTests :: FilePath -> Assertion
 ccReplTests ccFile = do
-    (r, rst) <- execScript' (Script False ccFile) ccFile
+    (r, rst) <- execScript' Quiet ccFile
     either fail (\_ -> execRepl rst) r
   where
     execRepl rst = do
@@ -110,7 +110,7 @@ loadCC = loadScript coinRepl
 
 loadScript :: FilePath -> IO (PactDbEnv LibState, ModuleCache)
 loadScript fp = do
-  (r, rst) <- execScript' (Script False coinRepl) fp
+  (r, rst) <- execScript' Quiet fp
   either fail (const $ return ()) r
   let pdb = PactDbEnv
             (view (rEnv . eePactDb) rst)

--- a/test/Chainweb/Test/Pact/Utils.hs
+++ b/test/Chainweb/Test/Pact/Utils.hs
@@ -455,8 +455,8 @@ withWebPactExecutionService v bdb mempoolAccess act =
               evalPactServiceM_ ctx $ Right <$> execLookupPactTxs rp hashes
           , _pactPreInsertCheck = \_ txs ->
               evalPactServiceM_ ctx $ (Right . V.map (() <$)) <$> execPreInsertCheckReq txs
-          , _pactBlockTxHistory = \h ->
-              evalPactServiceM_ ctx $ Right <$> execBlockTxHistory h
+          , _pactBlockTxHistory = \h d ->
+              evalPactServiceM_ ctx $ Right <$> execBlockTxHistory h d
           }
 
 

--- a/test/Chainweb/Test/Pact/Utils.hs
+++ b/test/Chainweb/Test/Pact/Utils.hs
@@ -455,6 +455,8 @@ withWebPactExecutionService v bdb mempoolAccess act =
               evalPactServiceM_ ctx $ Right <$> execLookupPactTxs rp hashes
           , _pactPreInsertCheck = \_ txs ->
               evalPactServiceM_ ctx $ (Right . V.map (() <$)) <$> execPreInsertCheckReq txs
+          , _pactBlockTxHistory = \h ->
+              evalPactServiceM_ ctx $ Right <$> execBlockTxHistory h
           }
 
 


### PR DESCRIPTION
Provide full txlog history for a block via `WebPactExecutionService`