### PR TITLE
Adds /account/balance endpoint

### DIFF
--- a/src/Chainweb/Pact/Templates.hs
+++ b/src/Chainweb/Pact/Templates.hs
@@ -18,6 +18,10 @@ module Chainweb.Pact.Templates
 ( mkBuyGasTerm
 , mkCoinbaseTerm
 , mkCoinbaseCmd
+, app
+, bn
+, qn
+, strLit
 ) where
 
 

--- a/src/Chainweb/Pact/TransactionExec.hs
+++ b/src/Chainweb/Pact/TransactionExec.hs
@@ -94,7 +94,7 @@ import Chainweb.BlockHeader
 import Chainweb.BlockHeight
 import Chainweb.Miner.Pact
 import Chainweb.Pact.Service.Types
-import Chainweb.Pact.Templates
+import Chainweb.Pact.Templates hiding (qn)
 import Chainweb.Pact.Transactions.UpgradeTransactions (upgradeTransactions)
 import Chainweb.Pact.Types
 import Chainweb.Transaction

--- a/src/Chainweb/RestAPI.hs
+++ b/src/Chainweb/RestAPI.hs
@@ -241,7 +241,7 @@ someChainwebServer v dbs mr (HeaderStream hs) (Rosetta r) =
         <> PactAPI.somePactServers v pacts
         <> maybe mempty (Mining.someMiningServer v) mr
         <> maybe mempty (someHeaderStreamServer v) (bool Nothing cuts hs)
-        <> maybe mempty (bool mempty (someRosettaServer v concreteMs cutPeerDb) r) cuts
+        <> maybe mempty (bool mempty (someRosettaServer v concreteMs cutPeerDb concreteCr) r) cuts
         -- TODO: not sure if passing the correct PeerDb here
   where
     payloads = _chainwebServerPayloadDbs dbs
@@ -251,6 +251,7 @@ someChainwebServer v dbs mr (HeaderStream hs) (Rosetta r) =
     peers = _chainwebServerPeerDbs dbs
     mempools = _chainwebServerMempools dbs
     concreteMs = map (second (_chainResMempool . snd)) pacts
+    concreteCr = map (second snd) pacts
     cutPeerDb = fromJuste $ lookup CutNetwork peers
 
 chainwebApplication

--- a/src/Chainweb/Rosetta/RestAPI.hs
+++ b/src/Chainweb/Rosetta/RestAPI.hs
@@ -149,10 +149,9 @@ readChainIdText v c = do
 kdaToRosettaAmount :: Decimal -> Amount
 kdaToRosettaAmount k = Amount (sshow amount) currency Nothing
   where
-    -- Value of the transaction in atomic units represented as an
-    -- arbitrary-sized signed integer.
+    -- Value in atomic units represented as an arbitrary-sized signed integer.
     amount :: Integer
-    amount = floor $ k * (realToFrac $ (10 :: Integer) ^ numDecimals)
+    amount = floor $ k * (realToFrac ((10 :: Integer) ^ numDecimals))
 
     -- How to convert from atomic units to standard units
     numDecimals = 12 :: Word

--- a/src/Chainweb/Rosetta/RestAPI.hs
+++ b/src/Chainweb/Rosetta/RestAPI.hs
@@ -21,6 +21,7 @@ module Chainweb.Rosetta.RestAPI
   , rosettaError
   , throwRosetta
   , validateNetwork
+  , kdaToRosettaAmount
   ) where
 
 import Control.Error.Util
@@ -29,6 +30,7 @@ import Control.Monad.Except (throwError)
 import Control.Monad.Trans.Except (ExceptT)
 
 import Data.Aeson (encode)
+import Data.Decimal
 import qualified Data.Text as T
 
 import Rosetta
@@ -85,7 +87,7 @@ type RosettaApi_ =
 
 type RosettaApi (v :: ChainwebVersionT) = 'ChainwebEndpoint v :> Reassoc RosettaApi_
 
--- TODO: Investigate if Rosetta Erros can be dynamic
+-- TODO: Investigate if Rosetta Erros can be dynamic?
 data RosettaFailure
     = RosettaChainUnspecified
     | RosettaInvalidChain
@@ -94,9 +96,16 @@ data RosettaFailure
     | RosettaInvalidTx
     | RosettaInvalidBlockchainName
     | RosettaMismatchNetworkName
+    | RosettaHistBalCheckUnsupported
+    | RosettaPactExceptionThrown
+    | RosettaPactErrorThrown
+    | RosettaExpectedBalDecimal
+    | RosettaInvalidResultMetaData
+    | RosettaSubAcctUnsupported
     deriving (Show, Enum, Bounded)
 
--- TODO: Better grouping of rosetta error index
+
+-- TODO: Better grouping of rosetta error index?
 rosettaError :: RosettaFailure -> RosettaError
 rosettaError RosettaChainUnspecified = RosettaError 0 "No SubNetwork (chain) specified" False
 rosettaError RosettaInvalidChain = RosettaError 1 "Invalid chain value" False
@@ -105,9 +114,19 @@ rosettaError RosettaUnparsableTx = RosettaError 3 "Transaction not parsable" Fal
 rosettaError RosettaInvalidTx = RosettaError 4 "Invalid transaction" False
 rosettaError RosettaInvalidBlockchainName = RosettaError 5 "Invalid blockchain name" False
 rosettaError RosettaMismatchNetworkName = RosettaError 6 "Invalid Chainweb network name" False
+rosettaError RosettaHistBalCheckUnsupported =
+  RosettaError 7 "Historical account balance lookup is not supported." False
+rosettaError RosettaPactExceptionThrown =
+  RosettaError 7 "A pact exception was thrown" False
+rosettaError RosettaPactErrorThrown = RosettaError 8 "Transaction failed with a pact error" False
+rosettaError RosettaExpectedBalDecimal = RosettaError 9 "Expected balance as a decimal" False
+rosettaError RosettaInvalidResultMetaData = RosettaError 10 "Invalid meta data field in command result" False
+rosettaError RosettaSubAcctUnsupported = RosettaError 11 "Sub account identifier is not supported" False
+
 
 throwRosetta :: RosettaFailure -> Handler a
 throwRosetta e = throwError err500 { errBody = encode $ rosettaError e }
+
 
 -- | Every Rosetta request that requires a `NetworkId` also requires a
 -- `SubNetworkId`, at least in the case of Chainweb.
@@ -118,9 +137,24 @@ validateNetwork v (NetworkId bc n msni) = do
     SubNetworkId cid _ <- msni ?? RosettaChainUnspecified
     readChainIdText v cid ?? RosettaInvalidChain
 
+
 -- | Guarantees that the `ChainId` given actually belongs to this
 -- `ChainwebVersion`.
 readChainIdText :: ChainwebVersion -> T.Text -> Maybe ChainId
 readChainIdText v c = do
   cid <- readMaybe @Word (T.unpack c)
   mkChainId v cid
+
+
+kdaToRosettaAmount :: Decimal -> Amount
+kdaToRosettaAmount k = Amount (sshow amount) currency Nothing
+  where
+    -- Value of the transaction in atomic units represented as an
+    -- arbitrary-sized signed integer.
+    amount :: Integer
+    amount = floor $ k * (realToFrac $ (10 :: Integer) ^ numDecimals)
+
+    -- How to convert from atomic units to standard units
+    numDecimals = 12 :: Word
+
+    currency = Currency "KDA" numDecimals Nothing


### PR DESCRIPTION
- [x] blocker: have /local return the block hash and block height of the block where the local command was run in. Currently, it returns the parents of the block and (+1 of the block height).
- [ ] ~~Research possible bug (checkpointer error keeps being thrown when I hit this endpoint in non-genesis case)~~ Can't replicate and it seems to work fine with a local mining node now.

