### PR TITLE
Create "chainweb-portable" package, which can run on other linuxes

### DIFF
--- a/make-portable.nix
+++ b/make-portable.nix
@@ -1,0 +1,57 @@
+{ runCommand, patchelf, coreutils, binutils-unwrapped, find-libs }:
+
+targetPrefix: inputPackage:
+
+runCommand (inputPackage.pname + "-portable") {
+  inherit inputPackage targetPrefix;
+} ''
+  set -euo pipefail
+
+  cp -a "$inputPackage" "$out"
+  chmod -R u+w "$out"
+  mkdir -p "$out/lib"
+
+  processLib() {
+    lib="$1"
+    target="$2"
+
+    cp "$lib" "$target"
+    chmod u+w "$target"
+    if [ ! -z "$("${patchelf}/bin/patchelf" --print-rpath "$target")" ] ; then
+      "${patchelf}/bin/patchelf" --set-rpath "$targetPrefix/lib" "$target"
+    fi
+  }
+
+  addLib() {
+    lib="$1"
+
+    libname="$(${coreutils}/bin/basename "$lib")"
+    target="$out/lib/$libname"
+    if [ -e "$target" ] ; then
+      tmpfile="$("${coreutils}/bin/mktemp" "make-portable.XXXXXXXX")"
+      processLib "$lib" "$tmpfile"
+      diff "$target" "$tmpfile" >/dev/null
+      libsAreIdentical=$?
+      rm "$tmpfile"
+
+      if [ "$libsAreIdentical" -ne 0 ] ; then
+        2>&1 echo "error: multiple libraries named $libname are required, and they are not identical files"
+        exit 1
+      fi
+      echo "Library $lib already present - skipping"
+    else
+      echo "Adding library $lib"
+      processLib "$lib" "$target"
+    fi
+  }
+
+  for exe in $out/bin/* ; do
+    echo "Processing executable $exe"
+    for lib in $("${find-libs}/bin/find-libs" "$exe") ; do
+      addLib "$lib"
+    done
+    interpreter="$("${patchelf}/bin/patchelf" --print-interpreter "$exe")"
+    addLib "$interpreter"
+    "${patchelf}/bin/patchelf" --set-interpreter "$targetPrefix/lib/$("${coreutils}/bin/basename" "$interpreter")" --set-rpath "$targetPrefix/lib" "$exe"
+  done
+''

--- a/project.nix
+++ b/project.nix
@@ -14,11 +14,19 @@ proj = kpkgs.rp.project ({ pkgs, hackGet, ... }: with pkgs.haskell.lib;
         sed -i -e 's/^\(test-suite\|benchmark\) /executable /' -e '/^ *type: *exitcode-stdio-1.0$/d' *.cabal
       '';
     });
+  # Nixpkgs with the `find-libs` command added as a top-level package
+  nixpkgsWithFindLibs = import (pkgs.fetchFromGitHub {
+    owner = "ryantrinkle";
+    repo = "nixpkgs";
+    rev = "a9a141a10f32691228ae7668e571359f2aaf82e4";
+    sha256 = "0ncqzsq3rwkh4g68bxsxmznq4z4pcqy6wclslnrsnqbq1b2lk2gl";
+  }) {};
   in {
     name = "chainweb";
     overrides = self: super: {
       chainweb = enableCabalFlag (
         justStaticExecutables (enableDWARFDebugging (convertCabalTestsAndBenchmarksToExecutables super.chainweb))) "use_systemd";
+      chainweb-portable = nixpkgsWithFindLibs.callPackage ./make-portable.nix {} "/opt/chainweb" self.chainweb;
     };
 
     packages = {


### PR DESCRIPTION
This has not been extensively tested, but it did work on the one Ubuntu machine I tried.

To build, do this: nix-build ./project.nix -A proj.ghc.chainweb-portable

To install, take all the files in the output and copy them to /opt/chainweb on the target machine.  This prefix directory can be changed by supplying a different argument in `project.nix`, but it cannot be made fully relocatable easily.  Perhaps something like [rtldi](http://bitwagon.com/rtldi/rtldi.html) could help, but I haven't evaluated it.  It would also be possible to supply a script based on `patchelf` to change the prefix without rebuilding.