### PR TITLE
Make miner reward calculation graph order aware

### DIFF
--- a/src/Chainweb/Miner/Pact.hs
+++ b/src/Chainweb/Miner/Pact.hs
@@ -29,7 +29,6 @@ module Chainweb.Miner.Pact
   -- * Optics
 , minerId
 , minerKeys
-, minerRewardHeights
 , minerRewards
   -- * Defaults
 , noMiner
@@ -49,9 +48,8 @@ import qualified Data.Csv as CSV
 import Data.Decimal (Decimal)
 import Data.FileEmbed (embedFile)
 import Data.Hashable
-import Data.HashMap.Strict (HashMap)
-import qualified Data.HashMap.Strict as HM
-import qualified Data.List as L (sort)
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as M
 import Data.String (IsString(..))
 import Data.Text (Text)
 import qualified Data.Vector as V
@@ -145,22 +143,15 @@ fromMinerData :: MonadThrow m => MinerData -> m Miner
 fromMinerData = decodeStrictOrThrow' . _minerData
 {-# INLINABLE fromMinerData #-}
 
-data MinerRewards = MinerRewards
-    { _minerRewards :: !(HashMap BlockHeight Decimal)
+newtype MinerRewards = MinerRewards
+    { _minerRewards :: Map BlockHeight Decimal
       -- ^ The map of blockheight thresholds to miner rewards
-    , _minerRewardHeights :: !(V.Vector BlockHeight)
-      -- ^ A (sorted) vector of blockheights (head is most recent)
     } deriving (Eq, Ord, Show, Generic)
 
 -- | A getter into the map of heights to rewards
 --
-minerRewards :: Getter MinerRewards (HashMap BlockHeight Decimal)
+minerRewards :: Getter MinerRewards (Map BlockHeight Decimal)
 minerRewards = to _minerRewards
-
--- | A lens into the sorted vector of significant block heights pegged to a reward
---
-minerRewardHeights :: Lens' MinerRewards (V.Vector BlockHeight)
-minerRewardHeights = lens _minerRewardHeights (\t b -> t { _minerRewardHeights = b })
 
 -- | Rewards table mapping 3-month periods to their rewards
 -- according to the calculated exponential decay over 120 year period
@@ -171,9 +162,7 @@ readRewards =
       Left e -> error
         $ "cannot construct miner reward map: "
         <> sshow e
-      Right vs ->
-        let !rs = HM.fromList . V.toList . V.map formatRow $ vs
-        in MinerRewards rs (V.fromList . L.sort $! HM.keys rs)
+      Right vs -> MinerRewards $ M.fromList . V.toList . V.map formatRow $ vs
   where
     formatRow :: (Word64, Double) -> (BlockHeight, Decimal)
     formatRow (!a,!b) = (BlockHeight $ int a,  fromRational $ toRational b)

--- a/src/Chainweb/Miner/Pact.hs
+++ b/src/Chainweb/Miner/Pact.hs
@@ -29,7 +29,6 @@ module Chainweb.Miner.Pact
   -- * Optics
 , minerId
 , minerKeys
-, minerRewards
   -- * Defaults
 , noMiner
 , defaultMiner
@@ -147,11 +146,6 @@ newtype MinerRewards = MinerRewards
     { _minerRewards :: Map BlockHeight Decimal
       -- ^ The map of blockheight thresholds to miner rewards
     } deriving (Eq, Ord, Show, Generic)
-
--- | A getter into the map of heights to rewards
---
-minerRewards :: Getter MinerRewards (Map BlockHeight Decimal)
-minerRewards = to _minerRewards
 
 -- | Rewards table mapping 3-month periods to their rewards
 -- according to the calculated exponential decay over 120 year period

--- a/src/Chainweb/Pact/PactService.hs
+++ b/src/Chainweb/Pact/PactService.hs
@@ -912,7 +912,7 @@ minerReward v (MinerRewards rs q) bh = case V.find (bh <=) q of
       Nothing -> err
       Just m -> pure $! P.ParsedDecimal (roundTo 8 (m / n))
   where
-    !n = int $! order (chainGraphAt v bh)
+    !n = view (chainGraph . to (int . order)) v
     err = internalError "block heights have been exhausted"
 {-# INLINE minerReward #-}
 

--- a/src/Chainweb/Pact/PactService.hs
+++ b/src/Chainweb/Pact/PactService.hs
@@ -906,11 +906,10 @@ minerReward
     -> MinerRewards
     -> BlockHeight
     -> IO P.ParsedDecimal
-minerReward v (MinerRewards rs q) bh = case V.find (bh <=) q of
-    Nothing -> err
-    Just h -> case HM.lookup h rs of
+minerReward v (MinerRewards rs) bh =
+    case Map.lookupGE bh rs of
       Nothing -> err
-      Just m -> pure $! P.ParsedDecimal (roundTo 8 (m / n))
+      Just (_, m) -> pure $! P.ParsedDecimal (roundTo 8 (m / n))
   where
     !n = view (chainGraph . to (int . order)) v
     err = internalError "block heights have been exhausted"

--- a/src/Chainweb/Pact/PactService.hs
+++ b/src/Chainweb/Pact/PactService.hs
@@ -247,7 +247,7 @@ initPactService'
     -> IO (T2 a PactServiceState)
 initPactService' ver cid chainwebLogger bhDb pdb sqlenv config act = do
     checkpointEnv <- initRelationalCheckpointer initBlockState sqlenv logger ver
-    let !rs = readRewards ver
+    let !rs = readRewards
         !gasModel = officialGasModel
         !initialParentHeader = ParentHeader $ genesisBlockHeader ver cid
         !pse = PactServiceEnv
@@ -902,14 +902,17 @@ readAccountGuard pdb account
 -- See: 'rewards/miner_rewards.csv'
 --
 minerReward
-    :: MinerRewards
+    :: ChainwebVersion
+    -> MinerRewards
     -> BlockHeight
     -> IO P.ParsedDecimal
-minerReward (MinerRewards rs q) bh =
-    case V.find (bh <=) q of
+minerReward v (MinerRewards rs q) bh = case V.find (bh <=) q of
+    Nothing -> err
+    Just h -> case HM.lookup h rs of
       Nothing -> err
-      Just h -> maybe err pure (HM.lookup h rs)
+      Just m -> pure $! P.ParsedDecimal (roundTo 8 (m / n))
   where
+    !n = int $! order (chainGraphAt v bh)
     err = internalError "block heights have been exhausted"
 {-# INLINE minerReward #-}
 
@@ -1295,7 +1298,8 @@ runCoinbase False dbEnv miner enfCBFail usePrecomp mc = do
 
     let !bh = ctxCurrentBlockHeight pd
 
-    reward <- liftIO $! minerReward rs bh
+    reward <- liftIO $! minerReward v rs bh
+
     (T2 cr upgradedCacheM) <-
       liftIO $! applyCoinbase v logger dbEnv miner reward pd enfCBFail usePrecomp mc
     mapM_ upgradeInitCache upgradedCacheM

--- a/test/Chainweb/Test/Pact/RewardsTest.hs
+++ b/test/Chainweb/Test/Pact/RewardsTest.hs
@@ -30,8 +30,8 @@ tests = ScheduledTest "Chainweb.Test.Pact.RewardsTest" $
 rewardsTest :: HasCallStack => TestTree
 rewardsTest = testCaseSteps "rewards" $ \step -> do
 
-    let rs = readRewards v
-        k = minerReward rs
+    let rs = readRewards
+        k = minerReward v rs
 
     step "block heights below initial threshold"
     ParsedDecimal a <- k 0

--- a/test/Chainweb/Test/Pact/Utils.hs
+++ b/test/Chainweb/Test/Pact/Utils.hs
@@ -398,7 +398,7 @@ testPactCtxSQLite
   -> IO (TestPactCtx cas,PactDbEnv')
 testPactCtxSQLite v cid bhdb pdb sqlenv config = do
     (dbSt,cpe) <- initRelationalCheckpointer' initBlockState sqlenv logger v
-    let rs = readRewards v
+    let rs = readRewards
         ph = ParentHeader $ genesisBlockHeader v cid
     !ctx <- TestPactCtx
       <$!> newMVar (PactServiceState Nothing mempty ph noSPVSupport)


### PR DESCRIPTION
Instead of just pre-calculating miner rewards, expecting the order of the chain graph to remain fixed, this PR moves the graph-order calculation out to the `minerReward` function, so that we can calculate the division on the fly.