### PR TITLE
Fix PublicData for /local

### DIFF
--- a/src/Chainweb/Pact/TransactionExec.hs
+++ b/src/Chainweb/Pact/TransactionExec.hs
@@ -336,7 +336,7 @@ applyLocal logger dbEnv gasModel txCtx spv cmdIn mc execConfig =
 
       case cr of
         Left e -> jsonErrorResult e "applyLocal"
-        Right r -> return $! r { _crMetaData = Just (toJSON $ ctxToPublicData txCtx) }
+        Right r -> return $! r { _crMetaData = Just (toJSON $ ctxToPublicData' txCtx) }
 
     go = do
       em <- case _pPayload $ _cmdPayload cmd of

--- a/src/Chainweb/Pact/Types.hs
+++ b/src/Chainweb/Pact/Types.hs
@@ -373,11 +373,11 @@ ctxToPublicData ctx@(TxContext _ pm) = PublicData
 --
 ctxToPublicData' :: TxContext -> PublicData
 ctxToPublicData' (TxContext ph pm) = PublicData
-  { _pdPublicMeta = pm
-  , _pdBlockHeight = bh
-  , _pdBlockTime = bt
-  , _pdPrevBlockHash = toText h
-  }
+    { _pdPublicMeta = pm
+    , _pdBlockHeight = bh
+    , _pdBlockTime = bt
+    , _pdPrevBlockHash = toText h
+    }
   where
     bheader = _parentHeader ph
     BlockHeight !bh = succ $ _blockHeight bheader


### PR DESCRIPTION
This fix makes `/local` endpoint calls more correct, with public data that references: 

- parent header creation time
- previous block hash (which is the parent hash, instead of grandparent)
- current block height
