### PR TITLE
add upper bound for base64-bytestring

### DIFF
--- a/chainweb.cabal
+++ b/chainweb.cabal
@@ -309,7 +309,8 @@ library
         , attoparsec >= 0.13
         , base >= 4.12 && < 5
         , base16-bytestring >= 0.1
-        , base64-bytestring >= 1.0
+        , base64-bytestring >= 1.0 && < 1.1
+            -- due to change in error message that is inlined in pact
         , binary >= 0.8
         , bloomfilter >= 2.0
         , bytes >= 0.15
@@ -483,7 +484,8 @@ test-suite chainweb-tests
         , async >= 2.2
         , base >= 4.12 && < 5
         , base16-bytestring >= 0.1
-        , base64-bytestring >= 1.0
+        , base64-bytestring >= 1.0 && < 1.1
+            -- due to change in error message that is inlined in pact
         , bytes >= 0.15
         , bytestring >= 0.10
         , cereal >= 0.5


### PR DESCRIPTION
Pact inlines error messages from base64-bytestring via `Show` in internal pact errors.

There is the following change in base64-byestring-1.1.0:

```diff
- Base64DecodeException "invalid base64 encoding near offset 0" 
+ Base64DecodeException "invalid character at offset: 0"
```

which would break mainnet history. Until we have a long term fix, we'll put an upper bound on base64-bytestring.