### PR TITLE
remove broken base-prelude dependency

### DIFF
--- a/chainweb.cabal
+++ b/chainweb.cabal
@@ -644,7 +644,6 @@ executable cwtool
         , async >= 2.2
         , base >= 4.12 && < 5
         , base16-bytestring >= 0.1
-        , base-prelude >= 1.3
         , bytes >= 0.15
         , bytestring >= 0.10
         , cereal >= 0.5

--- a/tools/ea/Ea.hs
+++ b/tools/ea/Ea.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE LambdaCase #-}
-{-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TypeOperators #-}
 
@@ -27,8 +26,6 @@
 --
 module Ea ( main, genTxModules ) where
 
-import BasePrelude
-
 import Control.Lens (set)
 
 import Data.Aeson (ToJSON)
@@ -36,10 +33,12 @@ import Data.Aeson.Encode.Pretty
 import Data.ByteString (ByteString)
 import qualified Data.ByteString.Lazy as BL
 import Data.CAS.RocksDB
+import Data.Foldable
 import Data.Text (Text)
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as TE
 import qualified Data.Text.IO as TIO
+import Data.Traversable
 import Data.Tuple.Strict
 import qualified Data.Vector as V
 import qualified Data.Yaml as Yaml
@@ -47,6 +46,8 @@ import qualified Data.Yaml as Yaml
 import Ea.Genesis
 
 import System.LogLevel (LogLevel(..))
+
+import Text.Printf
 
 -- internal modules
 
@@ -109,9 +110,11 @@ mkPayload (Genesis v tag cid c k a ns) = do
       N -> "all chains"
       n -> "Chain " <> show n
     -- coin contract genesis txs
+    cc :: [FilePath]
     cc = [fungibleAsset, coinContract, gasPayer]
     -- final tx list.
     -- NB: this is position-sensitive data.
+    txs :: [FilePath]
     txs = cc <> toList ns <> toList k <> toList a <> toList c
 
 ---------------------

--- a/tools/run-nodes/RunNodes.hs
+++ b/tools/run-nodes/RunNodes.hs
@@ -1,23 +1,29 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiWayIf #-}
-{-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeOperators #-}
 
 module RunNodes ( main, runNodesOpts ) where
 
-import BasePrelude hiding (option, (%))
 import Chainweb.Graph (petersonChainGraph)
 import Chainweb.Version
+
+import Control.Concurrent
 import Control.Concurrent.Async
 import Control.Error.Util (note)
+import Control.Exception
+
 import qualified Data.Text as T
+import Data.Word
+
 import Formatting
+
 import Options.Applicative
-import System.Process (callProcess)
+
 import System.Directory (executable, getPermissions)
+import System.Process (callProcess)
 
 ---
 


### PR DESCRIPTION
the combination of `NoImplicitPrelude` and `base-prelude` was resulted in a bad `toList` instance for `Maybe` (possibly related to a bad `IsList` instance for `OverloadedLists`, but I didn't investigate it further).

This tiny PR drops the dependency on `base-prelude`.