### PR TITLE
Remove `these` dependency

### DIFF
--- a/chainweb.cabal
+++ b/chainweb.cabal
@@ -391,7 +391,6 @@ library
         , temporary >= 1.3
         , text >= 1.2
         , trifecta >= 2.1
-        , these >= 1 && < 1.2
         , time >= 1.8
         , tls >=1.5.2
         , token-bucket >= 0.1

--- a/src/Chainweb/CutDB.hs
+++ b/src/Chainweb/CutDB.hs
@@ -106,7 +106,6 @@ import Data.Maybe
 import Data.Monoid
 import Data.Ord
 import qualified Data.Text as T
-import Data.These
 import Data.Tuple.Strict
 import qualified Data.Vector as V
 
@@ -603,9 +602,10 @@ cutStreamToHeaderDiffStream db s = S.for (cutUpdates Nothing s) $ \(T2 p n) ->
         & void
 
     these2Either = flip S.for $ \case
-        This a -> S.each [Left a]
-        That a -> S.each [Right a]
-        These a b -> S.each [Left a, Right b]
+        (Just a,Nothing) -> S.each [Left a]
+        (Nothing,Just a) -> S.each [Right a]
+        (Just a,Just b) -> S.each [Left a, Right b]
+        (Nothing,Nothing) -> S.each []
 
     toOrd :: Either BlockHeader BlockHeader -> Int
     toOrd (Right a) = int $ uniqueBlockNumber a
@@ -750,4 +750,3 @@ getQueueStats db = QueueStats
     <*> (int <$> TM.size (_webBlockHeaderStoreMemo $ view cutDbWebBlockHeaderStore db))
     <*> pQueueSize (_webBlockPayloadStoreQueue $ view cutDbPayloadStore db)
     <*> (int <$> TM.size (_webBlockPayloadStoreMemo $ view cutDbPayloadStore db))
-

--- a/src/Chainweb/Utils.hs
+++ b/src/Chainweb/Utils.hs
@@ -1,5 +1,5 @@
-{-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE DefaultSignatures #-}
 {-# LANGUAGE DeriveAnyClass #-}
@@ -246,7 +246,6 @@ import Data.Time
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as T
 import qualified Data.Text.Lazy as TL
-import Data.These (These(..))
 import Data.Tuple.Strict
 import Data.Word
 
@@ -391,13 +390,13 @@ roundBy :: Integral a => a -> a -> a
 roundBy n m = ((n `div` m) + 1) * m
 {-# INLINE roundBy #-}
 
-partitionEithersNEL :: NonEmpty (Either a b) -> These (NonEmpty a) (NonEmpty b)
-partitionEithersNEL (h :| es) = case bimap NEL.nonEmpty NEL.nonEmpty $ partitionEithers es of
-    (Nothing, Nothing) -> either (This . pure) (That . pure) h
+partitionEithersNEL :: NonEmpty (Either a b) -> (Maybe (NonEmpty a), Maybe (NonEmpty b))
+partitionEithersNEL es = bimap NEL.nonEmpty NEL.nonEmpty $ partitionEithers (toList es)
+{-    (Nothing, Nothing) -> either (This . pure) (That . pure) h
     (Just as, Nothing) -> This as
     (Nothing, Just bs) -> That bs
     (Just as, Just bs) -> These as bs
-
+-}
 -- -------------------------------------------------------------------------- --
 -- * Read only Ixed
 


### PR DESCRIPTION
Aka "`these`? Pleeze"

Motivated by dislike of `These a b` as a primarily a stylistic maneuver over `(Maybe a,Maybe b)`, as well as ambient nervousness/distrust of the maintenance of the `these` package. 

You can argue for a lawful union of `NonEmpty (Either a b)` and `These`, in that `These` elides the `(Nothing,Nothing)` case when iterating, which does add some annoying (but harmless) cases to this PR. 

However, this can be countered by aesthetic dislike of both: `NonEmpty a` for its rampant API leakage into unsafe `[a]` via `init`, `drop` etc, and generally horrible UX; `These` because "really, I need to depend on a library for a hipster handling of `(Maybe a, Maybe b)`"? I personally dislike `This` and `That` imbued with a polarity.

The change of `alignWith f rs txs` to `f <$> padZip rs txs` is an example of "not having to learn a whole new DSL for a common need", with `padZip` in particular being one of those "where have you been all my life?" utilities. However, `semialign` makes the mistake that `these` does of seeing the 2-tuple as so primary: I would _love_ to have `padZip3`, `padZip4` but nooooooo.

In any case this is what happens when an opinionated programmer can't sleep. These? Deez.

NB: I think `NonEmpty` is primarily useful in APIs. In implementation code it's a drag.

NB: I found `padZip` with yet another awesome hoogle type search https://hoogle.haskell.org/?hoogle=%5Ba%5D%20-%3E%20%5Bb%5D%20-%3E%20%5B(Maybe%20a%2CMaybe%20b)%5D
