### PR TITLE
[WORK IN PROGRESS] Add db cleanup logic for checkpointer

### DIFF
--- a/src/Chainweb/Pact/Backend/InMemoryCheckpointer.hs
+++ b/src/Chainweb/Pact/Backend/InMemoryCheckpointer.hs
@@ -83,6 +83,7 @@ initInMemoryCheckpointEnv loggers logger ver cid = do
                     , _cpLookupProcessedTx = doLookupSuccessful inmem
                     , _cpGetBlockHistory = \_ _ -> error "unimplemented"
                     , _cpGetHistoricalLookup = \_ _ _ -> error "unimplemented"
+                    , _cpCleanupDb = doDiscard inmem
                 }
             , _cpeLogger = logger
             })

--- a/src/Chainweb/Pact/Backend/Types.hs
+++ b/src/Chainweb/Pact/Backend/Types.hs
@@ -299,6 +299,7 @@ data Checkpointer = Checkpointer
         forall k v . (FromJSON v) => BlockHeader -> Domain k v -> IO BlockTxHistory)
     , _cpGetHistoricalLookup :: !(
         forall k v . (FromJSON v) => BlockHeader -> Domain k v -> RowKey -> IO (Maybe (TxLog Value)))
+    , _cpCleanupDb :: IO ()
     }
 
 data CheckpointEnv = CheckpointEnv

--- a/src/Chainweb/Pact/Backend/Utils.hs
+++ b/src/Chainweb/Pact/Backend/Utils.hs
@@ -115,6 +115,9 @@ rollbackSavepoint :: SavepointName -> BlockHandler SQLiteEnv ()
 rollbackSavepoint name =
   callDb "rollbackSavepoint" $ \db -> exec_ db $ "ROLLBACK TRANSACTION TO SAVEPOINT [" <> toS (asString name) <> "];"
 
+rollbackAll :: BlockHandler SQLiteEnv ()
+rollbackAll = callDb "rollback all open transactions" $ \db -> exec_ db "ROLLBACK;"
+
 data SavepointName = BatchSavepoint | Block | DbTransaction |  PreBlock
   deriving (Eq, Ord, Enum)
 

--- a/src/Chainweb/Pact/PactService.hs
+++ b/src/Chainweb/Pact/PactService.hs
@@ -437,7 +437,11 @@ serviceRequests logFn memPoolAccess reqQ = do
                     ]
                 liftIO $ void $ tryPutMVar mvar $! toPactInternalError e
            ]
+        `finally`
+            -- Rolls back all open transactions and safepoints
+            getCheckpointer >>= liftIO . _cpCleanupDb
       where
+
         -- Pact turns AsyncExceptions into textual exceptions within
         -- PactInternalError. So there is no easy way for us to distinguish
         -- whether an exception originates from within pact or from the outside.


### PR DESCRIPTION
This adds a finalize to all pact service requests that does an unconditional `ROLLBACK` on pact db. This would clean up any possibly pending database SAVEPOINTs, which can possibly result if for some reason the the more fine-grained cleanup logic fails, for instance in the presence of asynchronous exceptions in the sqlite code.