### PR TITLE
rewind pact service initially to lastest available header in history

### DIFF
--- a/src/Chainweb/Chainweb.hs
+++ b/src/Chainweb/Chainweb.hs
@@ -714,9 +714,9 @@ withChainwebInternal conf logger peer rocksDb dbDir nodeid resetDb inner = do
             let hsh = _blockHash bh
             let h = _blockHeight bh
             logCr Info $ "pact db synchronizing to block "
-                      <> T.pack (show (h, hsh))
+                <> T.pack (show (h, hsh))
             payload <- payloadWithOutputsToPayloadData
-                       <$> casLookupM payloadDb (_blockPayloadHash bh)
+                <$> casLookupM payloadDb (_blockPayloadHash bh)
             void $ _pactValidateBlock pact bh payload
             logCr Info "pact db synchronized"
 

--- a/src/Chainweb/Pact/PactService.hs
+++ b/src/Chainweb/Pact/PactService.hs
@@ -1330,7 +1330,12 @@ rewindTo rewindLimit (Just (ParentHeader parent)) = do
         Just p -> return p
 
     if lastHash == parentHash
-      then setParentHeader "rewindTo" (ParentHeader parent)
+      then
+        -- We want to guarantee that '_psParentHeader' is in sync with the
+        -- latest block of the checkpointer at the end of and call to
+        -- 'rewindTo'. In the @else@ branch this is taken care of by the call to
+        -- 'withCheckPointerWithoutRewind'.
+        setParentHeader "rewindTo" (ParentHeader parent)
       else do
         lastHeader <- findLatestValidBlock >>= maybe failNonGenesisOnEmptyDb return
         logInfo $ T.unpack $ "rewind from last to checkpointer target"

--- a/src/Chainweb/Pact/PactService.hs
+++ b/src/Chainweb/Pact/PactService.hs
@@ -690,7 +690,7 @@ syncParentHeader caller = do
 -- Only use this function when
 --
 -- 1. you need the extra performance from skipping the call to 'rewindTo' and
--- 2. you know exactly what you do.
+-- 2. you know exactly what you are doing.
 --
 withCheckpointerWithoutRewind
     :: PayloadCasLookup cas
@@ -1404,7 +1404,7 @@ execValidateBlock
     -> PayloadData
     -> PactServiceM cas PayloadWithOutputs
 execValidateBlock currHeader plData = do
-    -- The parent block header must be available in the block header data base
+    -- The parent block header must be available in the block header database
     target <- getTarget
     psEnv <- ask
     let reorgLimit = fromIntegral $ view psReorgLimit psEnv
@@ -1419,7 +1419,7 @@ execValidateBlock currHeader plData = do
         | isGenesisBlockHeader currHeader = return Nothing
         | otherwise = Just . ParentHeader
             <$> lookupBlockHeader (_blockParent currHeader) "execValidateBlock"
-                -- It is up to the user of pact serivce to guaranteed that this
+                -- It is up to the user of pact service to guaranteed that this
                 -- succeeds. If this fails it usually means that the block
                 -- header database is corrupted.
 
@@ -1607,7 +1607,7 @@ execLookupPactTxs restorePoint txs
 -- (recovering from forks).
 --
 -- First the result of '_cpGetLatestBlock' is checked. If the respective block
--- header isn't available, the fucntion recursively checks the result of
+-- header isn't available, the function recursively checks the result of
 -- '_cpGetBlockParent'.
 --
 findLatestValidBlock :: PactServiceM cas (Maybe BlockHeader)

--- a/src/Chainweb/Pact/Service/Types.hs
+++ b/src/Chainweb/Pact/Service/Types.hs
@@ -79,7 +79,16 @@ data PactException
   | TransactionValidationException [(PactHash, Text)]
   | PactDuplicateTableError Text
   | TransactionDecodeFailure Text
-  | RewindLimitExceeded Text BlockHeight BlockHeight
+  | RewindLimitExceeded
+      { _rewindExceededLimit :: !Natural
+          -- ^ Rewind limit
+      , _rewindExceededLastHeight :: !BlockHeight
+          -- ^ current height
+      , _rewindExceededForkHeight :: !BlockHeight
+          -- ^ fork height
+      , _rewindExceededTarget :: !BlockHeader
+          -- ^ target header
+      }
   | BlockHeaderLookupFailure Text
   deriving (Eq,Generic)
 

--- a/src/Chainweb/TreeDB.hs
+++ b/src/Chainweb/TreeDB.hs
@@ -762,6 +762,7 @@ branchDiff_ db = go
 -- -------------------------------------------------------------------------- --
 -- | Collects the blocks on the old and new branches of a fork. Returns
 --   @(commonAncestor, oldBlocks, newBlocks)@.
+--
 collectForkBlocks
     :: forall db . TreeDb db
     => db

--- a/test/Chainweb/Test/Pact/Utils.hs
+++ b/test/Chainweb/Test/Pact/Utils.hs
@@ -614,8 +614,8 @@ withPactTestBlockDb version cid logLevel mempoolIO pactConfig f =
         bhdb <- getWebBlockHeaderDb (_bdbWebBlockHeaderDb bdb) cid
         let pdb = _bdbPayloadDb bdb
         sqlEnv <- startSqliteDb version cid logger (Just dir) Nothing False
-        a <- async $
-             initPactService version cid logger reqQ mempool bhdb pdb sqlEnv pactConfig
+        a <- async $ runForever (\_ _ -> return ()) "Chainweb.Test.Pact.Utils.withPactTestBlockDb" $
+            initPactService version cid logger reqQ mempool bhdb pdb sqlEnv pactConfig
         return (a, sqlEnv, (reqQ,bdb))
 
     stopPact (a, sqlEnv, _) = cancel a >> stopSqliteDb sqlEnv


### PR DESCRIPTION
If the latest block that is stored in the checkpointer gets orphaned after the service is stopped, pact service fails on startup. This PR fixes this by rewinding on startup to the latest block in the checkpointer block history that is available header in the block header db.

Some fixes and cleanups around the use of '_psParentHeader' and the use of the checkpointer are included in this PR, which was helpful for debugging and resolving the issue.

These are the changes in detail:

* [x] Before the checkpointer target was specified in pact service as `(parentHeight + 1, parentHash)`, which was more complicated than needed and could cause confusion. This PR consistently uses the 'ParentHeader' everywhere.

* [x] Add a check to `playOnBlock` that guarantees that the function is called only within the scope of a call to 'withCheckpointer*'.

* [x] Fix `rewindTo` to enforce the post condition that the checkpointer got restored to the requested target header, even if no rewind was needed for that.

* [x] Handle updating of `_psParentHeader` transparently along with the checkpointer state.

* [x] Guarantee that the block header for latest block of the checkpointer is always available.

* [x] Add a lots of new documentation that explains pre- and post-conditions for various checkpointer related functions in pact service.

* [x] Add a regression test for pact service initialization after the latest block of the checkpointer got orphaned.

* [x]  A very small unrelated change that provides version of `pruneForks` that doesn't require a logger. It ended up not being used at this point, but maybe become useful again in the future. So, I think, it's worth keeping it.