### PR TITLE
PactService module cleanup

### DIFF
--- a/bench/Chainweb/Pact/Backend/ForkingBench.hs
+++ b/bench/Chainweb/Pact/Backend/ForkingBench.hs
@@ -94,6 +94,7 @@ import Chainweb.Logger
 import Chainweb.Miner.Core
 import Chainweb.Miner.Pact
 import Chainweb.Pact.Backend.Types
+import Chainweb.Pact.Backend.Utils
 import Chainweb.Pact.PactService
 import Chainweb.Pact.Service.BlockValidation
 import Chainweb.Pact.Service.PactQueue

--- a/chainweb.cabal
+++ b/chainweb.cabal
@@ -270,6 +270,8 @@ library
         , Chainweb.Pact.Backend.Utils
         , Chainweb.Pact.NoCoinbase
         , Chainweb.Pact.PactService
+        , Chainweb.Pact.PactService.Checkpointer
+        , Chainweb.Pact.PactService.ExecBlock
         , Chainweb.Pact.RestAPI
         , Chainweb.Pact.RestAPI.Server
         , Chainweb.Pact.RestAPI.Client
@@ -632,8 +634,10 @@ executable cwtool
     main-is: CwTool.hs
     other-modules:
         Allocations
+        Chainweb.Test.HostAddress
         Chainweb.Test.MultiNode
         Chainweb.Test.Orphans.Internal
+        Chainweb.Test.Orphans.Time
         Chainweb.Test.P2P.Peer.BootstrapConfig
         Chainweb.Test.Utils
         Chainweb.Test.Utils.BlockHeader
@@ -643,12 +647,14 @@ executable cwtool
         EncodeDecodeB64Util
         GenConf
         HeaderDump
+        KnownGraphs
         Network.X509.SelfSigned.Test
+        P2P.Test.Orphans
         RunNodes
         SlowTests
-        TxStream
-        KnownGraphs
         TestMiner
+        TxStream
+
     build-depends:
         -- internal
           chainweb

--- a/src/Chainweb/Pact/Backend/Utils.hs
+++ b/src/Chainweb/Pact/Backend/Utils.hs
@@ -8,14 +8,14 @@
 
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
--- | SQLite interaction utilities
---
+-- |
 -- Module: Chainweb.Pact.ChainwebPactDb
 -- Copyright: Copyright © 2018 - 2020 Kadena LLC.
 -- License: MIT
 -- Maintainer: Emmanuel Denloye-Ito <emmanuel@kadena.io>
 -- Stability: experimental
 --
+-- SQLite interaction utilities.
 
 module Chainweb.Pact.Backend.Utils
   ( -- * General utils
@@ -41,6 +41,9 @@ module Chainweb.Pact.Backend.Utils
   , withSqliteDb
   , startSqliteDb
   , stopSqliteDb
+  , withSQLiteConnection
+  , openSQLiteConnection
+  , closeSQLiteConnection
   , withTempSQLiteConnection
   -- * SQLite Pragmas
   , chainwebPragmas

--- a/src/Chainweb/Pact/Backend/Utils.hs
+++ b/src/Chainweb/Pact/Backend/Utils.hs
@@ -8,7 +8,8 @@
 
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
--- |
+-- | SQLite interaction utilities
+--
 -- Module: Chainweb.Pact.ChainwebPactDb
 -- Copyright: Copyright © 2018 - 2020 Kadena LLC.
 -- License: MIT
@@ -16,9 +17,35 @@
 -- Stability: experimental
 --
 
-module Chainweb.Pact.Backend.Utils where
+module Chainweb.Pact.Backend.Utils
+  ( -- * General utils
+    callDb
+  , open2
+    -- * Savepoints
+  , withSavepoint
+  , beginSavepoint
+  , commitSavepoint
+  , rollbackSavepoint
+  , SavepointName(..)
+  -- * SQLite conversions and assertions
+  , domainTableName
+  , convKeySetName
+  , convModuleName
+  , convNamespaceName
+  , convRowKey
+  , convPactId
+  , expectSingleRowCol
+  , expectSingle
+  , execMulti
+  -- * SQLite runners
+  , withSqliteDb
+  , startSqliteDb
+  , stopSqliteDb
+  , withTempSQLiteConnection
+  -- * SQLite Pragmas
+  , chainwebPragmas
+  ) where
 
-import Control.Concurrent.MVar
 import Control.Exception (AsyncException, evaluate)
 import Control.Exception.Safe (tryAny)
 import Control.Lens
@@ -29,16 +56,17 @@ import Control.Monad.State.Strict
 import Control.Monad.Reader
 
 import Data.Bits
-import Data.ByteString hiding (pack)
+import Data.ByteString hiding (pack,unpack)
 import Data.String
 import Data.String.Conv
-import Data.Text (Text, pack)
+import Data.Text (Text, pack, unpack)
 import Database.SQLite3.Direct as SQ3
 
 import Prelude hiding (log)
 
-import System.Directory (removeFile)
+import System.Directory
 import System.IO.Temp
+import System.LogLevel
 
 -- pact
 
@@ -50,15 +78,14 @@ import Pact.Types.Util (AsString(..))
 
 -- chainweb
 
+import Chainweb.Logger
+import Chainweb.NodeId
 import Chainweb.Pact.Backend.SQLite.DirectV2
 import Chainweb.Pact.Backend.Types
 import Chainweb.Pact.Service.Types
+import Chainweb.Version
+import Chainweb.Utils
 
-runBlockEnv :: MVar (BlockEnv SQLiteEnv) -> BlockHandler SQLiteEnv a -> IO a
-runBlockEnv e m = modifyMVar e $
-  \(BlockEnv dbenv bs) -> do
-    (!a,!s) <- runStateT (runReaderT (runBlockHandler m) dbenv) bs
-    return (BlockEnv dbenv s, a)
 
 callDb :: (MonadCatch m, MonadReader (BlockDbEnv SQLiteEnv) m, MonadIO m) => Text -> (Database -> IO b) -> m b
 callDb callerName action = do
@@ -85,14 +112,6 @@ withSavepoint name action = mask $ \resetMask -> do
                , Handler $ \(e :: AsyncException) -> throwM e
                , Handler $ \(e :: SomeException) -> throwErr ("non-pact exception: " <> show e)
                ]
-
--- for debugging
-withTrace :: Database -> (Utf8 -> IO ()) -> IO a -> IO a
-withTrace db tracer dbaction = do
-  setTrace db (Just tracer)
-  a <- dbaction
-  setTrace db Nothing
-  return a
 
 beginSavepoint :: SavepointName -> BlockHandler SQLiteEnv ()
 beginSavepoint name =
@@ -128,41 +147,6 @@ instance Show SavepointName where
 instance AsString SavepointName where
   asString = Data.Text.pack . show
 
-withBlockEnv :: a -> (MVar a -> IO b) -> IO b
-withBlockEnv blockenv f = newMVar blockenv >>= f
-
-readBlockEnv :: (a -> b) -> MVar a -> IO b
-readBlockEnv f = fmap f . readMVar
-
-withSQLiteConnection :: String -> [Pragma] -> Bool -> (SQLiteEnv -> IO c) -> IO c
-withSQLiteConnection file ps todelete action =
-  bracket (openSQLiteConnection file ps) closer action
-  where
-    closer c = do
-      closeSQLiteConnection c
-      when todelete (removeFile file)
-
-
-openSQLiteConnection :: String -> [Pragma] -> IO SQLiteEnv
-openSQLiteConnection file ps = do
-  -- e <- open (fromString file) -- old way
-  e <- open2 file -- new way
-  case e of
-    Left (err, msg) ->
-      internalError $
-      "withSQLiteConnection: Can't open db with "
-      <> asString (show err) <> ": " <> asString (show msg)
-    Right r -> do
-      runPragmas r ps
-      return $ SQLiteEnv r
-        (SQLiteConfig file ps)
-
-closeSQLiteConnection :: SQLiteEnv -> IO ()
-closeSQLiteConnection c = void $ close_v2 $ _sConn c
-
-withTempSQLiteConnection :: [Pragma] -> (SQLiteEnv -> IO c) -> IO c
-withTempSQLiteConnection ps action =
-  withSystemTempFile "sqlite-tmp" (\file _ -> withSQLiteConnection file ps False action)
 
 domainTableName :: Domain k v -> Utf8
 domainTableName = Utf8 . toS . asString
@@ -233,20 +217,6 @@ chainwebPragmas =
   ]
 
 
-open2 :: String -> IO (Either (Error, Utf8) Database)
-open2 file = open_v2 (fromString file) (collapseFlags [sqlite_open_readwrite , sqlite_open_create , sqlite_open_fullmutex]) Nothing
--- Nothing corresponds to the nullPtr
-
-collapseFlags :: [SQLiteFlag] -> SQLiteFlag
-collapseFlags xs =
-    if Prelude.null xs then error "collapseFlags: You must pass a non-empty list"
-    else Prelude.foldr1 (.|.) xs
-
-sqlite_open_readwrite, sqlite_open_create, sqlite_open_fullmutex :: SQLiteFlag
-sqlite_open_readwrite = 0x00000002
-sqlite_open_create = 0x00000004
-sqlite_open_fullmutex = 0x00010000
-
 
 execMulti :: Traversable t => Database -> Utf8 -> t [SType] -> IO ()
 execMulti db q rows = do
@@ -260,3 +230,114 @@ execMulti db q rows = do
   where
     checkError (Left e) = void $ fail $ "error during batch insert: " ++ show e
     checkError (Right _) = return ()
+
+
+
+
+withSqliteDb
+    :: Logger logger
+    => ChainwebVersion
+    -> ChainId
+    -> logger
+    -> Maybe FilePath
+    -> Maybe NodeId
+    -> Bool
+    -> (SQLiteEnv -> IO a)
+    -> IO a
+withSqliteDb ver cid logger dbDir nodeid resetDb = bracket
+    (startSqliteDb ver cid logger dbDir nodeid resetDb)
+    stopSqliteDb
+
+startSqliteDb
+    :: Logger logger
+    => ChainwebVersion
+    -> ChainId
+    -> logger
+    -> Maybe FilePath
+    -> Maybe NodeId
+    -> Bool
+    -> IO SQLiteEnv
+startSqliteDb ver cid logger dbDir nodeid doResetDb = do
+    sqlitedir <- getSqliteDir
+    when doResetDb $ resetDb sqlitedir
+    createDirectoryIfMissing True sqlitedir
+    textLog Info $ mconcat
+        [ "opened sqlitedb for "
+        , sshow cid
+        , " in directory "
+        , sshow sqlitedir
+        ]
+    let sqlitefile = getSqliteFile sqlitedir
+    textLog Info $ "opening sqlitedb named " <> pack sqlitefile
+    openSQLiteConnection sqlitefile chainwebPragmas
+  where
+    textLog = logFunctionText logger
+
+    resetDb sqlitedir = do
+      exist <- doesDirectoryExist sqlitedir
+      when exist $ removeDirectoryRecursive sqlitedir
+
+    getSqliteFile dir = mconcat
+        [ dir
+        , "/pact-v1-chain-"
+        , unpack (chainIdToText cid)
+        , ".sqlite"
+        ]
+
+    getSqliteDir = case dbDir of
+        Nothing -> getXdgDirectory XdgData $ mconcat
+            [ "chainweb-node/"
+            , show ver
+            , maybe mempty (("/" <>) . unpack . toText) nodeid
+            , "/sqlite"
+            ]
+        Just d -> return (d <> "sqlite")
+
+stopSqliteDb :: SQLiteEnv -> IO ()
+stopSqliteDb = closeSQLiteConnection
+
+withSQLiteConnection :: String -> [Pragma] -> Bool -> (SQLiteEnv -> IO c) -> IO c
+withSQLiteConnection file ps todelete action =
+  bracket (openSQLiteConnection file ps) closer action
+  where
+    closer c = do
+      closeSQLiteConnection c
+      when todelete (removeFile file)
+
+
+openSQLiteConnection :: String -> [Pragma] -> IO SQLiteEnv
+openSQLiteConnection file ps = do
+  -- e <- open (fromString file) -- old way
+  e <- open2 file -- new way
+  case e of
+    Left (err, msg) ->
+      internalError $
+      "withSQLiteConnection: Can't open db with "
+      <> asString (show err) <> ": " <> asString (show msg)
+    Right r -> do
+      runPragmas r ps
+      return $ SQLiteEnv r
+        (SQLiteConfig file ps)
+
+closeSQLiteConnection :: SQLiteEnv -> IO ()
+closeSQLiteConnection c = void $ close_v2 $ _sConn c
+
+withTempSQLiteConnection :: [Pragma] -> (SQLiteEnv -> IO c) -> IO c
+withTempSQLiteConnection ps action =
+  withSystemTempFile "sqlite-tmp" (\file _ -> withSQLiteConnection file ps False action)
+
+
+
+open2 :: String -> IO (Either (Error, Utf8) Database)
+open2 file = open_v2 (fromString file) (collapseFlags [sqlite_open_readwrite , sqlite_open_create , sqlite_open_fullmutex]) Nothing
+-- Nothing corresponds to the nullPtr
+
+collapseFlags :: [SQLiteFlag] -> SQLiteFlag
+collapseFlags xs =
+    if Prelude.null xs then error "collapseFlags: You must pass a non-empty list"
+    else Prelude.foldr1 (.|.) xs
+
+sqlite_open_readwrite, sqlite_open_create, sqlite_open_fullmutex :: SQLiteFlag
+sqlite_open_readwrite = 0x00000002
+sqlite_open_create = 0x00000004
+sqlite_open_fullmutex = 0x00010000

--- a/src/Chainweb/Pact/PactService.hs
+++ b/src/Chainweb/Pact/PactService.hs
@@ -651,7 +651,7 @@ execValidateBlock currHeader plData = do
     let reorgLimit = fromIntegral $ view psReorgLimit psEnv
     T2 miner transactions <- exitOnRewindLimitExceeded $ withBatch $ do
         withCheckpointerRewind (Just reorgLimit) target "execValidateBlock" $ \pdbenv -> do
-            !result <- playOneBlock currHeader plData pdbenv
+            !result <- execBlock currHeader plData pdbenv
             return $! Save currHeader result
     either throwM return $!
         validateHashes currHeader plData miner transactions

--- a/src/Chainweb/Pact/PactService/Checkpointer.hs
+++ b/src/Chainweb/Pact/PactService/Checkpointer.hs
@@ -1,0 +1,451 @@
+{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE MultiWayIf #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+
+-- |
+-- Module: Chainweb.Pact.PactService.Checkpointer
+-- Copyright: Copyright © 2020 Kadena LLC.
+-- License: See LICENSE file
+-- Maintainers: Stuart Popejoy, Lars Kuhtz, Emily Pillmore
+-- Stability: experimental
+--
+-- Checkpointer interaction for Pact service.
+--
+module Chainweb.Pact.PactService.Checkpointer
+    (
+
+      -- * Checkpointer Batches
+      --
+      -- All usages of the checkpointer must be in the context of a checkpointer
+      -- batch, which ensure proper finalization of checkpointer usage by pact serice
+      -- calls.
+
+      withBatch
+    , withDiscardedBatch
+
+    -- * Pact Service Checkpointer
+    --
+    -- Within Chainweb Pact code is evaluated in the context of a parent header,
+    -- which the parent block, which is the latest block that was commit to the
+    -- block chain before the new transaction code is evaluated.
+    --
+    -- There are two function for restoring the checkpointer for evaluation of back
+    -- code:
+    --
+    -- * 'withCheckPointerRewind' and
+    -- * 'withCurrentCheckpointer'.
+    --
+    -- 'withCheckPointerRewind' rewinds the checkpointer to the provided parent
+    -- header. 'withCurrentCheckpointer' evaluates the pact transaction within the
+    -- context of the current checkpointer state. Both functions update the value of
+    -- '_psParentHeader' at the beginning and the end of each call.
+    --
+    -- The result of the evaluation indicates whether the result of the evaluation
+    -- is persisted, i.e. is commited as a new block, or is discarded, i.e.
+    -- subsequent evaluation are performed the same context as the current one.
+    --
+    , withCheckpointerRewind
+    , withCurrentCheckpointer
+    , WithCheckpointerResult(..)
+
+    -- * Low Level Pact Service Checkpointer Tools
+
+    , withCheckpointerWithoutRewind
+    , rewindTo
+    , findLatestValidBlock
+    , setParentHeader
+    , syncParentHeader
+    , getCheckpointer
+    , exitOnRewindLimitExceeded
+
+    ) where
+
+import Control.Lens
+import Control.Monad
+import Control.Monad.Catch
+import Control.Monad.Reader
+import Control.Monad.State.Strict
+
+import qualified Data.Aeson as A
+import Data.Either
+import Data.Text (Text)
+import qualified Data.Text as T
+import qualified Data.Vector as V
+
+import Prelude hiding (lookup)
+
+import Chainweb.BlockHash
+import Chainweb.BlockHeader
+import Chainweb.BlockHeight
+import Chainweb.Pact.Backend.Types
+import Chainweb.Pact.PactService.ExecBlock
+import Chainweb.Pact.Service.Types
+import Chainweb.Pact.Types
+import Chainweb.Payload
+import Chainweb.Payload.PayloadStore
+import Chainweb.TreeDB (collectForkBlocks, lookup, lookupM)
+import Chainweb.Utils hiding (check)
+import Data.CAS (casLookupM)
+
+exitOnRewindLimitExceeded :: PactServiceM cas a -> PactServiceM cas a
+exitOnRewindLimitExceeded = handle $ \case
+    e@RewindLimitExceeded{} -> do
+        killFunction <- asks _psOnFatalError
+        liftIO $ killFunction e (encodeToText $ msg e)
+    e -> throwM e
+  where
+    msg e = A.object
+        [ "details" A..= e
+        , "message" A..= id @T.Text "Your node is part of a losing fork longer than your\
+            \ reorg-limit, which is a situation that requires manual\
+            \ intervention.\
+            \ For information on recovering from this, please consult:\
+            \ https://github.com/kadena-io/chainweb-node/blob/master/\
+            \ docs/RecoveringFromDeepForks.md"
+        ]
+
+
+-- | When using the checkpointer for evaluating pact code the caller must
+-- indicate whether the result of the evaluation should be persisted or
+-- discarded.
+--
+data WithCheckpointerResult a
+    = Discard !a
+    | Save BlockHeader !a
+
+-- | INTERNAL FUNCTION. USE WITH CAUTION!
+--
+-- Same as 'withCheckpointer' but doesn't rewinds the checkpointer state to
+-- the provided target. Note that it still restores the state to the target.
+--
+-- In other words, this method can move the checkpointer back in time to a state
+-- in the current history. It doesn't resolve forks or fast forwards the
+-- checkpointer.
+--
+-- /Assumption:/
+--
+-- This function assumes that '_psParentHeader' has been updated to match the
+-- latest block in the checkpointers. This is guaranteed to be the case after
+-- calling any of 'rewindTo', 'syncParentHeader', 'withCheckPointerRewind',
+-- 'withCheckPointerWithoutRewind', or 'withCurrentCheckpointer'.
+--
+-- /NOTE:/
+--
+-- In most use cases one needs to rewind the checkpointer first to the target
+-- and function 'withCheckpointer' should be preferred.
+--
+-- Only use this function when
+--
+-- 1. you need the extra performance from skipping the call to 'rewindTo' and
+-- 2. you know exactly what you are doing.
+--
+withCheckpointerWithoutRewind
+    :: PayloadCasLookup cas
+    => Maybe ParentHeader
+        -- ^ block height and hash of the parent header
+    -> String
+        -- ^ Putative caller
+    -> (PactDbEnv' -> PactServiceM cas (WithCheckpointerResult a))
+    -> PactServiceM cas a
+withCheckpointerWithoutRewind target caller act = do
+    checkPointer <- getCheckpointer
+    logInfo $ "restoring (with caller " <> caller <> ") " <> sshow target
+
+    -- check requirement that this must be called within a batch
+    unlessM (asks _psIsBatch) $
+        error $ "Code invariant violation: withCheckpointerRewind called by " <> caller <> " outside of batch. Please report this as a bug."
+    -- we allow exactly one nested call of 'withCheckpointer', which is used
+    -- during fastforward in 'rewindTo'.
+    unlessM ((<= 1) <$> asks _psCheckpointerDepth) $ do
+        error $ "Code invariant violation: to many nested calls of withCheckpointerRewind. Please report this as a bug."
+
+    case target of
+        Just h -> setParentHeader (caller <> ".withCheckpointerWithoutRewind") h
+        Nothing -> return ()
+
+    local (over psCheckpointerDepth succ) $ mask $ \restore -> do
+        cenv <- restore $ do
+            r <- liftIO $! _cpRestore checkPointer checkpointerTarget
+            return r
+
+        try (restore (act cenv)) >>= \case
+            Left !e -> discardTx checkPointer >> throwM @_ @SomeException e
+            Right (Discard !result) -> discardTx checkPointer >> return result
+            Right (Save header !result) -> saveTx checkPointer header >> return result
+  where
+    checkpointerTarget = case target of
+        Nothing -> Nothing
+        Just (ParentHeader h) -> Just (_blockHeight h + 1, _blockHash h)
+            -- the second argument of _cpRestore expects the hash of the parent
+            -- and the height of the parent plus one.
+
+    discardTx checkPointer = liftIO $! _cpDiscard checkPointer
+
+    saveTx checkPointer !header = do
+        -- TODO: _cpSave is a complex call. If any thing in there throws
+        -- an exception it would result in a pending tx.
+        liftIO $! _cpSave checkPointer $ _blockHash header
+        modify' $ set psStateValidated (Just header)
+        setParentHeader (caller <> ".withCheckpointerWithoutRewind.saveTx") (ParentHeader header)
+
+-- | 'withCheckpointer' but using the cached parent header for target.
+--
+withCurrentCheckpointer
+    :: PayloadCasLookup cas
+    => String
+    -> (PactDbEnv' -> PactServiceM cas (WithCheckpointerResult a))
+    -> PactServiceM cas a
+withCurrentCheckpointer caller act = do
+    ph <- syncParentHeader "withCurrentCheckpointer"
+        -- discover the header for the latest block that is stored in the
+        -- checkpointer.
+    withCheckpointerRewind (Just 0) (Just ph) caller act
+
+-- | Execute an action in the context of an @Block@ that is provided by the
+-- checkpointer. The checkpointer is rewinded and restored to the state to the
+-- provided target.
+--
+-- The result of the inner action indicates whether the resulting checkpointer
+-- state should be discarded or saved.
+--
+-- If the inner action throws an exception the checkpointer state is discarded.
+--
+withCheckpointerRewind
+    :: PayloadCasLookup cas
+    => Maybe BlockHeight
+        -- ^ if set, limit rewinds to this delta
+    -> Maybe ParentHeader
+        -- ^ The parent header to which the checkpointer is restored
+        --
+        -- 'Nothing' restores the checkpointer for evaluating the genesis block.
+        --
+    -> String
+    -> (PactDbEnv' -> PactServiceM cas (WithCheckpointerResult a))
+    -> PactServiceM cas a
+withCheckpointerRewind rewindLimit p caller act = do
+    rewindTo rewindLimit p
+        -- This updates '_psParentHeader'
+    withCheckpointerWithoutRewind p caller act
+
+-- | Run a batch of checkpointer operations, possibly involving the evaluation
+-- transactions accross several blocks using more than a single call of
+-- 'withCheckPointerRewind' or 'withCurrentCheckpointer', and persist the final
+-- state. In case of an failure, the checkpointer is reverted to the initial
+-- state.
+--
+withBatch :: PactServiceM cas a -> PactServiceM cas a
+withBatch act = do
+    cp <- getCheckpointer
+    local (set psIsBatch True) $ mask $ \r -> do
+        liftIO $ _cpBeginCheckpointerBatch cp
+        v <- r act `onException` (liftIO $ _cpDiscardCheckpointerBatch cp)
+        liftIO $ _cpCommitCheckpointerBatch cp
+        return v
+
+-- | Run a batch of checkpointer operations, possibly involving the evaluation
+-- transactions accross several blocks using more than a single call of
+-- 'withCheckPointerRewind' or 'withCurrentCheckpointer', and discard the final
+-- state at the end.
+--
+withDiscardedBatch :: PactServiceM cas a -> PactServiceM cas a
+withDiscardedBatch act = do
+    cp <- getCheckpointer
+    local (set psIsBatch True) $ bracket_
+        (liftIO $ _cpBeginCheckpointerBatch cp)
+        (liftIO $ _cpDiscardCheckpointerBatch cp)
+        act
+
+
+-- | INTERNAL FUNCTION. USE 'withCheckpointer' instead.
+--
+-- TODO: The performance overhead is relatively low if there is no fork. We
+-- should consider merging it with 'restoreCheckpointer' and always rewind.
+--
+-- Rewinds the pact state to @mb@.
+--
+-- If @mb@ is 'Nothing', it rewinds to the genesis block. If the rewind is
+-- deeper than the optionally provided rewind limit, an exception is raised.
+--
+rewindTo
+    :: forall cas . PayloadCasLookup cas
+    => Maybe BlockHeight
+        -- ^ if set, limit rewinds to this delta
+    -> Maybe ParentHeader
+        -- ^ The parent header which is the rewind target
+    -> PactServiceM cas ()
+rewindTo _ Nothing = return ()
+rewindTo rewindLimit (Just (ParentHeader parent)) = do
+
+    -- skip if the checkpointer is already at the target.
+    (_, lastHash) <- getCheckpointer >>= liftIO . _cpGetLatestBlock >>= \case
+        Nothing -> throwM NoBlockValidatedYet
+        Just p -> return p
+
+    if lastHash == parentHash
+      then
+        -- We want to guarantee that '_psParentHeader' is in sync with the
+        -- latest block of the checkpointer at the end of and call to
+        -- 'rewindTo'. In the @else@ branch this is taken care of by the call to
+        -- 'withCheckPointerWithoutRewind'.
+        setParentHeader "rewindTo" (ParentHeader parent)
+      else do
+        lastHeader <- findLatestValidBlock >>= maybe failNonGenesisOnEmptyDb return
+        logInfo $ T.unpack $ "rewind from last to checkpointer target"
+            <> ". last height: " <> sshow (_blockHeight lastHeader)
+            <> "; last hash: " <> blockHashToText (_blockHash lastHeader)
+            <> "; target height: " <> sshow parentHeight
+            <> "; target hash: " <> blockHashToText parentHash
+
+        failOnTooLowRequestedHeight rewindLimit lastHeader
+        playFork lastHeader
+
+  where
+    parentHeight = _blockHeight parent
+    parentHash = _blockHash parent
+
+    failOnTooLowRequestedHeight (Just limit) lastHeader
+        | parentHeight + 1 + limit < lastHeight = -- need to stick with addition because Word64
+            throwM $ RewindLimitExceeded (int limit) parentHeight lastHeight parent
+      where
+        lastHeight = _blockHeight lastHeader
+    failOnTooLowRequestedHeight _ _ = return ()
+
+    failNonGenesisOnEmptyDb = error "impossible: playing non-genesis block to empty DB"
+
+    playFork lastHeader = do
+        bhdb <- asks _psBlockHeaderDb
+        (!commonAncestor, _, newBlocks) <-
+            liftIO $ collectForkBlocks bhdb lastHeader parent
+
+        if V.null newBlocks
+          then
+            -- If newBlocks is empty the checkpointer isn't restored via
+            -- 'fastForward'. So we do an empty 'withCheckPointerWithoutRewind'.
+            withCheckpointerWithoutRewind (Just $ ParentHeader commonAncestor) "rewindTo" $ \_ ->
+                return $! Save commonAncestor ()
+
+          else
+            -- play fork blocks
+            V.mapM_ fastForward $ V.zip
+                (ParentHeader <$> commonAncestor `V.cons` newBlocks)
+                newBlocks
+
+    fastForward
+        :: forall c . PayloadCasLookup c
+        => (ParentHeader, BlockHeader)
+        -> PactServiceM c ()
+    fastForward (target, block) = do
+        let bpHash = _blockPayloadHash block
+        payloadDb <- asks _psPdb
+
+        -- This does a restore, i.e. it rewinds the checkpointer back in
+        -- history, if needed.
+        withCheckpointerWithoutRewind (Just target) "fastForward" $ \pdbenv -> do
+            payload <- liftIO (payloadWithOutputsToPayloadData <$> casLookupM payloadDb bpHash)
+            void $ playOneBlock block payload pdbenv
+            return $! Save block ()
+        -- double check output hash here?
+
+
+
+-- | Find the latest block stored in the checkpointer for which the respective
+-- block header is available in the block header database.
+--
+-- NOTE: the function doesn't take into consideration the block header stored in
+-- '_psParentHeader' in 'PactServiceM'. It is meant to be used during re-orgs
+-- (recovering from forks).
+--
+-- First the result of '_cpGetLatestBlock' is checked. If the respective block
+-- header isn't available, the function recursively checks the result of
+-- '_cpGetBlockParent'.
+--
+findLatestValidBlock :: PactServiceM cas (Maybe BlockHeader)
+findLatestValidBlock = getCheckpointer >>= liftIO . _cpGetLatestBlock >>= \case
+    Nothing -> return Nothing
+    Just (height, hash) -> go height hash
+  where
+    go height hash = do
+        bhdb <- view psBlockHeaderDb
+        liftIO (lookup bhdb hash) >>= \case
+            Nothing -> do
+                logInfo $ "Latest block isn't valid."
+                    <> " Failed to lookup hash " <> sshow (height, hash) <> " in block header db."
+                    <> " Continuing with parent."
+                cp <- getCheckpointer
+                liftIO (_cpGetBlockParent cp (height, hash)) >>= \case
+                    Nothing -> throwM $ PactInternalError
+                        $ "missing block parent of last hash " <> sshow (height, hash)
+                    Just predHash -> go (pred height) predHash
+            x -> return x
+
+
+
+-- | Synchronizes the parent header with the latest block of the checkpointer.
+--
+-- Ideally, this function would not be needed. It
+--
+-- 1. does a best effort to recover from a situation where '_cpGetLatestBlock'
+--    '_psParentHeader' got out of sync, and
+-- 2. provides visibility into the state of that invariant via the info log
+--    message.
+--
+-- This call would fail if the latest block that is stored in the checkpointer
+-- got orphaned and the '_psParentHeader' got reset to some other block
+-- /without/ rewinding the checkpointer, too. That must not be possible. Hence,
+-- the result of '_cpGetLatestBlock' and '_psParentHeader' must be kept in sync.
+--
+-- The previously described scenario /is/ possible if the service gets restarted
+-- and the latest block got orphaned after the service stopped. This is
+-- prevented by rewinding on pact service startup to the latest available header
+-- in the block header db.
+--
+syncParentHeader :: String -> PactServiceM cas ParentHeader
+syncParentHeader caller = do
+    cp <- getCheckpointer
+    liftIO (_cpGetLatestBlock cp) >>= \case
+        Nothing -> throwM NoBlockValidatedYet
+        Just (h, ph) -> do
+            cur <- _parentHeader <$> use psParentHeader
+            unless (_blockHash cur == ph) $
+                logInfo $ T.unpack
+                    $ T.pack caller <> ".syncParentHeader"
+                    <> "; current hash: " <> blockHashToText (_blockHash cur)
+                    <> "; current height: " <>  sshow (_blockHeight cur)
+                    <> "; checkpointer hash: " <> blockHashToText ph
+                    <> "; checkpointer height: " <>  sshow h
+
+            parent <- ParentHeader
+                <$!> lookupBlockHeader ph (T.pack caller <> ".syncParentHeader")
+            setParentHeader (caller <> ".syncParentHeader") parent
+            return parent
+
+-- | Lookup a block header.
+--
+-- The block header is expected to be either in the block header database or to
+-- be the the currently stored '_psParentHeader'. The latter addresses the case
+-- when a block has already been validate with 'execValidateBlock' but isn't (yet)
+-- available in the block header database. If that's the case two things can
+-- happen:
+--
+-- 1. the header becomes available before the next 'execValidateBlock' call, or
+-- 2. the header gets orphaned and the next 'execValidateBlock' call would cause
+--    a rewind to an ancestor, which is available in the db.
+--
+lookupBlockHeader :: BlockHash -> Text -> PactServiceM cas BlockHeader
+lookupBlockHeader bhash ctx = do
+    ParentHeader cur <- use psParentHeader
+    if (bhash == _blockHash cur)
+      then return cur
+      else do
+        bhdb <- asks _psBlockHeaderDb
+        liftIO $! lookupM bhdb bhash `catchAllSynchronous` \e ->
+            throwM $ BlockHeaderLookupFailure $
+                "failed lookup of parent header in " <> ctx <> ": " <> sshow e

--- a/src/Chainweb/Pact/PactService/Checkpointer.hs
+++ b/src/Chainweb/Pact/PactService/Checkpointer.hs
@@ -350,7 +350,7 @@ rewindTo rewindLimit (Just (ParentHeader parent)) = do
         -- history, if needed.
         withCheckpointerWithoutRewind (Just target) "fastForward" $ \pdbenv -> do
             payload <- liftIO (payloadWithOutputsToPayloadData <$> casLookupM payloadDb bpHash)
-            void $ playOneBlock block payload pdbenv
+            void $ execBlock block payload pdbenv
             return $! Save block ()
         -- double check output hash here?
 

--- a/src/Chainweb/Pact/PactService/ExecBlock.hs
+++ b/src/Chainweb/Pact/PactService/ExecBlock.hs
@@ -21,7 +21,7 @@
 --
 module Chainweb.Pact.PactService.ExecBlock
     ( setParentHeader
-    , playOneBlock
+    , execBlock
     , execTransactions
     , toHashCommandResult
     , minerReward
@@ -106,7 +106,7 @@ setParentHeader msg ph@(ParentHeader bh) = do
 -- 'withChwithCheckpointerRewind', 'withCurrentCheckpointer' or
 -- 'withCheckPointerWithoutRewind'.
 --
-playOneBlock
+execBlock
     :: (PayloadCasLookup cas)
     => BlockHeader
         -- ^ this is the current header. We may consider changing this to the parent
@@ -116,10 +116,10 @@ playOneBlock
     -> PayloadData
     -> PactDbEnv'
     -> PactServiceM cas (T2 Miner Transactions)
-playOneBlock currHeader plData pdbenv = do
+execBlock currHeader plData pdbenv = do
 
     unlessM ((> 0) <$> asks _psCheckpointerDepth) $ do
-        error $ "Code invariant violation: playOneBlock must be called with withCheckpointer. Please report this as a bug."
+        error $ "Code invariant violation: execBlock must be called with withCheckpointer. Please report this as a bug."
 
     miner <- decodeStrictOrThrow' (_minerData $ _payloadDataMiner plData)
     trans <- liftIO $ transactionsFromPayload plData

--- a/src/Chainweb/Pact/PactService/ExecBlock.hs
+++ b/src/Chainweb/Pact/PactService/ExecBlock.hs
@@ -1,0 +1,505 @@
+{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE MultiWayIf #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+
+-- |
+-- Module: Chainweb.Pact.PactService.ExecBlock
+-- Copyright: Copyright © 2020 Kadena LLC.
+-- License: See LICENSE file
+-- Maintainers: Lars Kuhtz, Emily Pillmore, Stuart Popejoy
+-- Stability: experimental
+--
+-- Functionality for playing block transactions.
+--
+module Chainweb.Pact.PactService.ExecBlock
+    ( setParentHeader
+    , playOneBlock
+    , execTransactions
+    , toHashCommandResult
+    , minerReward
+    , toPayloadWithOutputs
+    , validateChainwebTxs
+    , validateHashes
+    ) where
+
+import Control.DeepSeq
+import Control.Exception (evaluate)
+import Control.Lens
+import Control.Monad
+import Control.Monad.Catch
+import Control.Monad.Reader
+import Control.Monad.State.Strict
+
+import qualified Data.Aeson as A
+import qualified Data.ByteString.Short as SB
+import Data.Decimal
+import Data.Default (def)
+import Data.DList (DList(..))
+import qualified Data.DList as DL
+import Data.Either
+import Data.Foldable (toList)
+import qualified Data.HashMap.Strict as HM
+import qualified Data.Map as Map
+import Data.String.Conv (toS)
+import Data.Text (Text)
+import qualified Data.Text as T
+import qualified Data.Text.Encoding as T
+import Data.Tuple.Strict (T2(..))
+import Data.Vector (Vector)
+import qualified Data.Vector as V
+
+import System.IO
+
+import Prelude hiding (lookup)
+
+import Pact.Compile (compileExps)
+import qualified Pact.Interpreter as P
+import qualified Pact.Parse as P
+import qualified Pact.Types.Command as P
+import Pact.Types.Exp (ParsedCode(..))
+import Pact.Types.ExpParser (mkTextInfo)
+import qualified Pact.Types.Hash as P
+import Pact.Types.RPC
+import qualified Pact.Types.Runtime as P
+import qualified Pact.Types.SPV as P
+
+import Chainweb.BlockCreationTime
+import Chainweb.BlockHeader
+import Chainweb.BlockHeight
+import Chainweb.Mempool.Mempool as Mempool
+import Chainweb.Miner.Pact
+import Chainweb.Pact.Backend.Types
+import Chainweb.Pact.NoCoinbase
+import Chainweb.Pact.Service.Types
+import Chainweb.Pact.SPV
+import Chainweb.Pact.TransactionExec
+import Chainweb.Pact.Types
+import Chainweb.Pact.Utils
+import Chainweb.Payload
+import Chainweb.Payload.PayloadStore
+import Chainweb.Transaction
+import Chainweb.Utils hiding (check)
+import Chainweb.Version
+
+
+-- | Set parent header in state and spv support (using parent hash)
+setParentHeader :: String -> ParentHeader -> PactServiceM cas ()
+setParentHeader msg ph@(ParentHeader bh) = do
+  logDebug $ "setParentHeader: " ++ msg ++ ": " ++ show (_blockHash bh,_blockHeight bh)
+  modify' $ set psParentHeader ph
+  bdb <- view psBlockHeaderDb
+  modify' $ set psSpvSupport $! pactSPV bdb (_blockHash bh)
+
+-- | Execute a block -- only called in validate either for replay or for validating current block.
+--
+-- /NOTE:/
+--
+-- Any call of this function must occur within a dedicated call to
+-- 'withChwithCheckpointerRewind', 'withCurrentCheckpointer' or
+-- 'withCheckPointerWithoutRewind'.
+--
+playOneBlock
+    :: (PayloadCasLookup cas)
+    => BlockHeader
+        -- ^ this is the current header. We may consider changing this to the parent
+        -- header to avoid confusion with new block and prevent using data from this
+        -- header when we should use the respective values from the parent header
+        -- instead.
+    -> PayloadData
+    -> PactDbEnv'
+    -> PactServiceM cas (T2 Miner Transactions)
+playOneBlock currHeader plData pdbenv = do
+
+    unlessM ((> 0) <$> asks _psCheckpointerDepth) $ do
+        error $ "Code invariant violation: playOneBlock must be called with withCheckpointer. Please report this as a bug."
+
+    miner <- decodeStrictOrThrow' (_minerData $ _payloadDataMiner plData)
+    trans <- liftIO $ transactionsFromPayload plData
+    cp <- getCheckpointer
+
+    -- The reference time for tx timings validation.
+    --
+    -- The legacy behavior is to use the creation time of the /current/ header.
+    -- The new default behavior is to use the creation time of the /parent/ header.
+    --
+    (txValidationTime,lenientCreationTime) <- if
+        useLegacyCreationTimeForTxValidation v h || isGenesisBlockHeader currHeader
+      then
+        return (_blockCreationTime currHeader, False)
+      else do
+        parent <- use psParentHeader
+        return (_blockCreationTime $ _parentHeader parent, True)
+
+    -- prop_tx_ttl_validate
+    valids <- liftIO $ V.zip trans <$>
+        validateChainwebTxs v cid cp
+            txValidationTime lenientCreationTime
+            (_blockHeight currHeader) trans skipDebitGas
+
+    case foldr handleValids [] valids of
+      [] -> return ()
+      errs -> throwM $ TransactionValidationException $ errs
+
+    !results <- go miner trans
+    modify' $ set psStateValidated $ Just currHeader
+
+    -- Validate hashes if requested
+    asks _psValidateHashesOnReplay >>= \x -> when x $
+        either throwM (void . return) $!
+        validateHashes currHeader plData miner results
+
+    return $! T2 miner results
+
+  where
+
+    handleValids (tx,Left e) es = (P._cmdHash tx, sshow e):es
+    handleValids _ es = es
+
+    v = _chainwebVersion currHeader
+    h = _blockHeight currHeader
+    cid = _chainId currHeader
+
+    isGenesisBlock = isGenesisBlockHeader currHeader
+
+    go m txs = if isGenesisBlock
+      then do
+        -- GENESIS VALIDATE COINBASE: Reject bad coinbase, use date rule for precompilation
+        execTransactions True m txs
+          (EnforceCoinbaseFailure True) (CoinbaseUsePrecompiled False) pdbenv
+      else do
+        -- VALIDATE COINBASE: back-compat allow failures, use date rule for precompilation
+        execTransactions False m txs
+          (EnforceCoinbaseFailure False) (CoinbaseUsePrecompiled False) pdbenv
+
+
+-- | The principal validation logic for groups of Pact Transactions.
+--
+-- Skips validation for genesis transactions, since gas accounts, etc. don't
+-- exist yet.
+--
+validateChainwebTxs
+    :: ChainwebVersion
+    -> ChainId
+    -> Checkpointer
+    -> BlockCreationTime
+        -- ^ reference time for tx validation.
+        --
+        -- This time is the creation time of the parent header for calls from
+        -- newBlock. It is the creation time of the current header
+        -- for block validation if
+        -- @useLegacyCreationTimeForTxValidation blockHeight@ true.
+        --
+    -> Bool
+        -- ^ lenientCreationTime flag, see 'lenientTimeSlop' for details.
+    -> BlockHeight
+        -- ^ Current block height
+    -> Vector ChainwebTransaction
+    -> RunGas
+    -> IO ValidateTxs
+validateChainwebTxs v cid cp txValidationTime lenientCreationTime bh txs doBuyGas
+  | bh == genesisHeight v cid = pure $! V.map Right txs
+  | V.null txs = pure V.empty
+  | otherwise = go
+  where
+    go = V.mapM validations initTxList >>= doBuyGas
+
+    validations t = runValid checkUnique t
+      >>= runValid checkTimes
+      >>= runValid (return . checkCompile)
+
+    checkUnique :: ChainwebTransaction -> IO (Either InsertError ChainwebTransaction)
+    checkUnique t = do
+      found <- _cpLookupProcessedTx cp (P._cmdHash t)
+      case found of
+        Nothing -> pure $ Right t
+        Just _ -> pure $ Left InsertErrorDuplicate
+
+    checkTimes :: ChainwebTransaction -> IO (Either InsertError ChainwebTransaction)
+    checkTimes t
+        | timingsCheck txValidationTime lenientCreationTime $ fmap payloadObj t = return $ Right t
+        | otherwise = return $ Left InsertErrorInvalidTime
+
+    initTxList :: ValidateTxs
+    initTxList = V.map Right txs
+
+    runValid :: Monad m => (a -> m (Either e a)) -> Either e a -> m (Either e a)
+    runValid f (Right r) = f r
+    runValid _ l@Left{} = pure l
+
+
+type ValidateTxs = Vector (Either InsertError ChainwebTransaction)
+type RunGas = ValidateTxs -> IO ValidateTxs
+
+checkCompile :: ChainwebTransaction -> Either InsertError ChainwebTransaction
+checkCompile tx = case payload of
+  Exec (ExecMsg parsedCode _) ->
+    case compileCode parsedCode of
+      Left perr -> Left $ InsertErrorCompilationFailed (sshow perr)
+      Right _ -> Right tx
+  _ -> Right tx
+  where
+    payload = P._pPayload $ payloadObj $ P._cmdPayload tx
+    compileCode p =
+      compileExps (mkTextInfo (P._pcCode p)) (P._pcExps p)
+
+skipDebitGas :: RunGas
+skipDebitGas = return
+
+execTransactions
+    :: Bool
+    -> Miner
+    -> Vector ChainwebTransaction
+    -> EnforceCoinbaseFailure
+    -> CoinbaseUsePrecompiled
+    -> PactDbEnv'
+    -> PactServiceM cas Transactions
+execTransactions isGenesis miner ctxs enfCBFail usePrecomp (PactDbEnv' pactdbenv) = do
+    mc <- use psInitCache
+    coinOut <- runCoinbase isGenesis pactdbenv miner enfCBFail usePrecomp mc
+    txOuts <- applyPactCmds isGenesis pactdbenv ctxs miner mc
+    return $! Transactions (V.zip ctxs txOuts) coinOut
+
+runCoinbase
+    :: Bool
+    -> P.PactDbEnv p
+    -> Miner
+    -> EnforceCoinbaseFailure
+    -> CoinbaseUsePrecompiled
+    -> ModuleCache
+    -> PactServiceM cas (P.CommandResult [P.TxLog A.Value])
+runCoinbase True _ _ _ _ _ = return noCoinbase
+runCoinbase False dbEnv miner enfCBFail usePrecomp mc = do
+    logger <- view (psCheckpointEnv . cpeLogger)
+    rs <- view psMinerRewards
+    v <- view chainwebVersion
+    pd <- getTxContext def
+
+    let !bh = ctxCurrentBlockHeight pd
+
+    reward <- liftIO $! minerReward v rs bh
+
+    (T2 cr upgradedCacheM) <-
+      liftIO $! applyCoinbase v logger dbEnv miner reward pd enfCBFail usePrecomp mc
+    mapM_ upgradeInitCache upgradedCacheM
+    debugResult "runCoinbase" cr
+    return $! cr
+
+  where
+
+    upgradeInitCache newCache = do
+      logInfo "Updating init cache for upgrade"
+      modify' $ over psInitCache (HM.union newCache)
+
+
+-- | Apply multiple Pact commands, incrementing the transaction Id for each.
+-- The output vector is in the same order as the input (i.e. you can zip it
+-- with the inputs.)
+applyPactCmds
+    :: Bool
+    -> P.PactDbEnv p
+    -> Vector ChainwebTransaction
+    -> Miner
+    -> ModuleCache
+    -> PactServiceM cas (Vector (P.CommandResult [P.TxLog A.Value]))
+applyPactCmds isGenesis env cmds miner mc =
+    V.fromList . toList . sfst <$> V.foldM f (T2 mempty mc) cmds
+  where
+    f  (T2 dl mcache) cmd = applyPactCmd isGenesis env cmd miner mcache dl
+
+-- | Apply a single Pact command
+applyPactCmd
+    :: Bool
+    -> P.PactDbEnv p
+    -> ChainwebTransaction
+    -> Miner
+    -> ModuleCache
+    -> DList (P.CommandResult [P.TxLog A.Value])
+    -> PactServiceM cas (T2 (DList (P.CommandResult [P.TxLog A.Value])) ModuleCache)
+applyPactCmd isGenesis dbEnv cmdIn miner mcache dl = do
+    logger <- view (psCheckpointEnv . cpeLogger)
+    gasModel <- view psGasModel
+    v <- view psVersion
+
+    T2 result mcache' <- if isGenesis
+      then liftIO $! applyGenesisCmd logger dbEnv P.noSPVSupport (payloadObj <$> cmdIn)
+      else do
+        pd <- getTxContext (publicMetaOf $ payloadObj <$> cmdIn)
+        spv <- use psSpvSupport
+        liftIO $! applyCmd v logger dbEnv miner gasModel pd spv cmdIn mcache
+        {- the following can be used instead of above to nerf transaction execution
+        return $! T2 (P.CommandResult (P.cmdToRequestKey cmdIn) Nothing
+                      (P.PactResult (Right (P.PLiteral (P.LInteger 1))))
+                      0 Nothing Nothing Nothing)
+                      mcache -}
+
+    when isGenesis $
+      psInitCache <>= mcache'
+
+    unless isGenesis $ debugResult "applyPactCmd" result
+
+    cp <- getCheckpointer
+    -- mark the tx as processed at the checkpointer.
+    liftIO $ _cpRegisterProcessedTx cp (P._cmdHash cmdIn)
+    pure $! T2 (DL.snoc dl result) mcache'
+
+toHashCommandResult :: P.CommandResult [P.TxLog A.Value] -> P.CommandResult P.Hash
+toHashCommandResult = over (P.crLogs . _Just) $ P.pactHash . encodeToByteString
+
+transactionsFromPayload :: PayloadData -> IO (Vector ChainwebTransaction)
+transactionsFromPayload plData = do
+    vtrans <- fmap V.fromList $
+              mapM toCWTransaction $
+              toList (_payloadDataTransactions plData)
+    let (theLefts, theRights) = partitionEithers $ V.toList vtrans
+    unless (null theLefts) $ do
+        let ls = map T.pack theLefts
+        throwM $ TransactionDecodeFailure $ "Failed to decode pact transactions: "
+            <> T.intercalate ". " ls
+    return $! V.fromList theRights
+  where
+    toCWTransaction bs = evaluate (force (codecDecode chainwebPayloadCodec $
+                                          _transactionBytes bs))
+
+debugResult :: A.ToJSON a => Text -> a -> PactServiceM cas ()
+debugResult msg result =
+  logDebug $ T.unpack $ trunc $ msg <> " result: " <> encodeToText result
+  where
+    trunc t | T.length t < limit = t
+            | otherwise = T.take limit t <> " [truncated]"
+    limit = 5000
+
+
+-- | Calculate miner reward. We want this to error hard in the case where
+-- block times have finally exceeded the 120-year range. Rewards are calculated
+-- at regular blockheight intervals.
+--
+-- See: 'rewards/miner_rewards.csv'
+--
+minerReward
+    :: ChainwebVersion
+    -> MinerRewards
+    -> BlockHeight
+    -> IO P.ParsedDecimal
+minerReward v (MinerRewards rs) bh =
+    case Map.lookupGE bh rs of
+      Nothing -> err
+      Just (_, m) -> pure $! P.ParsedDecimal (roundTo 8 (m / n))
+  where
+    !n = int . order $ chainGraphAt v bh
+    err = internalError "block heights have been exhausted"
+{-# INLINE minerReward #-}
+
+
+data CRLogPair = CRLogPair P.Hash [P.TxLog A.Value]
+instance A.ToJSON CRLogPair where
+  toJSON (CRLogPair h logs) = A.object
+    [ "hash" A..= h
+    , "rawLogs" A..= logs ]
+
+validateHashes
+    :: BlockHeader
+        -- ^ Current Header
+    -> PayloadData
+    -> Miner
+    -> Transactions
+    -> Either PactException PayloadWithOutputs
+validateHashes bHeader pData miner transactions =
+    if newHash == prevHash
+    then Right pwo
+    else Left $ BlockValidationFailure $ A.object
+         [ "mismatch" A..= errorMsg "Payload hash" prevHash newHash
+         , "details" A..= details
+         ]
+    where
+
+      pwo = toPayloadWithOutputs miner transactions
+
+      newHash = _payloadWithOutputsPayloadHash pwo
+      prevHash = _blockPayloadHash bHeader
+
+      newTransactions = V.map fst (_payloadWithOutputsTransactions pwo)
+      prevTransactions = _payloadDataTransactions pData
+
+      newMiner = _payloadWithOutputsMiner pwo
+      prevMiner = _payloadDataMiner pData
+
+      newTransactionsHash = _payloadWithOutputsTransactionsHash pwo
+      prevTransactionsHash = _payloadDataTransactionsHash pData
+
+      newOutputsHash = _payloadWithOutputsOutputsHash pwo
+      prevOutputsHash = _payloadDataOutputsHash pData
+
+      check desc extra expect actual
+        | expect == actual = []
+        | otherwise =
+          [A.object $ "mismatch" A..= errorMsg desc expect actual :  extra]
+
+      errorMsg desc expect actual = A.object
+        [ "type" A..= (desc :: Text)
+        , "actual" A..= actual
+        , "expected" A..= expect
+        ]
+
+      checkTransactions prev new =
+        ["txs" A..= concatMap (uncurry (check "Tx" [])) (V.zip prev new)]
+
+      addOutputs (Transactions pairs coinbase) =
+        [ "outputs" A..= A.object
+         [ "coinbase" A..= toPairCR coinbase
+         , "txs" A..= (addTxOuts <$> pairs)
+         ]
+        ]
+
+      addTxOuts :: (ChainwebTransaction, P.CommandResult [P.TxLog A.Value]) -> A.Value
+      addTxOuts (tx,cr) = A.object
+        [ "tx" A..= fmap (fmap _pcCode . payloadObj) tx
+        , "result" A..= toPairCR cr
+        ]
+
+      toPairCR cr = over (P.crLogs . _Just)
+        (CRLogPair (fromJuste $ P._crLogs (toHashCommandResult cr))) cr
+
+      details = concat
+        [ check "Miner" [] prevMiner newMiner
+        , check "TransactionsHash" (checkTransactions prevTransactions newTransactions)
+          prevTransactionsHash newTransactionsHash
+        , check "OutputsHash" (addOutputs transactions)
+          prevOutputsHash newOutputsHash
+        ]
+
+
+toTransactionBytes :: P.Command Text -> Transaction
+toTransactionBytes cwTrans =
+    let plBytes = encodeToByteString cwTrans
+    in Transaction { _transactionBytes = plBytes }
+
+
+toOutputBytes :: P.CommandResult P.Hash -> TransactionOutput
+toOutputBytes cr =
+    let outBytes = A.encode cr
+    in TransactionOutput { _transactionOutputBytes = toS outBytes }
+
+toPayloadWithOutputs :: Miner -> Transactions -> PayloadWithOutputs
+toPayloadWithOutputs mi ts =
+    let oldSeq = _transactionPairs ts
+        trans = cmdBSToTx . fst <$> oldSeq
+        transOuts = toOutputBytes . toHashCommandResult . snd <$> oldSeq
+
+        miner = toMinerData mi
+        cb = CoinbaseOutput $ encodeToByteString $ toHashCommandResult $ _transactionCoinbase ts
+        blockTrans = snd $ newBlockTransactions miner trans
+        cmdBSToTx = toTransactionBytes
+          . fmap (T.decodeUtf8 . SB.fromShort . payloadBytes)
+        blockOuts = snd $ newBlockOutputs cb transOuts
+
+        blockPL = blockPayload blockTrans blockOuts
+        plData = payloadData blockTrans blockPL
+     in payloadWithOutputs plData cb transOuts

--- a/src/Chainweb/Pact/Service/PactInProcApi.hs
+++ b/src/Chainweb/Pact/Service/PactInProcApi.hs
@@ -44,6 +44,7 @@ import Chainweb.Mempool.Consensus
 import Chainweb.Mempool.Mempool
 import Chainweb.NodeId
 import Chainweb.Pact.Backend.Types
+import Chainweb.Pact.Backend.Utils
 import Chainweb.Pact.Service.Types
 import qualified Chainweb.Pact.PactService as PS
 import Chainweb.Pact.Service.PactQueue
@@ -70,7 +71,7 @@ withPactService
     -> (PactQueue -> IO a)
     -> IO a
 withPactService ver cid logger mpc bhdb pdb dbDir nodeid config action =
-    PS.withSqliteDb ver cid logger dbDir nodeid (_pactResetDb config) $ \sqlenv ->
+    withSqliteDb ver cid logger dbDir nodeid (_pactResetDb config) $ \sqlenv ->
         withPactService' ver cid logger mpa bhdb pdb sqlenv config action
   where
     mpa = pactMemPoolAccess mpc logger

--- a/src/Chainweb/Pact/TransactionExec.hs
+++ b/src/Chainweb/Pact/TransactionExec.hs
@@ -96,7 +96,7 @@ import Chainweb.Miner.Pact
 import Chainweb.Pact.Service.Types
 import Chainweb.Pact.Templates
 import Chainweb.Pact.Transactions.UpgradeTransactions
-import Chainweb.Pact.Types
+import Chainweb.Pact.Types hiding (logError)
 import Chainweb.Transaction
 import Chainweb.Utils (encodeToByteString, sshow, tryAllSynchronous)
 import Chainweb.Version as V

--- a/test/Chainweb/Test/Pact/ModuleCacheOnRestart.hs
+++ b/test/Chainweb/Test/Pact/ModuleCacheOnRestart.hs
@@ -35,6 +35,7 @@ import Chainweb.ChainId
 import Chainweb.Logger
 import Chainweb.Miner.Pact
 import Chainweb.Pact.PactService
+import Chainweb.Pact.Backend.Utils
 import Chainweb.Pact.Types
 import Chainweb.Payload
 import Chainweb.Payload.PayloadStore

--- a/test/Chainweb/Test/Pact/PactExec.hs
+++ b/test/Chainweb/Test/Pact/PactExec.hs
@@ -48,6 +48,7 @@ import Chainweb.BlockHeaderDB (BlockHeaderDb)
 import Chainweb.Graph
 import Chainweb.Miner.Pact
 import Chainweb.Pact.PactService
+import Chainweb.Pact.PactService.ExecBlock
 import Chainweb.Pact.Types
 import Chainweb.Pact.Service.Types
 import Chainweb.Payload

--- a/test/Chainweb/Test/Pact/RewardsTest.hs
+++ b/test/Chainweb/Test/Pact/RewardsTest.hs
@@ -12,7 +12,7 @@ import Pact.Parse
 
 import Chainweb.Graph
 import Chainweb.Miner.Pact
-import Chainweb.Pact.PactService
+import Chainweb.Pact.PactService.ExecBlock
 import Chainweb.Test.Utils
 import Chainweb.Version
 

--- a/tools/ea/Ea.hs
+++ b/tools/ea/Ea.hs
@@ -51,6 +51,7 @@ import Text.Printf
 import Chainweb.BlockHeaderDB
 import Chainweb.Logger (genericLogger)
 import Chainweb.Miner.Pact (noMiner)
+import Chainweb.Pact.Backend.Utils
 import Chainweb.Pact.PactService
 import Chainweb.Pact.Types (defaultPactServiceConfig)
 import Chainweb.Pact.Utils (toTxCreationTime)


### PR DESCRIPTION
Motivated by wanting Checkpointer interactions in a submodule, `ExecBlock` submodule became necessary for shared deps, and moved other things into various Types and Utils modules.