### PR TITLE
Remove legacy tx timing validation code

### DIFF
--- a/src/Chainweb/Pact/PactService/ExecBlock.hs
+++ b/src/Chainweb/Pact/PactService/ExecBlock.hs
@@ -133,7 +133,7 @@ execBlock currHeader plData pdbenv = do
       then
         return (ParentCreationTime $ _blockCreationTime currHeader)
       else
-         (ParentCreationTime . _blockCreationTime . _parentHeader) <$> use psParentHeader
+         ParentCreationTime . _blockCreationTime . _parentHeader <$> use psParentHeader
 
     -- prop_tx_ttl_validate
     valids <- liftIO $ V.zip trans <$>

--- a/src/Chainweb/Pact/Utils.hs
+++ b/src/Chainweb/Pact/Utils.hs
@@ -77,7 +77,7 @@ maxTTL = ParsedInteger $ 2 * 24 * 60 * 60
 -- Timing checks used to be based on the creation time of the validated
 -- block. That changed on mainnet at block height 449940. Tx creation time
 -- and TTL don't affect the tx outputs and pact state and can thus be
--- when replaying old blocks.
+-- skipped when replaying old blocks.
 --
 timingsCheck
     :: ParentCreationTime

--- a/src/Chainweb/Pact/Utils.hs
+++ b/src/Chainweb/Pact/Utils.hs
@@ -34,6 +34,7 @@ import Pact.Types.ChainMeta
 import Pact.Types.Command
 
 import Chainweb.BlockCreationTime
+import Chainweb.BlockHeader
 import Chainweb.ChainId
 import Chainweb.Pact.Backend.Types
 import Chainweb.Time
@@ -72,17 +73,17 @@ maxTTL = ParsedInteger $ 2 * 24 * 60 * 60
 -- This is probably going to be changed. Let us make it 2 days for now.
 
 -- prop_tx_ttl_newBlock/validateBlock
+--
+-- Timing checks used to be based on the creation time of the validated
+-- block. That changed on mainnet at block height 449940. Tx creation time
+-- and TTL don't affect the tx outputs and pact state and can thus be
+-- when replaying old blocks.
+--
 timingsCheck
-    :: BlockCreationTime
-        -- ^ reference time for tx validation.
-        --  If @useLegacyCreationTimeForTxValidation blockHeight@
-        --  this is the the creation time of the current block. Otherwise it
-        --  is the creation time of the parent block header.
-    -> Bool
-        -- ^ use lenient creation time validation. See 'lenientTimeSlop' for details.
+    :: ParentCreationTime
     -> Command (Payload PublicMeta ParsedCode)
     -> Bool
-timingsCheck (BlockCreationTime txValidationTime) lenientCreationTime tx =
+timingsCheck (ParentCreationTime (BlockCreationTime txValidationTime)) tx =
     ttl > 0
     && txValidationTime >= timeFromSeconds 0
     && txOriginationTime >= 0
@@ -93,9 +94,7 @@ timingsCheck (BlockCreationTime txValidationTime) lenientCreationTime tx =
     (TTLSeconds ttl) = timeToLiveOf tx
     timeFromSeconds = Time . secondsToTimeSpan . Seconds . fromIntegral
     (TxCreationTime txOriginationTime) = creationTimeOf tx
-    lenientTxValidationTime
-      | lenientCreationTime = add (scaleTimeSpan lenientTimeSlop second) txValidationTime
-      | otherwise = txValidationTime
+    lenientTxValidationTime = add (scaleTimeSpan lenientTimeSlop second) txValidationTime
 
 -- | Validation "slop" to allow for a more lenient creation time check after
 -- @useLegacyCreationTimeForTxValidation@ is no longer true.

--- a/src/Chainweb/Version.hs
+++ b/src/Chainweb/Version.hs
@@ -51,7 +51,7 @@ module Chainweb.Version
 , coinV2Upgrade
 , to20ChainRebalance
 , pactBackCompat_v16
-, useLegacyCreationTimeForTxValidation
+, skipTxTimingValidation
 , enableModuleNameFix
 , enableModuleNameFix2
 -- ** BlockHeader Validation Guards
@@ -809,17 +809,15 @@ pactBackCompat_v16 :: ChainwebVersion -> BlockHeight -> Bool
 pactBackCompat_v16 Mainnet01 h = h < 328000
 pactBackCompat_v16 _ _ = False
 
--- | If this is true the creation time of the current header is used for pact tx
--- creation time and ttl validation.
+-- | Early versions of chainweb used the creation time of the current header
+-- for validation of pact tx creation time and TTL. Nowadays the times of
+-- the parent header a used.
 --
--- Once the block height for triggering this on mainnet is in the past, the
--- result of this guard becomes trivial for `newBlock` applications and the
--- dependency of `newBlock` on the creation time of the current header can be
--- removed.
+-- When this guard is enabled timing validation is skipped.
 --
-useLegacyCreationTimeForTxValidation :: ChainwebVersion -> BlockHeight -> Bool
-useLegacyCreationTimeForTxValidation Mainnet01 h = h < 449940 -- ~ 2020-04-03T00:00:00Z
-useLegacyCreationTimeForTxValidation _ h = h <= 1
+skipTxTimingValidation :: ChainwebVersion -> BlockHeight -> Bool
+skipTxTimingValidation Mainnet01 h = h < 449940 -- ~ 2020-04-03T00:00:00Z
+skipTxTimingValidation _ h = h <= 1
     -- For most chainweb versions there is a large gap between creation times of
     -- the genesis blocks and the corresponding first blocks.
     --


### PR DESCRIPTION
This PR simplifies the tx timing validation code.

Early versions of chainweb used the creation time of the current block header for timing validation. Recent version use the parent creation time. Special logic was needed during the transition period, which now can be removed.

In addition to removing transition code, this PR also simplifies the handling of old blocks. Since, once a tx passes timing validation, it has no further effect on the pact validation of the tx, it is possible to just skip the timing validation for historic blocks.