### PR TITLE
Update mempool after execValidateBlock and keep track of committed txs

### DIFF
--- a/chainweb.cabal
+++ b/chainweb.cabal
@@ -176,6 +176,7 @@ library
         , Chainweb.Logging.Config
         , Chainweb.Logging.Miner
         , Chainweb.Mempool.Consensus
+        , Chainweb.Mempool.CurrentTxIndex
         , Chainweb.Mempool.InMem
         , Chainweb.Mempool.InMemTypes
         , Chainweb.Mempool.Mempool

--- a/chainweb.cabal
+++ b/chainweb.cabal
@@ -177,7 +177,7 @@ library
         , Chainweb.Logging.Config
         , Chainweb.Logging.Miner
         , Chainweb.Mempool.Consensus
-        , Chainweb.Mempool.CurrentTxIndex
+        , Chainweb.Mempool.CurrentTxs
         , Chainweb.Mempool.InMem
         , Chainweb.Mempool.InMemTypes
         , Chainweb.Mempool.Mempool

--- a/src/Chainweb/Chainweb.hs
+++ b/src/Chainweb/Chainweb.hs
@@ -583,10 +583,16 @@ validatingMempoolConfig cid v gl mv = Mempool.InMemConfig
     , Mempool._inmemMaxRecentItems = maxRecentLog
     , Mempool._inmemPreInsertPureChecks = preInsertSingle
     , Mempool._inmemPreInsertBatchChecks = preInsertBatch
+    , Mempool._inmemCurrentTxsSize = currentTxsSize
     }
   where
     txcfg = Mempool.chainwebTransactionConfig
     maxRecentLog = 2048
+
+    currentTxsSize = 1024 * 1024 -- ~16MB per mempool
+        -- 1M items is is sufficient for supporing about 12 TPS per chain, which
+        -- is about 360 tx per block. Larger TPS values would result in false
+        -- negatives in the set.
 
     preInsertSingle :: ChainwebTransaction -> Either Mempool.InsertError ChainwebTransaction
     preInsertSingle tx = checkMetadata tx

--- a/src/Chainweb/Mempool/CurrentTxIndex.hs
+++ b/src/Chainweb/Mempool/CurrentTxIndex.hs
@@ -1,0 +1,156 @@
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+-- |
+-- Module: Chainweb.Mempool.CurrentTxIndex
+-- Copyright: Copyright © 2020 Kadena LLC.
+-- License: MIT
+-- Maintainer: Lars Kuhtz <lars@kadena.io>
+-- Stability: experimental
+--
+-- A probabilistic index for non-expired transactions.
+--
+-- The false positive rate is very low. False negatives rate is 0 when the
+-- number of entries is smaller than 'maxCurrentTxIdxSize' and grows with each
+-- entry beyond that size.
+--
+-- The purpose of this data structure is to allow the mempool to keep track of
+-- transactions that haven't yet expired and have already been included in a
+-- block. A false positive causes the mempool to ignore a valid transactions. A
+-- false negative causes the mempool to mark a transactions as pending which has
+-- already been included in a block. The transaction would only be rejected by
+-- pact service during new block validation once it has been included in another
+-- block.
+--
+module Chainweb.Mempool.CurrentTxIndex
+( CurrentTxIdx
+, newCurrentTxIdx
+, currentTxIdxSize
+, currentTxIdxInsert
+, currentTxIdxInsertBatch
+, currentTxIdxMember
+, currentTxIdxRemove
+) where
+
+import qualified Data.ByteString as B
+import qualified Data.ByteString.Short as BS
+import qualified Data.List as L
+import qualified Data.Set as S
+import qualified Data.Vector as V
+
+import Numeric.Natural
+
+import System.Random
+
+-- internal imports
+
+-- import Chainweb.Mempool.InMemTypes
+import Chainweb.Mempool.Mempool
+import Chainweb.Time
+import Chainweb.Utils
+
+-- -------------------------------------------------------------------------- --
+-- Configuration
+
+-- | Limits the size of the commit log. If the size is reached elements are
+-- deleted, and queries may return false negatives. Not guarantee is made about
+-- what elements are deleted.
+--
+-- 16 MB ~ 1000000 entries
+--
+maxCurrentTxIdxSize :: Natural
+maxCurrentTxIdxSize = 1024 * 1024
+
+-- -------------------------------------------------------------------------- --
+-- Keys
+
+-- | The first 8 bytes are the expiration time of the key, the remaining 8 bytes
+-- are the first 8 bytes of tx hash. These two number provide plenty of entropy
+-- to make collisions very unlikely. In the rare event of an collision, the
+-- mempool may ignore some legitimate txs.
+--
+data CurrentTxIdxKey = CurrentTxIdxKey
+    { _currentTxIdxExpiration :: {-# UNPACK #-} !(Time Micros)
+    , _currentTxIdxKey :: {-# UNPACK #-} !BS.ShortByteString
+    }
+    deriving (Show, Eq, Ord)
+
+getCurrentTxIdxKey :: Time Micros -> TransactionHash -> CurrentTxIdxKey
+getCurrentTxIdxKey expiry h = CurrentTxIdxKey
+    { _currentTxIdxExpiration = expiry
+    , _currentTxIdxKey = BS.toShort $ B.take 8 $ BS.fromShort $ unTransactionHash h
+    }
+
+-- -------------------------------------------------------------------------- --
+-- Index
+
+newtype CurrentTxIdx = CurrentTxIdx { _currentTxIdx :: S.Set CurrentTxIdxKey }
+
+newCurrentTxIdx :: CurrentTxIdx
+newCurrentTxIdx = CurrentTxIdx mempty
+
+currentTxIdxSize :: CurrentTxIdx -> Int
+currentTxIdxSize (CurrentTxIdx s) = S.size s
+{-# INLINE currentTxIdxSize #-}
+
+-- Membership
+
+currentTxIdxMember :: CurrentTxIdx -> Time Micros -> TransactionHash -> Bool
+currentTxIdxMember s expiry h = S.member (getCurrentTxIdxKey expiry h) (_currentTxIdx s)
+{-# INLINE currentTxIdxMember #-}
+
+-- Insertion
+
+-- | If the set is full random elements are deleted.
+--
+currentTxIdxInsert :: CurrentTxIdx -> Time Micros -> TransactionHash -> IO CurrentTxIdx
+currentTxIdxInsert s expiry h =
+    CurrentTxIdx . S.insert (getCurrentTxIdxKey expiry h) . _currentTxIdx
+    <$> pruneCurrentTxIdx s
+
+currentTxIdxInsertBatch
+    :: CurrentTxIdx
+    -> V.Vector (Time Micros, TransactionHash)
+    -> IO CurrentTxIdx
+currentTxIdxInsertBatch s txs = do
+    s0 <- pruneCurrentTxIdx s
+    let s1 = CurrentTxIdx $ foldr ins (_currentTxIdx s0) txs
+    pruneCurrentTxIdx s1
+  where
+    ins (e, h) = S.insert (getCurrentTxIdxKey e h)
+
+-- Deletion
+
+currentTxIdxRemove :: CurrentTxIdx -> Time Micros -> TransactionHash -> CurrentTxIdx
+currentTxIdxRemove (CurrentTxIdx s) expiry h = CurrentTxIdx $
+    S.delete (getCurrentTxIdxKey expiry h) s
+{-# INLINE currentTxIdxRemove #-}
+
+-- Pruning
+
+pruneCurrentTxIdx :: CurrentTxIdx -> IO CurrentTxIdx
+pruneCurrentTxIdx (CurrentTxIdx s) = do
+    now <- getCurrentTimeIntegral
+    let s0 = S.dropWhileAntitone (\x -> _currentTxIdxExpiration x < now) s
+        l = S.size s0
+
+    -- a random set of distinct set indexes that are going to be deleted to make
+    -- room for the new entry. For performance reasons we delete elements in
+    -- chunks of 1000.
+    --
+    indexesToBeDeleted <- if l >= int maxCurrentTxIdxSize
+      then
+        -- The following terminates because n <= l
+        --
+        -- @maxCurrentTxIdxSize@ should be much larger than 1000. The worst case
+        -- expected running time is for @1000 == maxCurrentTxIdxSize@, which still
+        -- is very fast.
+        --
+        let n = min l (max 1000 (l - int maxCurrentTxIdxSize))
+        in take n . L.nub . randomRs (0, l-1) <$> newStdGen
+      else return []
+
+    -- Not sure if foldl' would be faster here
+    return $ CurrentTxIdx $! foldr S.deleteAt s0 indexesToBeDeleted
+

--- a/src/Chainweb/Mempool/CurrentTxIndex.hs
+++ b/src/Chainweb/Mempool/CurrentTxIndex.hs
@@ -115,8 +115,7 @@ currentTxIdxInsertBatch
     -> IO CurrentTxIdx
 currentTxIdxInsertBatch s txs = do
     s0 <- pruneCurrentTxIdx s
-    let s1 = CurrentTxIdx $ foldr ins (_currentTxIdx s0) txs
-    pruneCurrentTxIdx s1
+    pruneCurrentTxIdx $ CurrentTxIdx $ foldr ins (_currentTxIdx s0) txs
   where
     ins (e, h) = S.insert (getCurrentTxIdxKey e h)
 

--- a/src/Chainweb/Mempool/CurrentTxs.hs
+++ b/src/Chainweb/Mempool/CurrentTxs.hs
@@ -53,9 +53,9 @@ import Chainweb.Utils
 -- -------------------------------------------------------------------------- --
 -- Configuration
 
--- | Limits the size of the commit log. If the size is reached elements are
--- deleted, and queries may return false negatives. Not guarantee is made about
--- what elements are deleted.
+-- | Limits the size of the set of current txs. If the size is reached elements are
+-- deleted, and queries may return false negatives. No guarantee is made about
+-- which elements are deleted.
 --
 -- 16 MB ~ 1000000 entries
 --
@@ -152,4 +152,3 @@ pruneCurrentTxs (CurrentTxs s) = do
 
     -- Not sure if foldl' would be faster here
     return $ CurrentTxs $! foldr S.deleteAt s0 indexesToBeDeleted
-

--- a/src/Chainweb/Mempool/CurrentTxs.hs
+++ b/src/Chainweb/Mempool/CurrentTxs.hs
@@ -35,6 +35,7 @@ module Chainweb.Mempool.CurrentTxs
 
 import qualified Data.ByteString as B
 import qualified Data.ByteString.Short as BS
+import Data.Foldable
 import qualified Data.List as L
 import qualified Data.Set as S
 import qualified Data.Vector as V
@@ -115,9 +116,9 @@ currentTxsInsertBatch
     -> IO CurrentTxs
 currentTxsInsertBatch s txs = do
     s0 <- pruneCurrentTxs s
-    pruneCurrentTxs $ CurrentTxs $ foldr ins (_currentTxs s0) txs
+    pruneCurrentTxs $ CurrentTxs $ foldl' ins (_currentTxs s0) txs
   where
-    ins (e, h) = S.insert (getCurrentTxsKey e h)
+    ins x (e, h) = S.insert (getCurrentTxsKey e h) x
 
 -- Deletion
 
@@ -151,4 +152,4 @@ pruneCurrentTxs (CurrentTxs s) = do
       else return []
 
     -- Not sure if foldl' would be faster here
-    return $ CurrentTxs $! foldr S.deleteAt s0 indexesToBeDeleted
+    return $ CurrentTxs $! foldl' (flip S.deleteAt) s0 indexesToBeDeleted

--- a/src/Chainweb/Mempool/InMem.hs
+++ b/src/Chainweb/Mempool/InMem.hs
@@ -130,7 +130,7 @@ toMempoolBackend logger mempool = do
     nonce = _inmemNonce mempool
     lockMVar = _inmemDataLock mempool
 
-    InMemConfig tcfg _ _ _ _ = cfg
+    InMemConfig tcfg _ _ _ _ _ = cfg
     member = memberInMem lockMVar
     lookup = lookupInMem tcfg lockMVar
     insert = insertInMem cfg lockMVar

--- a/src/Chainweb/Mempool/InMemTypes.hs
+++ b/src/Chainweb/Mempool/InMemTypes.hs
@@ -40,7 +40,7 @@ import Pact.Types.Gas (GasPrice(..))
 
 -- internal imports
 
-import Chainweb.Mempool.CurrentTxIndex
+import Chainweb.Mempool.CurrentTxs
 import Chainweb.Mempool.Mempool
 import Chainweb.Time (Micros(..), Time(..))
 
@@ -97,7 +97,7 @@ data InMemoryMempoolData t = InMemoryMempoolData {
     -- known to be bad. Those must not be attempted again because the user would
     -- possibly have to pay gas for it several times.
 
-  , _inmemCurrentTxIdx :: !(IORef CurrentTxIdx)
+  , _inmemCurrentTxs :: !(IORef CurrentTxs)
     -- ^ The set of non-expired transactions that have been addeded to a block.
     -- Transactions are remove from the set of pending transactions when they
     -- are added to a block. This set is used to prevent transactions from being
@@ -117,7 +117,7 @@ data MempoolStats = MempoolStats
     { _mStatsPendingCount :: {-# UNPACK #-} !Int
     , _mStatsRecentCount :: {-# UNPACK #-} !Int
     , _mStatsBadlistCount :: {-# UNPACK #-} !Int
-    , _mStatsCurrentTxIdxCount :: {-# UNPACK #-} !Int
+    , _mStatsCurrentTxsCount :: {-# UNPACK #-} !Int
     }
     deriving (Show, Eq, Ord, Generic)
     deriving anyclass (ToJSON, NFData)

--- a/src/Chainweb/Mempool/InMemTypes.hs
+++ b/src/Chainweb/Mempool/InMemTypes.hs
@@ -36,6 +36,8 @@ import qualified Data.Vector as V
 
 import GHC.Generics
 
+import Numeric.Natural
+
 import Pact.Types.Gas (GasPrice(..))
 
 -- internal imports
@@ -67,6 +69,12 @@ data InMemConfig t = InMemConfig {
   , _inmemPreInsertBatchChecks
         :: V.Vector (T2 TransactionHash t)
         -> IO (V.Vector (Either (T2 TransactionHash InsertError) (T2 TransactionHash t)))
+  , _inmemCurrentTxsSize :: !Natural
+    -- ^ The number of active transactions in validated blocks that can be
+    -- distinguished. If there are more txs than this number, checks can
+    -- return false negatives (and a very small amount of false positives).
+    --
+    -- The set uses 16 bytes per entry.
 }
 
 ------------------------------------------------------------------------------

--- a/src/Chainweb/Mempool/InMemTypes.hs
+++ b/src/Chainweb/Mempool/InMemTypes.hs
@@ -40,6 +40,7 @@ import Pact.Types.Gas (GasPrice(..))
 
 -- internal imports
 
+import Chainweb.Mempool.CurrentTxIndex
 import Chainweb.Mempool.Mempool
 import Chainweb.Time (Micros(..), Time(..))
 
@@ -85,6 +86,7 @@ data InMemoryMempoolData t = InMemoryMempoolData {
   , _inmemPending :: !(IORef PendingMap)
   , _inmemRecentLog :: !(IORef RecentLog)
   , _inmemBadMap :: !(IORef BadMap)
+  , _inmemCurrentTxIdx :: !(IORef CurrentTxIdx)
 }
 
 ------------------------------------------------------------------------------
@@ -99,6 +101,7 @@ data MempoolStats = MempoolStats
     { _mStatsPendingCount :: {-# UNPACK #-} !Int
     , _mStatsRecentCount :: {-# UNPACK #-} !Int
     , _mStatsBadlistCount :: {-# UNPACK #-} !Int
+    , _mStatsCurrentTxIdxCount :: {-# UNPACK #-} !Int
     }
     deriving (Show, Eq, Ord, Generic)
     deriving anyclass (ToJSON, NFData)

--- a/src/Chainweb/Mempool/InMemTypes.hs
+++ b/src/Chainweb/Mempool/InMemTypes.hs
@@ -83,10 +83,26 @@ type BadMap = HashMap TransactionHash (Time Micros)
 ------------------------------------------------------------------------------
 data InMemoryMempoolData t = InMemoryMempoolData {
     _inmemCountPending :: !(IORef Int)
+    -- ^ The number of pending transactions
+
   , _inmemPending :: !(IORef PendingMap)
+    -- ^ The set of pending transactions
+
   , _inmemRecentLog :: !(IORef RecentLog)
+    -- ^ The log of all recently added transactions. This is used to compute the
+    -- highwater mark for synchronization with remote mempools.
+
   , _inmemBadMap :: !(IORef BadMap)
+    -- ^ Non-expired transactions that failed during pact validation and are
+    -- known to be bad. Those must not be attempted again because the user would
+    -- possibly have to pay gas for it several times.
+
   , _inmemCurrentTxIdx :: !(IORef CurrentTxIdx)
+    -- ^ The set of non-expired transactions that have been addeded to a block.
+    -- Transactions are remove from the set of pending transactions when they
+    -- are added to a block. This set is used to prevent transactions from being
+    -- re-inserts when synchronizing with nodes that haven't yet validated the
+    -- block.
 }
 
 ------------------------------------------------------------------------------

--- a/src/Chainweb/Mempool/Mempool.hs
+++ b/src/Chainweb/Mempool/Mempool.hs
@@ -241,7 +241,7 @@ data MempoolBackend t = MempoolBackend {
   , mempoolInsertCheck :: Vector t -> IO (Either (T2 TransactionHash InsertError) ())
 
     -- | Remove the given hashes from the pending set.
-  , mempoolMarkValidated :: Vector TransactionHash -> IO ()
+  , mempoolMarkValidated :: Vector t -> IO ()
 
     -- | Mark a transaction as bad.
   , mempoolAddToBadList :: TransactionHash -> IO ()

--- a/src/Chainweb/Mempool/RestAPI.hs
+++ b/src/Chainweb/Mempool/RestAPI.hs
@@ -49,9 +49,9 @@ import Chainweb.Version
 
 ------------------------------------------------------------------------------
 -- type-indexed mempool
-newtype Mempool_ (v :: ChainwebVersionT) (c :: ChainIdT) (t :: Type) = Mempool_ {
-    _mrMempool :: MempoolBackend t
-  }
+newtype Mempool_ (v :: ChainwebVersionT) (c :: ChainIdT) (t :: Type) = Mempool_
+    { _mrMempool :: MempoolBackend t
+    }
 
 data SomeMempool t = forall v c
     . (KnownChainwebVersionSymbol v, KnownChainIdSymbol c)
@@ -84,42 +84,60 @@ instance FromJSON PendingTransactions where
 
 ------------------------------------------------------------------------------
 -- servant sub-api
-mempoolApi :: forall (v :: ChainwebVersionT) (c :: ChainIdT) .
-              Proxy (MempoolApi v c)
+
+mempoolApi
+    :: forall (v :: ChainwebVersionT) (c :: ChainIdT)
+    . Proxy (MempoolApi v c)
 mempoolApi = Proxy
 
-type MempoolApi v c = MempoolInsertApi v c :<|>
-                        MempoolMemberApi v c :<|>
-                        MempoolLookupApi v c :<|>
-                        MempoolGetPendingApi v c
+type MempoolApi v c
+    = MempoolInsertApi v c
+    :<|> MempoolMemberApi v c
+    :<|> MempoolLookupApi v c
+    :<|> MempoolGetPendingApi v c
 
-type MempoolInsertApi v c =
-    'ChainwebEndpoint v :> MempoolEndpoint c :> "insert" :>
-    ReqBody '[JSON] [Text] :> Put '[JSON] NoContent
-type MempoolMemberApi v c =
-    'ChainwebEndpoint v :> MempoolEndpoint c :> "member" :>
-    ReqBody '[JSON] [TransactionHash] :> Post '[JSON] [Bool]
-type MempoolLookupApi v c =
-    'ChainwebEndpoint v :> MempoolEndpoint c :> "lookup" :>
-    ReqBody '[JSON] [TransactionHash] :> Post '[JSON] [LookupResult Text]
-type MempoolGetPendingApi v c =
-    'ChainwebEndpoint v :> MempoolEndpoint c :> "getPending" :>
-    QueryParam "nonce" ServerNonce :>
-    QueryParam "since" MempoolTxId :>
-    Post '[JSON] PendingTransactions
+type MempoolInsertApi v c = 'ChainwebEndpoint v
+    :> MempoolEndpoint c
+    :> "insert"
+    :> ReqBody '[JSON] [Text]
+    :> Put '[JSON] NoContent
 
-mempoolInsertApi :: forall (v :: ChainwebVersionT) (c :: ChainIdT)
-                 . Proxy (MempoolInsertApi v c)
+type MempoolMemberApi v c = 'ChainwebEndpoint v
+    :> MempoolEndpoint c
+    :> "member"
+    :> ReqBody '[JSON] [TransactionHash]
+    :> Post '[JSON] [Bool]
+
+type MempoolLookupApi v c = 'ChainwebEndpoint v
+    :> MempoolEndpoint c
+    :> "lookup"
+    :> ReqBody '[JSON] [TransactionHash]
+    :> Post '[JSON] [LookupResult Text]
+
+type MempoolGetPendingApi v c = 'ChainwebEndpoint v
+    :> MempoolEndpoint c
+    :> "getPending"
+    :> QueryParam "nonce" ServerNonce
+    :> QueryParam "since" MempoolTxId
+    :> Post '[JSON] PendingTransactions
+
+mempoolInsertApi
+    :: forall (v :: ChainwebVersionT) (c :: ChainIdT)
+    . Proxy (MempoolInsertApi v c)
 mempoolInsertApi = Proxy
 
-mempoolMemberApi :: forall (v :: ChainwebVersionT) (c :: ChainIdT)
-                 . Proxy (MempoolMemberApi v c)
+mempoolMemberApi
+    :: forall (v :: ChainwebVersionT) (c :: ChainIdT)
+    . Proxy (MempoolMemberApi v c)
 mempoolMemberApi = Proxy
 
-mempoolLookupApi :: forall (v :: ChainwebVersionT) (c :: ChainIdT)
-                 . Proxy (MempoolLookupApi v c)
+mempoolLookupApi
+    :: forall (v :: ChainwebVersionT) (c :: ChainIdT)
+    . Proxy (MempoolLookupApi v c)
 mempoolLookupApi = Proxy
 
-mempoolGetPendingApi :: forall (v :: ChainwebVersionT) (c :: ChainIdT)
-                     . Proxy (MempoolGetPendingApi v c)
+mempoolGetPendingApi
+    :: forall (v :: ChainwebVersionT) (c :: ChainIdT)
+    . Proxy (MempoolGetPendingApi v c)
 mempoolGetPendingApi = Proxy
+

--- a/src/Chainweb/Pact/PactService.hs
+++ b/src/Chainweb/Pact/PactService.hs
@@ -567,6 +567,15 @@ execValidateBlock memPoolAccess currHeader plData = do
         validateHashes currHeader plData miner transactions
 
     -- update mempool
+    --
+    -- Using the parent isn't optimal, since it doesn't delete the txs of
+    -- `currHeader` from the set of pending tx. The reason for this is that the
+    -- implementation 'mpaProcessFork' uses the chain database and at this point
+    -- 'currHeader' is generally not yet available in the database. It would be
+    -- possible to extract the txs from the result and remove them from the set
+    -- of pending txs. However, that would add extra complexity and at little
+    -- gain.
+    --
     case target of
         Nothing -> return ()
         Just (ParentHeader p) -> liftIO $ do

--- a/src/Chainweb/Pact/PactService.hs
+++ b/src/Chainweb/Pact/PactService.hs
@@ -109,7 +109,7 @@ initPactService
     -> IO ()
 initPactService ver cid chainwebLogger reqQ mempoolAccess bhDb pdb sqlenv config =
     void $ initPactService' ver cid chainwebLogger bhDb pdb sqlenv config $ do
-        initialPayloadState chainwebLogger ver cid
+        initialPayloadState chainwebLogger mempoolAccess ver cid
         serviceRequests (logFunction chainwebLogger) mempoolAccess reqQ
 
 initPactService'
@@ -171,31 +171,33 @@ initialPayloadState
     :: Logger logger
     => PayloadCasLookup cas
     => logger
+    -> MemPoolAccess
     -> ChainwebVersion
     -> ChainId
     -> PactServiceM cas ()
-initialPayloadState _ Test{} _ = pure ()
-initialPayloadState _ TimedConsensus{} _ = pure ()
-initialPayloadState _ PowConsensus{} _ = pure ()
-initialPayloadState logger v@TimedCPM{} cid =
-    initializeCoinContract logger v cid $ genesisBlockPayload v cid
-initialPayloadState logger v@FastTimedCPM{} cid =
-    initializeCoinContract logger v cid $ genesisBlockPayload v cid
-initialPayloadState logger  v@Development cid =
-    initializeCoinContract logger v cid $ genesisBlockPayload v cid
-initialPayloadState logger v@Testnet04 cid =
-    initializeCoinContract logger v cid $ genesisBlockPayload v cid
-initialPayloadState logger v@Mainnet01 cid =
-    initializeCoinContract logger v cid $ genesisBlockPayload v cid
+initialPayloadState _ _ Test{} _ = pure ()
+initialPayloadState _ _ TimedConsensus{} _ = pure ()
+initialPayloadState _ _ PowConsensus{} _ = pure ()
+initialPayloadState logger mpa v@TimedCPM{} cid =
+    initializeCoinContract logger mpa v cid $ genesisBlockPayload v cid
+initialPayloadState logger mpa v@FastTimedCPM{} cid =
+    initializeCoinContract logger mpa v cid $ genesisBlockPayload v cid
+initialPayloadState logger mpa v@Development cid =
+    initializeCoinContract logger mpa v cid $ genesisBlockPayload v cid
+initialPayloadState logger mpa v@Testnet04 cid =
+    initializeCoinContract logger mpa v cid $ genesisBlockPayload v cid
+initialPayloadState logger mpa v@Mainnet01 cid =
+    initializeCoinContract logger mpa v cid $ genesisBlockPayload v cid
 
 initializeCoinContract
     :: forall cas logger. (PayloadCasLookup cas, Logger logger)
     => logger
+    -> MemPoolAccess
     -> ChainwebVersion
     -> ChainId
     -> PayloadWithOutputs
     -> PactServiceM cas ()
-initializeCoinContract _logger v cid pwo = do
+initializeCoinContract _logger memPoolAccess v cid pwo = do
     cp <- getCheckpointer
     genesisExists <- liftIO
         $ _cpLookupBlockInCheckpointer cp (genesisHeight v cid, ghash)
@@ -205,7 +207,7 @@ initializeCoinContract _logger v cid pwo = do
 
   where
     validateGenesis = void $!
-        execValidateBlock genesisHeader inputPayloadData
+        execValidateBlock memPoolAccess genesisHeader inputPayloadData
 
     ghash :: BlockHash
     ghash = _blockHash genesisHeader
@@ -281,7 +283,7 @@ serviceRequests logFn memPoolAccess reqQ = do
                     _valBlockHeader
                     (length (_payloadDataTransactions _valPayloadData)) $
                     tryOne "execValidateBlock" _valResultVar $
-                        execValidateBlock _valBlockHeader _valPayloadData
+                        execValidateBlock memPoolAccess _valBlockHeader _valPayloadData
                 go
             LookupPactTxsMsg (LookupPactTxsReq restorePoint txHashes resultVar) -> do
                 trace logFn "Chainweb.Pact.PactService.execLookupPactTxs" ()
@@ -548,10 +550,11 @@ execLocal cmd = withDiscardedBatch $ do
 --
 execValidateBlock
     :: PayloadCasLookup cas
-    => BlockHeader
+    => MemPoolAccess
+    -> BlockHeader
     -> PayloadData
     -> PactServiceM cas PayloadWithOutputs
-execValidateBlock currHeader plData = do
+execValidateBlock memPoolAccess currHeader plData = do
     -- The parent block header must be available in the block header database
     target <- getTarget
     psEnv <- ask
@@ -560,8 +563,17 @@ execValidateBlock currHeader plData = do
         withCheckpointerRewind (Just reorgLimit) target "execValidateBlock" $ \pdbenv -> do
             !result <- execBlock currHeader plData pdbenv
             return $! Save currHeader result
-    either throwM return $!
+    result <- either throwM return $!
         validateHashes currHeader plData miner transactions
+
+    -- update mempool
+    case target of
+        Nothing -> return ()
+        Just (ParentHeader p) -> liftIO $ do
+            mpaProcessFork memPoolAccess p
+            mpaSetLastHeader memPoolAccess p
+
+    return result
   where
     getTarget
         | isGenesisBlockHeader currHeader = return Nothing

--- a/src/Chainweb/Pact/Service/PactInProcApi.hs
+++ b/src/Chainweb/Pact/Service/PactInProcApi.hs
@@ -145,13 +145,9 @@ pactProcessFork mpc theLogger bHeader = do
     -- No need to run pre-insert check here -- we know these are ok, and
     -- calling the pre-check would block here (it calls back into pact service)
     mempoolInsert (mpcMempool mpc) UncheckedInsert reintroTxs
-    mempoolMarkValidated (mpcMempool mpc) $ fmap hasher validatedTxs
+    mempoolMarkValidated (mpcMempool mpc) validatedTxs
 
   where
-    mempool = mpcMempool mpc
-    txcfg = mempoolTxConfig mempool
-    hasher = txHasher txcfg
-
     logFn :: Logger l => l -> LogFunctionText
     logFn lg = logFunction lg
 

--- a/test/Chainweb/Test/Mempool/InMem.hs
+++ b/test/Chainweb/Test/Mempool/InMem.hs
@@ -25,7 +25,7 @@ tests = testGroup "Chainweb.Test.Mempool"
     wf :: (InsertCheck -> MempoolBackend MockTx -> IO a) -> IO a
     wf f = do
         mv <- newMVar (pure . V.map Right)
-        let cfg = InMemConfig txcfg mockBlockGasLimit 2048 Right (checkMv mv)
+        let cfg = InMemConfig txcfg mockBlockGasLimit 2048 Right (checkMv mv) (1024 * 10)
         InMem.withInMemoryMempool cfg (Test singletonChainGraph) $ f mv
 
     checkMv :: MVar (t -> IO b) -> t -> IO b

--- a/test/Chainweb/Test/Mempool/RestAPI.hs
+++ b/test/Chainweb/Test/Mempool/RestAPI.hs
@@ -53,7 +53,7 @@ data TestServer = TestServer
 newTestServer :: IO TestServer
 newTestServer = mask_ $ do
     checkMv <- newMVar (pure . V.map Right)
-    let inMemCfg = InMemConfig txcfg mockBlockGasLimit 2048 Right (checkMvFunc checkMv)
+    let inMemCfg = InMemConfig txcfg mockBlockGasLimit 2048 Right (checkMvFunc checkMv) (1024 * 10)
     inmemMv <- newEmptyMVar
     envMv <- newEmptyMVar
     tid <- forkIOWithUnmask $ server inMemCfg inmemMv envMv

--- a/test/Chainweb/Test/Mempool/Sync.hs
+++ b/test/Chainweb/Test/Mempool/Sync.hs
@@ -39,7 +39,7 @@ tests = testGroup "Chainweb.Mempool.sync"
     wf :: (InsertCheck -> MempoolBackend MockTx -> IO a) -> IO a
     wf f = do
         mv <- newMVar (pure . V.map Right)
-        let cfg = InMemConfig txcfg mockBlockGasLimit 2048 Right (checkMv mv)
+        let cfg = InMemConfig txcfg mockBlockGasLimit 2048 Right (checkMv mv) (1024 * 10)
         withInMemoryMempool cfg (Test singletonChainGraph) $ f mv
 
     checkMv :: MVar (t -> IO b) -> t -> IO b
@@ -67,7 +67,7 @@ txcfg = TransactionConfig mockCodec hasher hashmeta mockGasPrice
 
 testInMemCfg :: InMemConfig MockTx
 testInMemCfg =
-    InMemConfig txcfg mockBlockGasLimit 2048 Right (pure . V.map Right)
+    InMemConfig txcfg mockBlockGasLimit 2048 Right (pure . V.map Right) (1024 * 10)
 
 propSync
     :: (Set MockTx, Set MockTx , Set MockTx)

--- a/test/Chainweb/Test/Pact/ModuleCacheOnRestart.hs
+++ b/test/Chainweb/Test/Pact/ModuleCacheOnRestart.hs
@@ -108,7 +108,7 @@ testCoinbase iobdb = (initPayloadState >> doCoinbase,snapshotCache)
       pwo <- execNewBlock mempty (ParentHeader genblock) noMiner
       liftIO $ addTestBlockDb bdb (Nonce 0) (offsetBlockTime second) testChainId pwo
       nextH <- liftIO $ getParentTestBlockDb bdb testChainId
-      void $ execValidateBlock nextH (payloadWithOutputsToPayloadData pwo)
+      void $ execValidateBlock mempty nextH (payloadWithOutputsToPayloadData pwo)
 
 -- | Interfaces can't be upgraded, but modules can, so verify hash in that case.
 justModuleHashes :: ModuleCache -> HM.HashMap ModuleName (Maybe ModuleHash)
@@ -118,7 +118,7 @@ genblock :: BlockHeader
 genblock = genesisBlockHeader testVer testChainId
 
 initPayloadState :: PayloadCasLookup cas => PactServiceM cas ()
-initPayloadState = initialPayloadState dummyLogger testVer testChainId
+initPayloadState = initialPayloadState dummyLogger mempty testVer testChainId
 
 snapshotCache :: IO (MVar ModuleCache) -> ModuleCache -> IO ()
 snapshotCache iomcache initCache = do

--- a/test/Chainweb/Test/Pact/Utils.hs
+++ b/test/Chainweb/Test/Pact/Utils.hs
@@ -413,7 +413,7 @@ testPactCtxSQLite v cid bhdb pdb sqlenv conf = do
     !ctx <- TestPactCtx
       <$!> newMVar (PactServiceState Nothing mempty ph noSPVSupport)
       <*> pure (pactServiceEnv cpe rs)
-    evalPactServiceM_ ctx (initialPayloadState dummyLogger v cid)
+    evalPactServiceM_ ctx (initialPayloadState dummyLogger mempty v cid)
     return (ctx,dbSt)
   where
     initialBlockState = initBlockState $ Version.genesisHeight v cid
@@ -461,7 +461,7 @@ withWebPactExecutionService v bdb mempoolAccess act =
           { _pactNewBlock = \m p ->
               evalPactServiceM_ ctx $ execNewBlock mempoolAccess p m
           , _pactValidateBlock = \h d ->
-              evalPactServiceM_ ctx $ execValidateBlock h d
+              evalPactServiceM_ ctx $ execValidateBlock mempoolAccess h d
           , _pactLocal = \cmd ->
               evalPactServiceM_ ctx $ Right <$> execLocal cmd
           , _pactLookup = \rp hashes ->


### PR DESCRIPTION
This PR addresses two issues with the current Mempool:

1.  The mempool currently only deletes transactions that are included in a new block from the list of pending transactions in calls of `execNewBlock`. That means that transactions are removed from the pending set only on nodes that are mining.

    The PR adds the respective calls of

    ```Haskell
    mpaProcessFork memPoolAccess p
    mpaSetLastHeader memPoolAccess p
    ```

    to `execValidateBlock`. `p` is the parent header of the currently validate header. This isn't optimal. Ideally, the transactions in the current header should be removed, too. However, the implementation of these functions of the mempool accesses the payload db in order to obtain the transactions of the block. At the time these calls are made the current block is generally not yet available in the chain database. 

This could be fixed by explicitly deleting the transactions of the currently validated block from the set of pending transactions. However, the overhead for keeping the transactions a little longer is small and the logic is simpler this way.

2.  Transactions that are included in a block are deleted from the mempool only 1. when included in a new block or 2. when they expire. The latter can take up to 2 days. In the former case the following can happen:

    1. Node `A` validates Block `b` with tx `t` and deletes `t` from the set of pending tx
    2. Node `B` hasn't yet validated `b` and synchronizes its mempool with `A`. `t` gets added to the mempool of `A`.
    3. Node `B` validates Block `b` and deletes `t` from the set of pending tx
    4. Node `A` synchronizes its mempool with `B`. `t` gets added to the mempool of `B`.
    5. At this point `A` and `B` both have validated `b` and have `t` in their mempools. It can take up to 2 days until `t` is removed.

    The PR introduces a probabilistic data structure that keeps track of unexpired transactions that have been included
    in blocks and prevents these from being added to the mempool.

TODO:

* [x] make `maxCurrentTxIdSize` configurable.
* [x] motivate PR and document changes
* [x] add code comment explaining why mempool update is done only for the parent and the current header
* [x] consider renaming `CurrentTxIdx` into something more meaningful
* [x] Provide telemetry and test results from mainnet tests.