### PR TITLE
Support Pact Events

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -11,7 +11,7 @@ debug-info: True
 source-repository-package
     type: git
     location: https://github.com/kadena-io/pact.git
-    tag: eff39aefdcff3979dd93b20bca8bff7ed8490ea8
+    tag: 5ec7c90beb0bd04c9a0dd93fc8d5169798286fca
 
 source-repository-package
     type: git
@@ -30,4 +30,3 @@ source-repository-package
 
 package vault
     documentation: false
-

--- a/cabal.project
+++ b/cabal.project
@@ -11,7 +11,7 @@ debug-info: True
 source-repository-package
     type: git
     location: https://github.com/kadena-io/pact.git
-    tag: 5ec7c90beb0bd04c9a0dd93fc8d5169798286fca
+    tag: 43f58739d3b8b5f63fe52036abd1892bef4344e6
 
 source-repository-package
     type: git

--- a/dep/kpkgs/github.json
+++ b/dep/kpkgs/github.json
@@ -3,6 +3,6 @@
   "repo": "kpkgs",
   "branch": "master",
   "private": false,
-  "rev": "3b57c663a47b430fead40337a7cc0bcae7e605a9",
-  "sha256": "0pg2p63w2aik974w2hqjqsv332a242krp32npdml61fybj1lz7bc"
+  "rev": "9f5ca511e3869584c5c595ac4ee5bd7f55ebfb2e",
+  "sha256": "0zzykcb9pqagv9w789wv4sgdfzpapxl60ppnqjyiznkyvk2pjk8m"
 }

--- a/dep/kpkgs/github.json
+++ b/dep/kpkgs/github.json
@@ -3,6 +3,6 @@
   "repo": "kpkgs",
   "branch": "master",
   "private": false,
-  "rev": "9b4eca57231077d42f9c65a7c9ae30dcc268059b",
-  "sha256": "1rjdnj136gwibg5rms8zxp1g41r8n7ih61713pzr9gxi2w0057xl"
+  "rev": "3b57c663a47b430fead40337a7cc0bcae7e605a9",
+  "sha256": "0pg2p63w2aik974w2hqjqsv332a242krp32npdml61fybj1lz7bc"
 }

--- a/src/Chainweb/Pact/NoCoinbase.hs
+++ b/src/Chainweb/Pact/NoCoinbase.hs
@@ -26,6 +26,6 @@ import Pact.Types.PactValue
 noCoinbase :: CommandResult a
 noCoinbase = CommandResult
     (RequestKey pactInitialHash) Nothing
-    (PactResult (Right (PLiteral (LString "NO_COINBASE"))))
+    (PactResult (Right (PactSuccess (PLiteral (LString "NO_COINBASE")) [])))
     0 Nothing Nothing Nothing
 {-# NOINLINE noCoinbase #-}

--- a/src/Chainweb/Pact/SPV.hs
+++ b/src/Chainweb/Pact/SPV.hs
@@ -31,6 +31,7 @@ import Control.Monad.Catch
 
 import Data.Aeson hiding (Object, (.=))
 import Data.Default (def)
+import qualified Data.Map.Strict as M
 import Data.Text (Text, pack)
 import qualified Data.Text.Encoding as T
 
@@ -121,11 +122,22 @@ verifySPV bdb bh typ proof = go typ proof
             case _crResult q of
               PactResult Left{} ->
                 return (Left "invalid command result in tx output proof")
-              PactResult (Right v) -> case fromPactValue v of
-                TObject !j _ -> return (Right j)
-                _ -> return $ Left "spv-verified tx output has invalid type"
+              PactResult (Right v) -> return $ Right $ translatePactSuccess v
 
       t -> return . Left $! "unsupported SPV types: " <> t
+
+translatePactSuccess :: PactSuccess -> Object Name
+translatePactSuccess (PactSuccess v es) = Object (ObjectMap m) TyAny def def
+  where
+    m = M.fromList
+        [("value",fromPactValue v)
+        ,("events",toTList TyAny def $ map ev es)]
+    ev e = toTObject TyAny def $
+           [("name",toTerm $ _eventName e)
+           ,("params",toTList TyAny def $ map fromPactValue $ _eventParams e)
+           ,("module",toTerm $ asString $ _eventModule e)
+           ,("moduleHash",toTerm $ asString $ _eventModuleHash e)
+           ]
 
 -- | SPV defpact transaction verification support. This call validates a pact 'endorsement'
 -- in Pact, providing a validation that the yield data of a cross-chain pact is valid.

--- a/src/Chainweb/Pact/Types.hs
+++ b/src/Chainweb/Pact/Types.hs
@@ -82,6 +82,7 @@ module Chainweb.Pact.Types
   , ctxToPublicData
   , ctxToPublicData'
   , ctxCurrentBlockHeight
+  , ctxVersion
   , getTxContext
 
     -- * Pact Service State
@@ -425,6 +426,9 @@ ctxBlockHeader = _parentHeader . _tcParentHeader
 -- which influenced legacy switch checks as well.
 ctxCurrentBlockHeight :: TxContext -> BlockHeight
 ctxCurrentBlockHeight = succ . _blockHeight . ctxBlockHeader
+
+ctxVersion :: TxContext -> ChainwebVersion
+ctxVersion = _blockChainwebVersion . ctxBlockHeader
 
 -- | Assemble tx context from transaction metadata and parent header.
 getTxContext :: PublicMeta -> PactServiceM cas TxContext

--- a/src/Chainweb/Version.hs
+++ b/src/Chainweb/Version.hs
@@ -54,6 +54,7 @@ module Chainweb.Version
 , skipTxTimingValidation
 , enableModuleNameFix
 , enableModuleNameFix2
+, enablePactEvents
 -- ** BlockHeader Validation Guards
 , slowEpochGuard
 , oldTargetGuard
@@ -838,6 +839,12 @@ enableModuleNameFix2 :: ChainwebVersion -> BlockHeight -> Bool
 enableModuleNameFix2 Mainnet01 bh = bh >= 752214 -- ~ 2020-07-17 0:00:00 UTC
 enableModuleNameFix2 Testnet04 bh = bh >= 289966 -- ~ 2020-07-13
 enableModuleNameFix2 _ bh = bh >= 2
+
+-- | Enable serialization of Pact Events (Pact 3.6) in output
+enablePactEvents :: ChainwebVersion -> BlockHeight -> Bool
+enablePactEvents Mainnet01 bh = bh >= 1_000_000 -- TODO
+enablePactEvents Testnet04 bh = bh >= 600_000 -- TODO
+enablePactEvents _ bh = bh >= 2
 
 -- -------------------------------------------------------------------------- --
 -- Header Validation Guards

--- a/src/Chainweb/Version.hs
+++ b/src/Chainweb/Version.hs
@@ -844,6 +844,7 @@ enableModuleNameFix2 _ bh = bh >= 2
 enablePactEvents :: ChainwebVersion -> BlockHeight -> Bool
 enablePactEvents Mainnet01 bh = bh >= 1_013_500 -- 2020-10-15 18:47:13 UTC
 enablePactEvents Testnet04 bh = bh >= 558_000 -- 2020-10-15 17:11:45 UTC
+enablePactEvents Development bh = bh >= 120
 enablePactEvents (FastTimedCPM g) _ = g == singletonChainGraph -- For testing events
 enablePactEvents _ bh = bh >= 2
 

--- a/src/Chainweb/Version.hs
+++ b/src/Chainweb/Version.hs
@@ -844,6 +844,7 @@ enableModuleNameFix2 _ bh = bh >= 2
 enablePactEvents :: ChainwebVersion -> BlockHeight -> Bool
 enablePactEvents Mainnet01 bh = bh >= 1_000_000 -- TODO
 enablePactEvents Testnet04 bh = bh >= 600_000 -- TODO
+enablePactEvents (FastTimedCPM g) _ = g == singletonChainGraph -- For testing events
 enablePactEvents _ bh = bh >= 2
 
 -- -------------------------------------------------------------------------- --

--- a/src/Chainweb/Version.hs
+++ b/src/Chainweb/Version.hs
@@ -842,8 +842,8 @@ enableModuleNameFix2 _ bh = bh >= 2
 
 -- | Enable serialization of Pact Events (Pact 3.6) in output
 enablePactEvents :: ChainwebVersion -> BlockHeight -> Bool
-enablePactEvents Mainnet01 bh = bh >= 1_000_000 -- TODO
-enablePactEvents Testnet04 bh = bh >= 600_000 -- TODO
+enablePactEvents Mainnet01 bh = bh >= 1_013_500 -- 2020-10-15 18:47:13 UTC
+enablePactEvents Testnet04 bh = bh >= 558_000 -- 2020-10-15 17:11:45 UTC
 enablePactEvents (FastTimedCPM g) _ = g == singletonChainGraph -- For testing events
 enablePactEvents _ bh = bh >= 2
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -40,7 +40,7 @@ extra-deps:
 
   # --- Custom Pins --- #
   - github: kadena-io/pact
-    commit: 5ec7c90beb0bd04c9a0dd93fc8d5169798286fca
+    commit: 43f58739d3b8b5f63fe52036abd1892bef4344e6
   - github: kadena-io/chainweb-storage
     commit: 07e7eb7596c7105aee42dbdb6edd10e3f23c0d7e
   - github: kadena-io/rosetta

--- a/stack.yaml
+++ b/stack.yaml
@@ -40,7 +40,7 @@ extra-deps:
 
   # --- Custom Pins --- #
   - github: kadena-io/pact
-    commit: eff39aefdcff3979dd93b20bca8bff7ed8490ea8
+    commit: 5ec7c90beb0bd04c9a0dd93fc8d5169798286fca
   - github: kadena-io/chainweb-storage
     commit: 07e7eb7596c7105aee42dbdb6edd10e3f23c0d7e
   - github: kadena-io/rosetta

--- a/test/Chainweb/Test/Pact/PactExec.hs
+++ b/test/Chainweb/Test/Pact/PactExec.hs
@@ -59,16 +59,19 @@ import Chainweb.Test.Utils
 import Chainweb.Transaction
 import Chainweb.Version (ChainwebVersion(..))
 import Chainweb.Version.Utils (someChainId)
-import Chainweb.Utils (sshow, tryAllSynchronous)
+import Chainweb.Utils (sshow, tryAllSynchronous, decodeB64UrlNoPaddingText)
 
 import Pact.Types.Command
 import Pact.Types.Hash
-import Pact.Types.PactValue
 import Pact.Types.Persistence
 import Pact.Types.Pretty
+import Pact.Types.Runtime (PactEvent(..),ModuleHash(..))
 
 testVersion :: ChainwebVersion
 testVersion = FastTimedCPM petersonChainGraph
+
+testEventsVersion :: ChainwebVersion
+testEventsVersion = FastTimedCPM singletonChainGraph
 
 tests :: ScheduledTest
 tests = ScheduledTest label $
@@ -88,7 +91,7 @@ tests = ScheduledTest label $
         \ctx -> _schTest $ execTest ctx testReq4
     , withPactCtxSQLite testVersion (bhdbIO rocksIO) pdb defaultPactServiceConfig $
         \ctx -> _schTest $ execTest ctx testReq5
-    , withPactCtxSQLite testVersion (bhdbIO rocksIO) pdb defaultPactServiceConfig $
+    , withPactCtxSQLite testEventsVersion (bhdbIO rocksIO) pdb defaultPactServiceConfig $
         \ctx -> _schTest $ execTxsTest ctx "testTfrGas" testTfrGas
     , withPactCtxSQLite testVersion (bhdbIO rocksIO) pdb defaultPactServiceConfig $
         \ctx -> _schTest $ execTxsTest ctx "testGasPayer" testGasPayer
@@ -201,11 +204,11 @@ checkResultSuccess :: HasCallStack => ([PactResult] -> Assertion) -> Either Stri
 checkResultSuccess _ (Left e) = assertFailure $ "Expected success, got: " ++ show e
 checkResultSuccess test (Right (TestResponse outs _)) = test $ map (_crResult . snd) outs
 
-checkPactResultSuccess :: HasCallStack => String -> PactResult -> (PactValue -> Assertion) -> Assertion
+checkPactResultSuccess :: HasCallStack => String -> PactResult -> (PactSuccess -> Assertion) -> Assertion
 checkPactResultSuccess _ (PactResult (Right pv)) test = test pv
 checkPactResultSuccess msg (PactResult (Left e)) _ = assertFailure $ msg ++ ": expected tx success, got " ++ show e
 
-checkPactResultSuccessLocal :: HasCallStack => String -> (PactValue -> Assertion) -> PactResult -> Assertion
+checkPactResultSuccessLocal :: HasCallStack => String -> (PactSuccess -> Assertion) -> PactResult -> Assertion
 checkPactResultSuccessLocal msg test r = checkPactResultSuccess msg r test
 
 checkPactResultFailure :: HasCallStack => String -> String -> PactResult -> Assertion
@@ -235,7 +238,16 @@ testTfrGas = (V.singleton <$> tx,checkResultSuccess test)
          ]
          $ mkCmd "testTfrGas"
          $ mkExec' "(coin.transfer \"sender00\" \"sender01\" 1.0)"
-    test [PactResult (Right pv)] = assertEqual "transfer succeeds" (pString "Write succeeded") pv
+    test [PactResult (Right pv)] = do
+      mh <- decodeB64UrlNoPaddingText "_S6HOO3J8-dEusvtnjSF4025dAxKu6eFSIOZocQwimA"
+      assertEqual "transfer succeeds"
+          (PactSuccess (pString "Write succeeded")
+           [PactEvent "TRANSFER"
+            [pString "sender00",pString "sender01",pDecimal 1.0]
+            "coin"
+            (ModuleHash (Hash mh))
+           ])
+          pv
     test r = assertFailure $ "Expected single result, got: " ++ show r
 
 testBadSenderFails :: TxsTest
@@ -296,13 +308,13 @@ testGasPayer = (txs,checkResultSuccess test)
 
     test [impl,setupUser,fundGasAcct,paidTx] = do
       checkPactResultSuccess "impl" impl $
-        assertEqual "impl" (pString "TableCreated")
+        assertEqual "impl" (pactSuccess $ pString "TableCreated")
       checkPactResultSuccess "setupUser" setupUser $
-        assertEqual "setupUser" (pString "Write succeeded")
+        assertEqual "setupUser" (pactSuccess $ pString "Write succeeded")
       checkPactResultSuccess "fundGasAcct" fundGasAcct $
-        assertEqual "fundGasAcct" (pString "Write succeeded")
+        assertEqual "fundGasAcct" (pactSuccess $ pString "Write succeeded")
       checkPactResultSuccess "paidTx" paidTx $
-        assertEqual "paidTx" (pDecimal 3)
+        assertEqual "paidTx" (pactSuccess $ pDecimal 3)
     test r = assertFailure $ "Expected 4 results, got: " ++ show r
 
 
@@ -354,15 +366,15 @@ testContinuationGasPayer = (txs,checkResultSuccess test)
 
     test [impl,fundGasAcct,contFirstStep,balCheck1,paidSecondStep,balCheck2] = do
       checkPactResultSuccess "impl" impl $ assertEqual "impl"
-        (pString "Loaded module user.simple-cont-module, hash pCtVh0IDPvRIdVFXxznBFTwsZcwbIcYAnfv7yzr4wRI")
+        (pactSuccess $ pString "Loaded module user.simple-cont-module, hash pCtVh0IDPvRIdVFXxznBFTwsZcwbIcYAnfv7yzr4wRI")
       checkPactResultSuccess "fundGasAcct" fundGasAcct $ assertEqual "fundGasAcct"
-        (pString "Write succeeded")
+        (pactSuccess $ pString "Write succeeded")
       checkPactResultSuccess "contFirstStep" contFirstStep $ assertEqual "contFirstStep"
-        (pString "Step One")
-      checkPactResultSuccess "balCheck1" balCheck1 $ assertEqual "balCheck1" (pDecimal 100)
+        (pactSuccess $ pString "Step One")
+      checkPactResultSuccess "balCheck1" balCheck1 $ assertEqual "balCheck1" (pactSuccess $ pDecimal 100)
       checkPactResultSuccess "paidSecondStep" paidSecondStep $ assertEqual "paidSecondStep"
-        (pString "Step Two")
-      checkPactResultSuccess "balCheck2" balCheck2 $ assertEqual "balCheck2" (pDecimal 99.999_5)
+        (pactSuccess $ pString "Step Two")
+      checkPactResultSuccess "balCheck2" balCheck2 $ assertEqual "balCheck2" (pactSuccess $ pDecimal 99.999_5)
     test r = assertFailure $ "Expected 6 results, got: " ++ show r
 
 testExecGasPayer :: TxsTest
@@ -406,12 +418,12 @@ testExecGasPayer = (txs,checkResultSuccess test)
 
     test [impl,fundGasAcct,balCheck1,paidTx,balCheck2] = do
       checkPactResultSuccess "impl" impl $ assertEqual "impl"
-        (pString "Loaded module user.gas-payer-for-exec, hash _S7ASfb_Lvr5wmjERG_XwPUoojW6GHBWI2u0W6jmID0")
+        (pactSuccess $ pString "Loaded module user.gas-payer-for-exec, hash _S7ASfb_Lvr5wmjERG_XwPUoojW6GHBWI2u0W6jmID0")
       checkPactResultSuccess "fundGasAcct" fundGasAcct $ assertEqual "fundGasAcct"
-        (pString "Write succeeded")
-      checkPactResultSuccess "balCheck1" balCheck1 $ assertEqual "balCheck1" (pDecimal 100)
-      checkPactResultSuccess "paidTx" paidTx $ assertEqual "paidTx" (pDecimal 3)
-      checkPactResultSuccess "balCheck2" balCheck2 $ assertEqual "balCheck2" (pDecimal 99.999_6)
+        (pactSuccess $ pString "Write succeeded")
+      checkPactResultSuccess "balCheck1" balCheck1 $ assertEqual "balCheck1" (pactSuccess $ pDecimal 100)
+      checkPactResultSuccess "paidTx" paidTx $ assertEqual "paidTx" (pactSuccess $ pDecimal 3)
+      checkPactResultSuccess "balCheck2" balCheck2 $ assertEqual "balCheck2" (pactSuccess $ pDecimal 99.999_6)
     test r = assertFailure $ "Expected 6 results, got: " ++ show r
 
 testFailureRedeem :: TxsTest
@@ -433,19 +445,19 @@ testFailureRedeem = (txs,checkResultSuccess test)
     test [sbal0,mbal0,ferror,sbal1,mbal1] = do
       -- sender 00 first is 100000000 - full gas debit during tx (1)
       checkPactResultSuccess "sender bal 0" sbal0 $
-        assertEqual "sender bal 0" (pDecimal 99_999_990)
+        assertEqual "sender bal 0" (pactSuccess $ pDecimal 99_999_990)
       -- miner first is reward + epsilon tx size gas for [0]
       checkPactResultSuccess "miner bal 0" mbal0 $
-        assertEqual "miner bal 0" (pDecimal 2.344523)
+        assertEqual "miner bal 0" (pactSuccess $ pDecimal 2.344523)
       -- this should reward 10 more to miner
       checkPactResultFailure "forced error" "forced error" ferror
       -- sender 00 second is down epsilon size costs
       -- from [0,1] + 10 for error + 10 full gas debit during tx ~ 99999980
       checkPactResultSuccess "sender bal 1" sbal1 $
-        assertEqual "sender bal 1" (pDecimal 99_999_979.92)
+        assertEqual "sender bal 1" (pactSuccess $ pDecimal 99_999_979.92)
       -- miner second is up 10 from error plus epsilon from [1,2,3] ~ 12
       checkPactResultSuccess "miner bal 1" mbal1 $
-        assertEqual "miner bal 1" (pDecimal 12.424523)
+        assertEqual "miner bal 1" (pactSuccess $ pDecimal 12.424523)
     test r = assertFailure $ "Expected 5 results, got: " ++ show r
 
 
@@ -468,7 +480,7 @@ testAllowReadsLocalSuccess = (tx,test)
          mkExec' "(at 'balance (read coin.coin-table \"sender00\"))"
     test = checkLocalSuccess $
       checkPactResultSuccessLocal "testAllowReadsLocalSuccess" $
-      assertEqual "sender00 bal" (pDecimal 100_000_000.0)
+      assertEqual "sender00 bal" (pactSuccess $ pDecimal 100_000_000.0)
 
 
 -- -------------------------------------------------------------------------- --
@@ -579,7 +591,7 @@ _showValidationFailure = do
   let cr1 = CommandResult
         { _crReqKey = RequestKey pactInitialHash
         , _crTxId = Nothing
-        , _crResult = PactResult $ Right $ pString "hi"
+        , _crResult = PactResult $ Right $ pactSuccess $ pString "hi"
         , _crGas = 0
         , _crLogs = Just [TxLog "Domain" "Key" (object [ "stuff" .= True ])]
         , _crContinuation = Nothing

--- a/test/Chainweb/Test/Pact/RemotePactTest.hs
+++ b/test/Chainweb/Test/Pact/RemotePactTest.hs
@@ -189,7 +189,7 @@ localTest iot nio = do
     res <- local (unsafeChainId 0) cenv cmd
     let (PactResult e) = _crResult res
     assertEqual "expect /local to return gas for tx" (_crGas res) 5
-    assertEqual "expect /local to succeed and return 3" e (Right (PLiteral $ LDecimal 3))
+    assertEqual "expect /local to succeed and return 3" e (Right $ pactSuccess (PLiteral $ LDecimal 3))
 
 localContTest :: IO (Time Micros) -> IO ClientEnv -> TestTree
 localContTest iot nio = testCaseSteps "local continuation test" $ \step -> do
@@ -215,7 +215,7 @@ localContTest iot nio = testCaseSteps "local continuation test" $ \step -> do
     r <- _pactResult . _crResult <$> local sid cenv cmd2
     case r of
       Left err -> assertFailure (show err)
-      Right (PLiteral (LDecimal a)) | a == 2 -> return ()
+      Right (PactSuccess (PLiteral (LDecimal a)) _) | a == 2 -> return ()
       Right p -> assertFailure $ "unexpected cont return value: " ++ show p
   where
     tx =
@@ -265,7 +265,7 @@ localChainDataTest iot nio = do
           ttl = 2 * 24 * 60 * 60
           pm = Pact.PublicMeta pactCid "sender00" 1000 0.1 (fromInteger ttl)
 
-    expectedResult (PObject (ObjectMap m)) = do
+    expectedResult (PactSuccess (PObject (ObjectMap m)) _) = do
           assert' "chain-id" (PLiteral (LString "8"))
           assert' "gas-limit" (PLiteral (LInteger 1000))
           assert' "gas-price" (PLiteral (LDecimal 0.1))
@@ -506,7 +506,7 @@ caplistTest iot nio = testCaseSteps "caplist TRANSFER + FUND_TX test" $ \step ->
     pm t = Pact.PublicMeta (Pact.ChainId "0") t 100_000 0.01 ttl
 
     resultOf (CommandResult _ _ (PactResult pr) _ _ _ _) = pr
-    result0 = Just (Right (PLiteral (LString "Write succeeded")))
+    result0 = Just (Right (pactSuccess $ PLiteral (LString "Write succeeded")))
 
     clist :: Maybe [SigCapability]
     clist = Just $
@@ -641,7 +641,7 @@ allocationTest iot nio = testCaseSteps "genesis allocation tests" $ \step -> do
     getBlockHeight = preview (crMetaData . _Just . key "blockHeight" . _Number . to (fromRational . toRational))
 
     resultOf (CommandResult _ _ (PactResult pr) _ _ _ _) = pr
-    accountInfo = Right
+    accountInfo = Right $ pactSuccess
       $ PObject
       $ ObjectMap
       $ M.fromList
@@ -666,7 +666,7 @@ allocationTest iot nio = testCaseSteps "genesis allocation tests" $ \step -> do
     tx4 = PactTransaction "(coin.release-allocation \"allocation02\")" Nothing
     tx5 = PactTransaction "(coin.details \"allocation02\")" Nothing
 
-    accountInfo' = Right
+    accountInfo' = Right $ pactSuccess
       $ PObject
       $ ObjectMap
       $ M.fromList

--- a/test/Chainweb/Test/Pact/TransactionTests.hs
+++ b/test/Chainweb/Test/Pact/TransactionTests.hs
@@ -190,7 +190,7 @@ testCoinbase797DateFix = testCaseSteps "testCoinbase791Fix" $ \step -> do
 
     doCoinbaseExploit pdb mc preForkHeight cmd False $ \case
       Left _ -> assertFailure "local call to get-balance failed"
-      Right (PLiteral (LDecimal d))
+      Right (PactSuccess (PLiteral (LDecimal d)) _)
         | d == 1000.1 -> return ()
         | otherwise -> assertFailure $ "miner balance is incorrect: " <> show d
       Right l -> assertFailure $ "wrong return type: " <> show l
@@ -202,7 +202,7 @@ testCoinbase797DateFix = testCaseSteps "testCoinbase791Fix" $ \step -> do
 
     doCoinbaseExploit pdb mc postForkHeight cmd' False $ \case
       Left _ -> assertFailure "local call to get-balance failed"
-      Right (PLiteral (LDecimal d))
+      Right (PactSuccess (PLiteral (LDecimal d)) _)
         | d == 0.1 -> return ()
         | otherwise -> assertFailure $ "miner balance is incorrect: " <> show d
       Right l -> assertFailure $ "wrong return type: " <> show l
@@ -211,7 +211,7 @@ testCoinbase797DateFix = testCaseSteps "testCoinbase791Fix" $ \step -> do
 
     doCoinbaseExploit pdb mc preForkHeight cmd' True $ \case
       Left _ -> assertFailure "local call to get-balance failed"
-      Right (PLiteral (LDecimal d))
+      Right (PactSuccess (PLiteral (LDecimal d)) _)
         | d == 0.2 -> return ()
         | otherwise -> assertFailure $ "miner balance is incorrect: " <> show d
       Right l -> assertFailure $ "wrong return type: " <> show l
@@ -220,7 +220,7 @@ testCoinbase797DateFix = testCaseSteps "testCoinbase791Fix" $ \step -> do
 
     doCoinbaseExploit pdb mc postForkHeight cmd' True $ \case
       Left _ -> assertFailure "local call to get-balance failed"
-      Right (PLiteral (LDecimal d))
+      Right (PactSuccess (PLiteral (LDecimal d)) _)
         | d == 0.3 -> return ()
         | otherwise -> assertFailure $ "miner balance is incorrect: " <> show d
       Right l -> assertFailure $ "wrong return type: " <> show l


### PR DESCRIPTION
Forking change to support Pact Events (https://github.com/kadena-io/pact/pull/819) in output for SPV proofs etc.

TODOs: 
- [ ] Test against mainnet history (current block numbers should be high enough for this)
- [x] Populate block numbers for switch
- [x] merge `kpkgs` pact 3.6 bump to master https://github.com/kadena-io/kpkgs/pull/28 (waiting for mainnet replay to succeed for this)