### PR TITLE
Pact Events redux

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -11,7 +11,7 @@ debug-info: True
 source-repository-package
     type: git
     location: https://github.com/kadena-io/pact.git
-    tag: eff39aefdcff3979dd93b20bca8bff7ed8490ea8
+    tag: 39c196e00e97928764aa47139dbd73efdbaf9937
 
 source-repository-package
     type: git
@@ -26,8 +26,7 @@ source-repository-package
 source-repository-package
     type: git
     location: https://github.com/kadena-io/rosetta.git
-    tag: 1d69bb4ec46c001f2b501121e6c93e83ac60162b 
+    tag: 1d69bb4ec46c001f2b501121e6c93e83ac60162b
 
 package vault
     documentation: false
-

--- a/chainweb.cabal
+++ b/chainweb.cabal
@@ -362,7 +362,7 @@ library
         , mwc-probability >= 2.0 && <2.4
         , network >= 2.6 && < 3.1.1
         , optparse-applicative >= 0.14
-        , pact >= 2.6
+        , pact >= 3.6.0.1
         , paths >= 0.2
         , pem >=0.2
         , process >= 1.5

--- a/dep/kpkgs/github.json
+++ b/dep/kpkgs/github.json
@@ -3,6 +3,6 @@
   "repo": "kpkgs",
   "branch": "master",
   "private": false,
-  "rev": "378373e8f7142623d322daff0f1ef1b841b57bda",
-  "sha256": "18ysb396xhi8nm73y9idqsk8kfd296c8pn1jh2nxpfxxa9s6mwps"
+  "rev": "e9fe44ca2f52f3d69909871531ee1bff9141bc0e",
+  "sha256": "0d9jjvb13gcrpmjwjmvzrfhi61sd2n31k3kipvczcn28jimgqkkb"
 }

--- a/src/Chainweb/Pact/NoCoinbase.hs
+++ b/src/Chainweb/Pact/NoCoinbase.hs
@@ -27,5 +27,5 @@ noCoinbase :: CommandResult a
 noCoinbase = CommandResult
     (RequestKey pactInitialHash) Nothing
     (PactResult (Right (PLiteral (LString "NO_COINBASE"))))
-    0 Nothing Nothing Nothing
+    0 Nothing Nothing Nothing []
 {-# NOINLINE noCoinbase #-}

--- a/src/Chainweb/Pact/PactService.hs
+++ b/src/Chainweb/Pact/PactService.hs
@@ -536,8 +536,9 @@ execLocal cmd = withDiscardedBatch $ do
     mc <- use psInitCache
     pd <- getTxContext (publicMetaOf $! payloadObj <$> cmd)
     spv <- use psSpvSupport
-    let execConfig | _psAllowReadsInLocal = mkExecutionConfig [P.FlagAllowReadInLocal]
-                   | otherwise = def
+    let execConfig = mkExecutionConfig $
+            [ P.FlagAllowReadInLocal | _psAllowReadsInLocal ] ++
+            enablePactEvents' pd
         logger = _cpeLogger _psCheckpointEnv
     withCurrentCheckpointer "execLocal" $ \(PactDbEnv' pdbenv) -> do
         r <- liftIO $

--- a/src/Chainweb/Pact/RestAPI/Server.hs
+++ b/src/Chainweb/Pact/RestAPI/Server.hs
@@ -442,7 +442,7 @@ internalPoll cutR cid chain cut requestKeys0 = do
         let res = PactResult (Left err)
             err = PactError TxFailure def [] doc
             doc = pretty (T.pack $ show InsertErrorBadlisted)
-            !cr = CommandResult rk Nothing res 0 Nothing Nothing Nothing
+            !cr = CommandResult rk Nothing res 0 Nothing Nothing Nothing []
         in (rk, cr)
 
     enrichCR :: BlockHeader -> CommandResult Hash -> MaybeT IO (CommandResult Hash)

--- a/src/Chainweb/Pact/Types.hs
+++ b/src/Chainweb/Pact/Types.hs
@@ -82,6 +82,7 @@ module Chainweb.Pact.Types
   , ctxToPublicData
   , ctxToPublicData'
   , ctxCurrentBlockHeight
+  , ctxVersion
   , getTxContext
 
     -- * Pact Service State
@@ -425,6 +426,9 @@ ctxBlockHeader = _parentHeader . _tcParentHeader
 -- which influenced legacy switch checks as well.
 ctxCurrentBlockHeight :: TxContext -> BlockHeight
 ctxCurrentBlockHeight = succ . _blockHeight . ctxBlockHeader
+
+ctxVersion :: TxContext -> ChainwebVersion
+ctxVersion = _blockChainwebVersion . ctxBlockHeader
 
 -- | Assemble tx context from transaction metadata and parent header.
 getTxContext :: PublicMeta -> PactServiceM cas TxContext

--- a/src/Chainweb/Version.hs
+++ b/src/Chainweb/Version.hs
@@ -54,6 +54,7 @@ module Chainweb.Version
 , skipTxTimingValidation
 , enableModuleNameFix
 , enableModuleNameFix2
+, enablePactEvents
 -- ** BlockHeader Validation Guards
 , slowEpochGuard
 , oldTargetGuard
@@ -838,6 +839,13 @@ enableModuleNameFix2 :: ChainwebVersion -> BlockHeight -> Bool
 enableModuleNameFix2 Mainnet01 bh = bh >= 752214 -- ~ 2020-07-17 0:00:00 UTC
 enableModuleNameFix2 Testnet04 bh = bh >= 289966 -- ~ 2020-07-13
 enableModuleNameFix2 _ bh = bh >= 2
+
+enablePactEvents :: ChainwebVersion -> BlockHeight -> Bool
+enablePactEvents Mainnet01 bh = bh >= 1500000 -- TODO
+enablePactEvents Testnet04 bh = bh >= 1000000 -- TODO
+enablePactEvents Development bh = bh >= 120
+enablePactEvents (FastTimedCPM g) _ = g == singletonChainGraph -- For testing events
+enablePactEvents _ bh = bh >= 2
 
 -- -------------------------------------------------------------------------- --
 -- Header Validation Guards

--- a/stack.yaml
+++ b/stack.yaml
@@ -40,8 +40,8 @@ extra-deps:
 
   # --- Custom Pins --- #
   - github: kadena-io/pact
-    commit: eff39aefdcff3979dd93b20bca8bff7ed8490ea8
+    commit: 39c196e00e97928764aa47139dbd73efdbaf9937
   - github: kadena-io/chainweb-storage
     commit: 07e7eb7596c7105aee42dbdb6edd10e3f23c0d7e
   - github: kadena-io/rosetta
-    commit: 1d69bb4ec46c001f2b501121e6c93e83ac60162b 
+    commit: 1d69bb4ec46c001f2b501121e6c93e83ac60162b

--- a/test/Chainweb/Test/Pact/PactExec.hs
+++ b/test/Chainweb/Test/Pact/PactExec.hs
@@ -59,16 +59,20 @@ import Chainweb.Test.Utils
 import Chainweb.Transaction
 import Chainweb.Version (ChainwebVersion(..))
 import Chainweb.Version.Utils (someChainId)
-import Chainweb.Utils (sshow, tryAllSynchronous)
+import Chainweb.Utils (sshow, tryAllSynchronous, decodeB64UrlNoPaddingText)
 
 import Pact.Types.Command
 import Pact.Types.Hash
 import Pact.Types.PactValue
 import Pact.Types.Persistence
 import Pact.Types.Pretty
+import Pact.Types.Runtime (PactEvent(..),ModuleHash(..))
 
 testVersion :: ChainwebVersion
 testVersion = FastTimedCPM petersonChainGraph
+
+testEventsVersion :: ChainwebVersion
+testEventsVersion = FastTimedCPM singletonChainGraph
 
 tests :: ScheduledTest
 tests = ScheduledTest label $
@@ -88,7 +92,7 @@ tests = ScheduledTest label $
         \ctx -> _schTest $ execTest ctx testReq4
     , withPactCtxSQLite testVersion (bhdbIO rocksIO) pdb defaultPactServiceConfig $
         \ctx -> _schTest $ execTest ctx testReq5
-    , withPactCtxSQLite testVersion (bhdbIO rocksIO) pdb defaultPactServiceConfig $
+    , withPactCtxSQLite testEventsVersion (bhdbIO rocksIO) pdb defaultPactServiceConfig $
         \ctx -> _schTest $ execTxsTest ctx "testTfrGas" testTfrGas
     , withPactCtxSQLite testVersion (bhdbIO rocksIO) pdb defaultPactServiceConfig $
         \ctx -> _schTest $ execTxsTest ctx "testGasPayer" testGasPayer
@@ -225,7 +229,7 @@ testTfrNoGasFails =
          $ mkExec' "(coin.transfer \"sender00\" \"sender01\" 1.0)"
 
 testTfrGas :: TxsTest
-testTfrGas = (V.singleton <$> tx,checkResultSuccess test)
+testTfrGas = (V.singleton <$> tx,test)
   where
     tx = buildCwCmd $ set cbSigners
          [ mkSigner' sender00
@@ -235,8 +239,18 @@ testTfrGas = (V.singleton <$> tx,checkResultSuccess test)
          ]
          $ mkCmd "testTfrGas"
          $ mkExec' "(coin.transfer \"sender00\" \"sender01\" 1.0)"
-    test [PactResult (Right pv)] = assertEqual "transfer succeeds" (pString "Write succeeded") pv
-    test r = assertFailure $ "Expected single result, got: " ++ show r
+    test (Left e) = assertFailure $ "Expected success, got " ++ show e
+    test (Right (TestResponse [(_,cr)] _)) = do
+      checkPactResultSuccess "transfer succeeds" (_crResult cr) $ \pv ->
+        assertEqual "transfer succeeds" (pString "Write succeeded") pv
+      mh <- decodeB64UrlNoPaddingText "_S6HOO3J8-dEusvtnjSF4025dAxKu6eFSIOZocQwimA"
+      assertEqual "event found"
+          [PactEvent "TRANSFER"
+            [pString "sender00",pString "sender01",pDecimal 1.0]
+            "coin"
+            (ModuleHash (Hash mh))]
+          (_crEvents cr)
+    test r = assertFailure $ "expected single test response: " ++ show r
 
 testBadSenderFails :: TxsTest
 testBadSenderFails =
@@ -584,6 +598,7 @@ _showValidationFailure = do
         , _crLogs = Just [TxLog "Domain" "Key" (object [ "stuff" .= True ])]
         , _crContinuation = Nothing
         , _crMetaData = Nothing
+        , _crEvents = []
         }
       outs1 = Transactions
         { _transactionPairs = V.zip txs (V.singleton cr1)

--- a/test/Chainweb/Test/Pact/RemotePactTest.hs
+++ b/test/Chainweb/Test/Pact/RemotePactTest.hs
@@ -457,7 +457,6 @@ txTooBigGasTest iot nio = testCaseSteps "transaction size gas tests" $ \step -> 
         (Just gasError1) (getFailureMsg . resultOf <$> cr)
 
   where
-    resultOf (CommandResult _ _ (PactResult pr) _ _ _ _) = pr
     gasError0 = Just $ Left $
       Pact.PactError Pact.GasError def [] "Tx too big (4), limit 1"
     gasError1 = "Gas limit (5) exceeded: 6"
@@ -505,7 +504,6 @@ caplistTest iot nio = testCaseSteps "caplist TRANSFER + FUND_TX test" $ \step ->
     ttl = 2 * 24 * 60 * 60
     pm t = Pact.PublicMeta (Pact.ChainId "0") t 100_000 0.01 ttl
 
-    resultOf (CommandResult _ _ (PactResult pr) _ _ _ _) = pr
     result0 = Just (Right (PLiteral (LString "Write succeeded")))
 
     clist :: Maybe [SigCapability]
@@ -640,7 +638,6 @@ allocationTest iot nio = testCaseSteps "genesis allocation tests" $ \step -> do
     getBlockHeight :: CommandResult a -> Maybe Decimal
     getBlockHeight = preview (crMetaData . _Just . key "blockHeight" . _Number . to (fromRational . toRational))
 
-    resultOf (CommandResult _ _ (PactResult pr) _ _ _ _) = pr
     accountInfo = Right
       $ PObject
       $ ObjectMap
@@ -684,6 +681,9 @@ data PactTransaction = PactTransaction
   { _pactCode :: Text
   , _pactData :: Maybe A.Value
   } deriving (Eq, Show)
+
+resultOf :: CommandResult l -> Either Pact.PactError PactValue
+resultOf = _pactResult . _crResult
 
 mkSingletonBatch
     :: IO (Time Micros)

--- a/test/Chainweb/Test/Pact/TransactionTests.hs
+++ b/test/Chainweb/Test/Pact/TransactionTests.hs
@@ -237,7 +237,7 @@ testCoinbase797DateFix = testCaseSteps "testCoinbase791Fix" $ \step -> do
             noSPVSupport Nothing 0.0 (RequestKey h) 0 def
           txst = TransactionState mempty mempty 0 Nothing (_geGasModel freeGasEnv)
 
-      CommandResult _ _ (PactResult pr) _ _ _ _ <- evalTransactionM tenv txst $!
+      CommandResult _ _ (PactResult pr) _ _ _ _ _ <- evalTransactionM tenv txst $!
         applyExec defaultInterpreter localCmd [] h permissiveNamespacePolicy
 
       testResult pr


### PR DESCRIPTION
Retry of #1150 with better back-compat.

Picking block heights might need to wait for 2.3 release. @larskuhtz @mightybyte how should we track? Also we need a mainnet replay.

Only way to test with Chainweaver etc IMO is in devnet, however this build should deploy into testnet/prod without disturbance with the current blockheights, so can at least verify that `local` backcompat is not broken.