### PR TITLE
remove upper bound on network

### DIFF
--- a/chainweb.cabal
+++ b/chainweb.cabal
@@ -360,7 +360,7 @@ library
         , mtl >= 2.2
         , mwc-random >= 0.13
         , mwc-probability >= 2.0 && <2.4
-        , network >= 2.6
+        , network >= 2.6 && < 3.1.1 || >= 3.1.2
         , optparse-applicative >= 0.14
         , pact >= 3.7
         , paths >= 0.2
@@ -531,7 +531,7 @@ test-suite chainweb-tests
         , lens-aeson >= 1.1
         , loglevel >= 0.1
         , mtl >= 2.2
-        , network >= 2.6
+        , network >= 2.6 && < 3.1.1 || >= 3.1.2
         , http-client-tls >=0.3
         , pact
         , paths >= 0.2
@@ -696,7 +696,7 @@ executable cwtool
         , memory >=0.14
         , mtl >= 2.2
         , mwc-random >= 0.14
-        , network >= 2.6
+        , network >= 2.6 && < 3.1.1 || >= 3.1.2
         , optparse-applicative >= 0.14
         , pact
         , paths >= 0.2

--- a/chainweb.cabal
+++ b/chainweb.cabal
@@ -360,7 +360,7 @@ library
         , mtl >= 2.2
         , mwc-random >= 0.13
         , mwc-probability >= 2.0 && <2.4
-        , network >= 2.6 && < 3.1.1
+        , network >= 2.6
         , optparse-applicative >= 0.14
         , pact >= 3.7
         , paths >= 0.2
@@ -531,7 +531,7 @@ test-suite chainweb-tests
         , lens-aeson >= 1.1
         , loglevel >= 0.1
         , mtl >= 2.2
-        , network >= 2.6 && < 3.1.1
+        , network >= 2.6
         , http-client-tls >=0.3
         , pact
         , paths >= 0.2
@@ -696,7 +696,7 @@ executable cwtool
         , memory >=0.14
         , mtl >= 2.2
         , mwc-random >= 0.14
-        , network >= 2.6 && < 3.1.1
+        , network >= 2.6
         , optparse-applicative >= 0.14
         , pact
         , paths >= 0.2


### PR DESCRIPTION
Previous version of network the package (>= 3.1.1.0) had a bug that could cause nodes to stall after running for several days. The issue is reported here: https://github.com/haskell/network/issues/438.

Version [3.1.2.0 of the network package](https://github.com/haskell/network/releases/tag/v3.1.2.0) is supposed to fix this and we haven't observed the issue while testing this branch, which indicates that the issue is indeed fixed.

