### PR TITLE
validate p2p configuration on startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,27 @@ cabal v2-install
 
 ## Bootstrap Nodes
 
-### Testnet Nodes
+Bootstrap nodes are used by chainweb-nodes on startup in order to discover other
+nodes in the network. A least one of the bootstrap nodes must be trusted.
+
+Chainweb node operators can configure additional bootstrap nodes by using the
+`--known-peer-info` command line option or in a configuration file. It is also
+possible to ignore the builtin bootstrap nodes by using the
+`--enable-ignore-bootstrap-nodes` option or the respective configuration file
+setting.
+
+Bootstrap nodes must have public DNS names and a corresponding TLS certificate
+that is issued by an widely accepted CA (a minimum requirement is acceptance by
+the OpenSSL library).
+
+Operators of bootstrap nodes are expected be committed to guarantee long-term
+availability of the nodes. The list of builtin bootstrap nodes should be kept
+up-to-date and concise for each chainweb-node release.
+
+If you like to have your node included as a bootstrap node please make a pull
+request that adds your node to [P2P.BootstrapNodes module](src/P2P/BootstrapNodes.hs).
+
+### Current Testnet Bootstrap Nodes
 
 - us1.testnet.chainweb.com
 - us2.testnet.chainweb.com
@@ -196,7 +216,7 @@ cabal v2-install
 - ap1.testnet.chainweb.com
 - ap2.testnet.chainweb.com
 
-### Mainnet Nodes
+### Current Mainnet Bootstrap Nodes
 
 All bootstrap nodes are running on port 443.
 

--- a/chainweb.cabal
+++ b/chainweb.cabal
@@ -251,6 +251,7 @@ library
         , Numeric.Additive
         , Numeric.AffineSpace
 
+        , P2P.BootstrapNodes
         , P2P.Node
         , P2P.Node.Configuration
         , P2P.Node.PeerDB

--- a/src/Chainweb/Chainweb.hs
+++ b/src/Chainweb/Chainweb.hs
@@ -396,6 +396,10 @@ instance HasChainwebVersion ChainwebConfiguration where
 validateChainwebConfiguration :: ConfigValidation ChainwebConfiguration []
 validateChainwebConfiguration c = do
     validateMinerConfig (_configMining c)
+    case _configChainwebVersion c of
+        Mainnet01 -> validateP2pConfiguration (_configP2p c)
+        Testnet04 -> validateP2pConfiguration (_configP2p c)
+        _ -> return ()
     unless (_configNodeIdDeprecated c == Null) $ tell
         [ "Usage NodeId is deprecated. This option will be removed in a future version of chainweb-node"
         , "The value of NodeId is ignored by chainweb-node. In particular the database path will not depend on it"

--- a/src/Chainweb/Chainweb.hs
+++ b/src/Chainweb/Chainweb.hs
@@ -551,9 +551,9 @@ withChainweb
     -> (forall cas' . PayloadCasLookup cas' => Chainweb logger cas' -> IO a)
     -> IO a
 withChainweb c logger rocksDb pactDbDir resetDb inner =
-    withPeerResources v (view configP2p conf) logger $ \logger' peer ->
+    withPeerResources v (view configP2p confWithBootstraps) logger $ \logger' peer ->
         withChainwebInternal
-            (set configP2p (_peerResConfig peer) conf)
+            (set configP2p (_peerResConfig peer) confWithBootstraps)
             logger'
             peer
             rocksDb
@@ -565,8 +565,9 @@ withChainweb c logger rocksDb pactDbDir resetDb inner =
 
     -- Here we inject the hard-coded bootstrap peer infos for the configured
     -- chainweb version into the configuration.
-    conf | _p2pConfigIgnoreBootstrapNodes (_configP2p c) = c
-         | otherwise = configP2p . p2pConfigKnownPeers <>~ bootstrapPeerInfos v $ c
+    confWithBootstraps
+        | _p2pConfigIgnoreBootstrapNodes (_configP2p c) = c
+        | otherwise = configP2p . p2pConfigKnownPeers <>~ bootstrapPeerInfos v $ c
 
 -- TODO: The type InMempoolConfig contains parameters that should be
 -- configurable as well as parameters that are determined by the chainweb

--- a/src/P2P/BootstrapNodes.hs
+++ b/src/P2P/BootstrapNodes.hs
@@ -1,0 +1,65 @@
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+-- |
+-- Module: P2P.BootstrapNodes
+-- Copyright: Copyright © 2020 Kadena LLC.
+-- License: MIT
+-- Maintainer: Lars Kuhtz <lars@kadena.io>
+-- Stability: experimental
+--
+-- TODO
+--
+module P2P.BootstrapNodes
+( mainnetBootstrapHosts
+, testnetBootstrapHosts
+) where
+
+-- internal modules
+
+import Chainweb.HostAddress
+
+-- -------------------------------------------------------------------------- --
+-- | Mainnet bootstrap nodes.
+--
+-- Nodes in this list need a public DNS name and a corresponding TLS
+-- certificate. Operators of the nodes are expected to guarantee long term
+-- availability of the nodes.
+--
+-- Please make a pull request, if you like to see your node being included here.
+--
+mainnetBootstrapHosts :: [HostAddress]
+mainnetBootstrapHosts = map unsafeHostAddressFromText
+    [ "us-e1.chainweb.com:443"
+    , "us-e2.chainweb.com:443"
+    , "us-e3.chainweb.com:443"
+    , "us-w1.chainweb.com:443"
+    , "us-w2.chainweb.com:443"
+    , "us-w3.chainweb.com:443"
+    , "fr1.chainweb.com:443"
+    , "fr2.chainweb.com:443"
+    , "fr3.chainweb.com:443"
+    , "jp1.chainweb.com:443"
+    , "jp2.chainweb.com:443"
+    , "jp3.chainweb.com:443"
+    ]
+
+-- -------------------------------------------------------------------------- --
+-- | Testnet bootstrap nodes.
+--
+-- Nodes in this list need a public DNS name and a corresponding TLS
+-- certificate. Operators of the nodes are expected to guarantee long term
+-- availability of the nodes.
+--
+-- Please make a pull request, if you like to see your node being included here.
+--
+testnetBootstrapHosts :: [HostAddress]
+testnetBootstrapHosts = map unsafeHostAddressFromText
+    [ "us1.testnet.chainweb.com:443"
+    , "us2.testnet.chainweb.com:443"
+    , "eu1.testnet.chainweb.com:443"
+    , "eu2.testnet.chainweb.com:443"
+    , "ap1.testnet.chainweb.com:443"
+    , "ap2.testnet.chainweb.com:443"
+    ]
+

--- a/src/P2P/Peer.hs
+++ b/src/P2P/Peer.hs
@@ -79,7 +79,6 @@ import Control.Exception (evaluate)
 import Control.Lens hiding ((.=))
 import Control.Monad
 import Control.Monad.Catch
-import Control.Monad.Except
 import Control.Monad.Writer
 
 import qualified Data.Attoparsec.Text as A
@@ -106,6 +105,8 @@ import Chainweb.Utils hiding (check)
 import Chainweb.Version
 
 import Network.X509.SelfSigned
+
+import P2P.BootstrapNodes
 
 -- -------------------------------------------------------------------------- --
 -- Peer Id
@@ -465,9 +466,9 @@ bootstrapPeerInfos TimedConsensus{} = [testBootstrapPeerInfos]
 bootstrapPeerInfos PowConsensus{} = [testBootstrapPeerInfos]
 bootstrapPeerInfos TimedCPM{} = [testBootstrapPeerInfos]
 bootstrapPeerInfos FastTimedCPM{} = [testBootstrapPeerInfos]
-bootstrapPeerInfos Development = productionBootstrapPeerInfo
-bootstrapPeerInfos Testnet04 = productionBootstrapPeerInfo
-bootstrapPeerInfos Mainnet01 = productionBootstrapPeerInfo
+bootstrapPeerInfos Development = []
+bootstrapPeerInfos Testnet04 = domainAddr2PeerInfo testnetBootstrapHosts
+bootstrapPeerInfos Mainnet01 = domainAddr2PeerInfo mainnetBootstrapHosts
 
 testBootstrapPeerInfos :: PeerInfo
 testBootstrapPeerInfos =
@@ -489,19 +490,7 @@ testBootstrapPeerInfos =
             }
         }
 
-productionBootstrapPeerInfo :: [PeerInfo]
-productionBootstrapPeerInfo = map f testnetBootstrapHosts
-  where
-    f hn = PeerInfo
-        { _peerId = Nothing
-        , _peerAddr = HostAddress
-            { _hostAddressHost = hn
-            , _hostAddressPort = 443
-            }
-        }
-
--- | Official TestNet bootstrap nodes.
+-- | Official testnet bootstrap nodes
 --
-testnetBootstrapHosts :: [Hostname]
-testnetBootstrapHosts = map unsafeHostnameFromText []
-
+domainAddr2PeerInfo :: [HostAddress] -> [PeerInfo]
+domainAddr2PeerInfo = fmap (PeerInfo Nothing)

--- a/src/P2P/Peer.hs
+++ b/src/P2P/Peer.hs
@@ -316,11 +316,11 @@ defaultPeerConfig = PeerConfig
 
 validatePeerConfig :: Applicative a => ConfigValidation PeerConfig a
 validatePeerConfig c = do
-    when (isReservedHostAddress (_peerConfigAddr c)) $ throwError
-        $ "The configured hostname is a localhost name or from a reserved IP address range. Please use a public hostname or IP address."
+    when (isReservedHostAddress (_peerConfigAddr c)) $ tell
+        $ pure "The configured hostname is a localhost name or from a reserved IP address range. Please use a public hostname or IP address."
 
-    when (_peerConfigInterface c == "localhost" || _peerConfigInterface c == "localnet") $ throwError
-        $ "The node is configured to listen only on a private network. Please use a public network as interface configuration, e.g. '*' or '0.0.0.0'"
+    when (_peerConfigInterface c == "localhost" || _peerConfigInterface c == "localnet") $ tell
+        $ pure "The node is configured to listen only on a private network. Please use a public network as interface configuration, e.g. '*' or '0.0.0.0'"
 
     mapM_ (validateFileReadable "certificateChainFile") (_peerConfigCertificateChainFile c)
 


### PR DESCRIPTION
NOTE: the changes of this PR are now contained in #1174 

This is an updated version of #691 

* [x] Warnings about problematic P2P configuration settings
* [x] Errors on unacceptable P2P configuration settings
* [ ] Connectivity of bootstrap nodes and known peers at startup
    * [ ] new configuration option `requiredReachableBootstrapNodes` for the required number of bootstrap nodes that are reachable at startup
    * [ ] check available bootstrap nodes
    * [ ] check connectivity with available bootstrap nodes (depends on #1174)
 * [ ] validate that configured host IP/domain name and port matches actual external IP address (depends on #1174)
 * [ ] auto-configure host IP if not set (depends on #1174)
 * [ ] option to turn of p2p-validation (for easier bootstrapping of development networks)

### Builtin Bootstrap Nodes

This PR also re-adds the list of builtin bootstrap nodes to the code base, which was removed before the mainnet launch in order to not reveal the network ahead of the official announcement.Including a builtin list of bootstrap nodes simplifies packaging and operation of chainweb-node. 

A hard code list of bootstrap nodes could be seen as a form of centralization. However, most Bitcoin clients also include such a list in the code. The code is open source and anybody can make a PR to add their own node, if they think that is satisfies the requirements for bootstrap nodes. Actually, I think, we should welcome additional bootstrap nodes from a diverse set of different entities. Moreover, it is sufficient that a single node from the set of bootstrap nodes is trusted and it is possible to configure additional known peers in addition to the builtin set of bootstrap nodes. It is always possible to ignore the builtin bootstrap nodes via a command line flag or configuration file setting.