### PR TITLE
remove these-skinny dependency

### DIFF
--- a/chainweb.cabal
+++ b/chainweb.cabal
@@ -393,7 +393,6 @@ library
         , temporary >= 1.3
         , text >= 1.2
         , trifecta >= 2.1
-        , these-skinny >= 0.7.4
         , time >= 1.8
         , tls >=1.5.2
         , tls-session-manager >= 0.0

--- a/src/Chainweb/Chainweb.hs
+++ b/src/Chainweb/Chainweb.hs
@@ -140,7 +140,6 @@ import qualified Data.HashMap.Strict as HM
 import Data.List (isPrefixOf, sortBy)
 import Data.Maybe
 import qualified Data.Text as T
-import Data.These (These(..))
 import Data.Tuple.Strict (T2(..))
 import qualified Data.Vector as V
 

--- a/src/Chainweb/Cut.hs
+++ b/src/Chainweb/Cut.hs
@@ -109,7 +109,6 @@ import Data.Maybe (catMaybes, fromMaybe)
 import Data.Monoid
 import Data.Ord
 import qualified Data.Text as T
-import Data.These
 
 import GHC.Generics (Generic)
 import GHC.Stack

--- a/src/Chainweb/CutDB.hs
+++ b/src/Chainweb/CutDB.hs
@@ -106,7 +106,6 @@ import Data.Maybe
 import Data.Monoid
 import Data.Ord
 import qualified Data.Text as T
-import Data.These
 import Data.Tuple.Strict
 import qualified Data.Vector as V
 

--- a/src/Chainweb/TreeDB.hs
+++ b/src/Chainweb/TreeDB.hs
@@ -95,7 +95,6 @@ import qualified Data.List.NonEmpty as NE
 import Data.Maybe (fromMaybe)
 import Data.Semigroup
 import qualified Data.Text as T
-import Data.These
 import Data.Typeable
 import Data.Vector (Vector)
 import qualified Data.Vector as V
@@ -954,7 +953,7 @@ getBranchIncreasing db e r inner
         Branch l0 a0 : bs@(Branch l1 _ : _)
             -- active branches are sorted by length in decreasing order. If the first branch
             -- is longer than the second branch it is also longer than all other branches.
-            -- That means that its entries at the lowest ranks are unique for their rank and 
+            -- That means that its entries at the lowest ranks are unique for their rank and
             -- can be yielded to the result stream.
             --
             -- Invariant: `length l1 >= 1` and, thus, length keep >= 1`


### PR DESCRIPTION
Chainweb depends on these-skinny and indirectly also on these. Both export the module `Data.These`, which sometimes caused issues within ghci session. This PR remove the dependency on skinny-these.