### PR TITLE
use http-client-0.7.5 in cabal builds

### DIFF
--- a/.github/workflows/applications.yml
+++ b/.github/workflows/applications.yml
@@ -152,8 +152,6 @@ jobs:
         cat >> cabal.project.local <<EOF
         allow-newer:
           pact:*
-          tocken-bucket:*
-          servant-swagger:*
         constraints:
           base16-bytestring <1.0
     - uses: actions/cache@v2

--- a/cabal.project
+++ b/cabal.project
@@ -31,10 +31,15 @@ source-repository-package
 source-repository-package
     type: git
     location: https://github.com/kadena-io/kadena-ethereum-bridge.git
-    tag: 9838d1266b9ee43c88af6c01cd819e0c96b685e6
+    tag: ca31bab8dfa0b0b5e0be98ea6a4736cf898ffa7e
 
 package vault
     documentation: false
 
 package pact
     ghc-options: -Wwarn
+
+-- cf. https://github.com/snoyberg/http-client/pull/454
+constraints: http-client>=0.7.5
+allow-newer: servant-client:http-client
+


### PR DESCRIPTION
* [x] use http-client-0.7.5 for cabal builds (cf. https://github.com/snoyberg/http-client/pull/454)
* [x] remove redundant/outdated `allow-newer` settings from cabal ghc-8.10 builds
* [x] update ethereum package pin (fix cabal warning by adding missing CHANGELOG.md file)
