### PR TITLE
[DO NOT MERGE] Release candidate/2.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,58 @@
 # `chainweb-node` Changelog
 
+## 2.5 (21-01-17)
+
+This version replaces all previous versions. Any prior version will stop working
+on **2021-02-25T00:00:00Z**. Node administrators must upgrade to this version
+before that date.
+
+This version will stop working on **2021-03-25T00:00:00Z**.
+
+If chainweb-node-2.5 is started with existing configuration files, the P2P
+API remains unchanged. The service API endpoints will be available via HTTP on
+port 1848. Please read the description below for details about this change.
+
+Breaking changes:
+
+*   Publish service APIs on separate HTTP port (#1063)
+
+    The API of the chainweb-node is split into two separate sub-APIs which are
+    served on two different ports:
+
+    *   **P2P API**: this API includes all endpoint that are used in the P2P
+        inter-node communication. It is exported using HTTPS and must be
+        available on a publicly reachable port.
+
+        The command line option for the this APIs are prefixed with `p2p`:
+
+        `--p2p-host`, `--p2p-port`, `--p2p-interface`, and the respective
+        certificate related options.
+
+        The respective properties in in the configuration file are unchanged.
+
+    *   **Service API**: this API includes all endpoints that are not directly
+        used for P2P inter-node communication. These include the `pact`, `rosetta`,
+        `mining`, `header-stream`, `info`, and `health-check` endpoints. This
+        API is exported as plain HTTP and can thus be easily used along with a
+        reverse proxy. There is no need to make this API publicly available.
+
+        This API is configured with the configuration options `--service-port`
+        (default 1848) and `--service-interface` (default '*'). The respective
+        properties in the configuration file are `chainweb.serviceApi.port` and
+        `chainweb.serviceApi.interface`.
+
+    IMPORTANT: The previously used options `--hostname`, `--port`,
+    `--interface`, and the related certificate options got removed. Please, use
+    the new variants instead which are prefixed with the respective API as
+    described above.
+
+Miscellaneous changes:
+
+*   Add payload batch APIs (#1192)
+*   Use TLS session manager (#1173)
+*   Upgrade to a new version 0.7.5 of the http-client library (#1191)
+*   Build TLS with pclmulqdq support switched on (#1193)
+
 ## 2.4 (2021-01-11)
 
 This version replaces all previous versions. Any prior version will stop working

--- a/chainweb.cabal
+++ b/chainweb.cabal
@@ -1,7 +1,7 @@
 cabal-version: 2.4
 
 name:         chainweb
-version:      2.4
+version:      2.5
 synopsis:     A Proof-of-Work Parallel-Chain Architecture for Massive Throughput
 description:  A Proof-of-Work Parallel-Chain Architecture for Massive Throughput.
 homepage:     https://github.com/kadena-io/chainweb
@@ -10,12 +10,12 @@ license:      BSD-3-Clause
 license-file: LICENSE
 author:       Chainweb Dev Team
 maintainer:   chainweb-dev@kadena.io
-copyright:    Copyright (C) 2018 - 2020 Kadena LLC
+copyright:    Copyright (C) 2018 - 2021 Kadena LLC
 category:     Blockchain, Currency, Bitcoin
 build-type:   Custom
 
 tested-with:
-    GHC == 8.10.2
+    GHC == 8.10.4
     GHC == 8.8.4
     GHC == 8.6.5
 

--- a/node/ChainwebNode.hs
+++ b/node/ChainwebNode.hs
@@ -491,10 +491,10 @@ pkgInfoScopes =
 -- -------------------------------------------------------------------------- --
 -- main
 
--- KILLSWITCH for version 2.3
+-- KILLSWITCH for version 2.5
 --
 killSwitchDate :: Maybe String
-killSwitchDate = Just "2021-02-25T00:00:00Z"
+killSwitchDate = Just "2021-03-25T00:00:00Z"
 
 mainInfo :: ProgramInfo ChainwebNodeConfiguration
 mainInfo = programInfoValidate


### PR DESCRIPTION
# Release Info

version: 2.5
Revision: dfcc08bc18c90bc92ce635abe8f6688d7817e843

*Docker:*

*   image: kadena/chainweb-node:2.5
*   documentation: https://hub.docker.com/r/kadena/chainweb-node

*binaries:*

*   ubuntu-16.04 ghc-8.10.3: https://kadena-cabal-cache.s3.amazonaws.com/chainweb-node/chainweb.8.10.3.ubuntu-16.04.dfcc08b.tar.gz
*   ubuntu-18.04 ghc-8.10.3: https://kadena-cabal-cache.s3.amazonaws.com/chainweb-node/chainweb.8.10.3.ubuntu-18.04.dfcc08b.tar.gz
*   ubuntu-20.04 ghc-8.10.3: https://kadena-cabal-cache.s3.amazonaws.com/chainweb-node/chainweb.8.10.3.ubuntu-20.04.dfcc08b.tar.gz
*   macOS ghc-8.10.3: https://kadena-cabal-cache.s3.amazonaws.com/chainweb-node/chainweb.8.10.3.macOS-latest.dfcc08b.tar.gz

Github Actions build: https://github.com/kadena-io/chainweb-node/actions/runs/576346813

*Nix pins:*

* linux: `/nix/store/drfib8lh9mw76x99sg16qrxxrjva88yy-chainweb-2.5`
* mac: `/nix/store/03xqg5irl7rfsi413pr9grz06kzapmay-chainweb-2.5`

# Pull Requests

* [x] #1193 [remove unused deps and enabled optimization for tls]
* [x] #1194 [bump version to 2.5 and update kill-switch and changelog]
* [x] #1196 [enforce upper bound on prettyprinter]

# TODO

* [x] double check killswitch dates for 2.5
* [ ] inform pools and exchanges about API changes
* [x] set database snapshot and update docker image to use it
* [x] migrate official docker image to service APIs
* [ ] Prepare announcement
    * [ ] include note about API change
    * [ ] include node about removing service API from bootstrap nodes and `api.chainweb.com` 

# Testing

- [x] full CI build passed with all checks
- [x] Mainnet pact replay complete
- [x] Mainnet header validation complete
- [x] CI Tests

# Deployment

### Testnet

- [x] Rolled out release candidate to all Testnet nodes
- [x] Rolled out final release to all Testnet nodes
- [x] update monitors for bootstrap nodes
- [x] setup monitor for https://api.testnet.chainweb.com

### Mainnet

- [x] deployed release candidate to Kubernetes nodes
    - [x] chainweb.api.com
    - [x] test cluster
- [ ] Upgraded all other nodes (db synchronization, chainweb-data, etc.)
- [x] Tested with block explorer
    - [x] mainnet
    - [x] testnet
- [x] tested APIs
    - [x] api.chainweb.com
    - [x] api.testnet.chainweb.com 

### Mainnet Bootstrap nodes

- [x] update terraform templates and push to infra repository
- [x] apply configuration changes for service API to systemd files
- [x] Rolled out to bootstraps nodes
    - [x] `*1.chainweb.com`
    - [x] `*2.chainweb.com`
    - [x] `*3.chainweb.com`
- [x] update monitors for bootstrap nodes
- [x] setup monitor for https://api.chainweb.com