### PR TITLE
enforce upper bound on prettyprinter

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -47,8 +47,8 @@ allow-newer: rosetta:*
 allow-newer: swagger2:*
 
 -- required by pact
-constraints:
-    base16-bytestring <1
+constraints: base16-bytestring <1
+constraints: prettyprinter <1.6.1
 
 -- cf. https://github.com/snoyberg/http-client/pull/454
 constraints: http-client>=0.7.5


### PR DESCRIPTION
This bound should be moved into pact.cabal. But for now, we enforce it here.