### PR TITLE
do not export seekTreeDb

### DIFF
--- a/src/Chainweb/BlockHeaderDB.hs
+++ b/src/Chainweb/BlockHeaderDB.hs
@@ -15,9 +15,6 @@ module Chainweb.BlockHeaderDB
 , initBlockHeaderDb
 , closeBlockHeaderDb
 , withBlockHeaderDb
-
--- * internal
-, seekTreeDb
 ) where
 
 -- internal imports

--- a/src/Chainweb/BlockHeaderDB/Internal.hs
+++ b/src/Chainweb/BlockHeaderDB/Internal.hs
@@ -38,9 +38,6 @@ module Chainweb.BlockHeaderDB.Internal
 -- * Insertion
 , insertBlockHeaderDb
 , unsafeInsertBlockHeaderDb
-
--- * Misc
-, seekTreeDb
 ) where
 
 import Control.Arrow


### PR DESCRIPTION
`seekTreeDb` is unsafe, since it returns an iterator that must be released explicitly. There is an `withSeeTreeDb` function that should be used instead.