### PR TITLE
increase default listen timeoutto 3 minutes

### DIFF
--- a/src/Chainweb/Pact/RestAPI/Server.hs
+++ b/src/Chainweb/Pact/RestAPI/Server.hs
@@ -302,7 +302,7 @@ listenHandler logger cdb cid pact mem (ListenerRequest key) = do
                      return cut
 
     -- TODO: make configurable
-    defaultTimeout = 120 * 1000000 -- two minutes
+    defaultTimeout = 180 * 1000000 -- two minutes
 
 localHandler
     :: Logger logger


### PR DESCRIPTION
Increase the listen timeout in the chainweb-node from 2min to 3min.