### PR TITLE
[DO NOT MERGE] Release candidate/2.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # `chainweb-node` Changelog
 
+## 2.6 (2021-03-18)
+
+This version replaces all previous versions. Any prior version will stop working
+on **2021-03-25T00:00:00Z**. Node administrators must upgrade to this version
+before that date.
+
+This version will stop working on **2021-05-06T00:00:00Z**.
+
 ## 2.5 (2021-02-17)
 
 This version replaces all previous versions. Any prior version will stop working

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ before that date.
 
 This version will stop working on **2021-05-06T00:00:00Z**.
 
+Changes:
+
+*   Increase default listen timeout to 3 minutes (#1208)
+*   Additional verification for coin contract (#1200)
+
+Additional changes support the build of fully statically linked binaries that
+can be used with Alpine Linux.
+
 ## 2.5 (2021-02-17)
 
 This version replaces all previous versions. Any prior version will stop working

--- a/chainweb.cabal
+++ b/chainweb.cabal
@@ -1,7 +1,7 @@
 cabal-version: 2.4
 
 name:         chainweb
-version:      2.5
+version:      2.6
 synopsis:     A Proof-of-Work Parallel-Chain Architecture for Massive Throughput
 description:  A Proof-of-Work Parallel-Chain Architecture for Massive Throughput.
 homepage:     https://github.com/kadena-io/chainweb

--- a/node/ChainwebNode.hs
+++ b/node/ChainwebNode.hs
@@ -491,10 +491,10 @@ pkgInfoScopes =
 -- -------------------------------------------------------------------------- --
 -- main
 
--- KILLSWITCH for version 2.5
+-- KILLSWITCH for version 2.6
 --
 killSwitchDate :: Maybe String
-killSwitchDate = Just "2021-03-25T00:00:00Z"
+killSwitchDate = Just "2021-05-06T00:00:00Z"
 
 mainInfo :: ProgramInfo ChainwebNodeConfiguration
 mainInfo = programInfoValidate


### PR DESCRIPTION
# Release Info

version: 2.6
Revision: 69e8a5b72f2dcd103d7d91864c5f188509458fb6

*Docker:*

*   end-user ubuntu image: 
    *  `docker pull kadena/chainweb-node:2.6`
    *   documentation: https://hub.docker.com/r/kadena/chainweb-node

*  binary-only images: 
    *   ubuntu: `docker pull ghcr.io/kadena-io/chainweb-node/ubuntu:2.6`
    *   alpine: `docker pull ghcr.io/kadena-io/chainweb-node/alpine:2.6`
    *   documentation: https://github.com/orgs/kadena-io/packages/

*  binary-only 

*Ubuntu binaries:*

*   ubuntu-18.04 ghc-8.10.4: https://kadena-cabal-cache.s3.amazonaws.com/chainweb-node/chainweb.8.10.4.ubuntu-18.04.69e8a5b.tar.gz
*   ubuntu-20.04 ghc-8.10.4: https://kadena-cabal-cache.s3.amazonaws.com/chainweb-node/chainweb.8.10.4.ubuntu-20.04.69e8a5b.tar.gz
*   macOS ghc-8.10.4: https://kadena-cabal-cache.s3.amazonaws.com/chainweb-node/chainweb.8.10.4.macOS-latest.69e8a5b.tar.gz

Github Actions build: https://github.com/kadena-io/chainweb-node/actions/runs/662557996

*Nix pins:*

* linux: `/nix/store/3m2x53f9xibr3mpz4qk5d0n5snc51k04-chainweb-2.6`
* mac: `/nix/store/iwn0pa7ngnc4fqi51w6y5lkx60ymj5hv-chainweb-2.6`

# Pull Requests

* [x] #1211  [version 2.6]

# TODO

* [x] double check killswitch dates for 2.6
* [ ] double check database snapshot (possibly update links in docker image and documentation)
* [ ] Prepare announcement

# Testing

- [x] full CI build passed with all checks
- [x] Mainnet pact replay complete
- [x] Mainnet header validation complete
- [ ] Mainnet Catchup
- [x] CI Tests
- [ ] run regression test suite on testnet
- [ ] test block explorer
- [ ] test Kadenaswap

# Deployment

### Testnet

- [x] Rolled out release candidate to all Testnet nodes
- [x] Rolled out final release to all Testnet nodes

### Mainnet

- [x] deployed release candidate to Kubernetes clusters
    - [x] chainweb.api.com
    - [x] test cluster
- [ ] Upgraded all other nodes (db synchronization, chainweb-data, etc.)
- [x] Tested with block explorer
    - [x] mainnet
    - [x] testnet
- [ ] tested APIs
    - [ ] api.chainweb.com
    - [ ] api.testnet.chainweb.com 

### Mainnet Bootstrap nodes

- [x] Rolled out to bootstraps nodes
    - [x] `*1.chainweb.com`
    - [x] `*2.chainweb.com`
    - [x] `*3.chainweb.com`
 
# Relase

* [ ] collect finally builds
* [x] validate final builds
    * [x] pact history replay
    * [x] merkle tree validation 
* [ ] publish and tag docker images
* [ ] roll out final builds to Kubernetes cluster
* [ ] roll out final binaries to bootstrap nodes
* [ ] commit freeze file to release candidate branch

# Dependency Updates:

```
0a1
> active-repositories: hackage.haskell.org:merge
3,4c4
<              any.Decimal ==0.5.1,
<              any.FloatingHex ==0.5,
---
>              any.Decimal ==0.5.2,
18c18
<              any.aeson ==1.5.5.1,
---
>              any.aeson ==1.5.6.0,
58c58
<              any.blaze-markup ==0.8.2.7,
---
>              any.blaze-markup ==0.8.2.8,
76c76,77
<              any.charset ==0.3.7.1,
---
>              any.chainweb-storage ==0.1.0.0,
>              any.charset ==0.3.8,
85,86c86
<              any.concurrent-output ==1.10.12,
<              any.conduit ==1.3.4,
---
>              any.conduit ==1.3.4.1,
90c90
<              any.constraints ==0.12,
---
>              any.constraints ==0.13,
95d94
<              any.crackNum ==2.4,
100,101d98
<              any.crypto-api ==0.13.3,
<              crypto-api -all_cpolys,
117c114
<              any.dec ==0.0.3,
---
>              any.dec ==0.0.4,
130,131d126
<              any.double-conversion ==2.0.2.0,
<              double-conversion -developer,
133d127
<              any.ed25519-donna ==0.1.1,
137d130
<              any.erf ==2.0.0.0,
138a132
>              any.ethereum ==0.1.0.0,
145d138
<              any.formatting ==7.1.1,
150,151c143,144
<              any.generics-sop ==0.5.1.0,
<              any.ghc-boot-th ==8.10.3,
---
>              any.generics-sop ==0.5.1.1,
>              any.ghc-boot-th ==8.10.4,
153d145
<              any.happy ==1.20.0,
157,159c149
<              any.haskell-lexer ==1.1,
<              any.heaps ==0.3.6.1,
<              any.hedgehog ==1.0.4,
---
>              any.heaps ==0.4,
167d156
<              any.hspec-golden ==0.1.0.3,
170c159
<              any.http-client ==0.7.5,
---
>              any.http-client ==0.7.6,
173c162
<              any.http-date ==0.0.10,
---
>              any.http-date ==0.0.11,
176c165
<              any.http2 ==2.0.5,
---
>              any.http2 ==2.0.6,
178d166
<              any.hw-hspec-hedgehog ==0.1.0.4,
181c169,170
<              any.insert-ordered-containers ==0.2.3.1,
---
>              any.indexed-traversable-instances ==0.1,
>              any.insert-ordered-containers ==0.2.4,
185,186d173
<              any.intervals ==0.9.2,
<              intervals -herbie,
188c175
<              any.iproute ==1.7.10,
---
>              any.iproute ==1.7.11,
191c178
<              any.kan-extensions ==5.2.1,
---
>              any.kan-extensions ==5.2.2,
194,195c181,183
<              any.lens-aeson ==1.1,
<              lens-aeson +test-doctests,
---
>              any.lens-aeson ==1.1.1,
>              any.libBF ==0.6.2,
>              libBF -system-libbf,
198c186
<              any.lifted-async ==0.10.1.2,
---
>              any.lifted-async ==0.10.1.3,
232,234c220,223
<              any.optics-core ==0.3.0.1,
<              any.optics-extra ==0.3,
<              any.optics-th ==0.3.0.2,
---
>              any.optics-core ==0.4,
>              optics-core -explicit-generic-labels,
>              any.optics-extra ==0.4,
>              any.optics-th ==0.4,
237c226,227
<              pact -cryptonite-ed25519 -ghc-flags,
---
>              any.pact ==3.7,
>              pact +cryptonite-ed25519 -ghc-flags,
249d238
<              any.pretty-show ==1.10,
253d241
<              any.prettyprinter-convert-ansi-wl-pprint ==1.1.1,
265d252
<              any.raw-strings-qq ==1.1,
274a262
>              any.rosetta ==1.0.0,
278,280c266,267
<              any.safecopy ==0.10.3.1,
<              any.sbv ==8.10,
<              sbv -skiphlinttester,
---
>              any.safecopy ==0.10.4.1,
>              any.sbv ==8.12,
323d309
<              any.system-posix-redirect ==1.1.0.1,
335d320
<              any.terminal-size ==0.3.2.1,
342c327
<              any.th-compat ==0.1.1,
---
>              any.th-compat ==0.1.2,
344a330
>              any.thyme ==0.3.6.0,
360c346
<              any.trifecta ==2.1,
---
>              any.trifecta ==2.1.1,
374c360
<              any.vault ==0.3.1.4,
---
>              any.vault ==0.3.1.5,
382c368
<              any.vector-th-unbox ==0.2.1.7,
---
>              any.vector-th-unbox ==0.2.1.9,
398d383
<              any.wl-pprint-annotated ==0.1.0.1,
407c392
<              any.zlib ==0.6.2.2,
---
>              any.zlib ==0.6.2.3,
408a394
> index-state: hackage.haskell.org 2021-03-17T20:45:14Z
```
