### PR TITLE
Generate coin.TRANSFER events for gas, coinbase, crosschain

### DIFF
--- a/chainweb.cabal
+++ b/chainweb.cabal
@@ -365,7 +365,7 @@ library
         , mwc-probability >= 2.0 && <2.4
         , network >= 2.6 && < 3.1.1 || >= 3.1.2
         , optparse-applicative >= 0.14
-        , pact >= 3.7
+        , pact >= 4.0
         , paths >= 0.2
         , pem >=0.2
         , process >= 1.5

--- a/src/Chainweb/Version.hs
+++ b/src/Chainweb/Version.hs
@@ -864,7 +864,7 @@ pactGenerateEvents :: ChainwebVersion -> BlockHeight -> Bool
 pactGenerateEvents Mainnet01 = (>= 1_600_000) -- 2021-05-07T14:14:46
 pactGenerateEvents Testnet04 = (>= 1_140_000) -- 2021-05-06T13:47:27
 pactGenerateEvents Development = (>= 140)
-pactGenerateEvents (FastTimedCPM g) = const $ g == pairChainGraph || g == petersonChainGraph
+pactGenerateEvents (FastTimedCPM g) = const $ g == pairChainGraph
 pactGenerateEvents _ = const True
 
 -- -------------------------------------------------------------------------- --

--- a/src/Chainweb/Version.hs
+++ b/src/Chainweb/Version.hs
@@ -56,6 +56,7 @@ module Chainweb.Version
 , enableModuleNameFix2
 , enablePactEvents
 , enableSPVBridge
+, pactGenerateEvents
 
 -- ** BlockHeader Validation Guards
 , slowEpochGuard
@@ -857,6 +858,14 @@ enableSPVBridge Testnet04 = (>= 820_000) -- 2021-01-14T17:12:02
 enableSPVBridge Development = (>= 130)
 enableSPVBridge (FastTimedCPM g) = const $ g == pairChainGraph || g == petersonChainGraph
 enableSPVBridge _ = const True
+
+-- | Generate events for gas, coinbase, crosschain
+pactGenerateEvents :: ChainwebVersion -> BlockHeight -> Bool
+pactGenerateEvents Mainnet01 = (>= 1_600_000) -- 2021-05-07T14:14:46
+pactGenerateEvents Testnet04 = (>= 1_140_000) -- 2021-05-06T13:47:27
+pactGenerateEvents Development = (>= 140)
+pactGenerateEvents (FastTimedCPM g) = const $ g == pairChainGraph || g == petersonChainGraph
+pactGenerateEvents _ = const True
 
 -- -------------------------------------------------------------------------- --
 -- Header Validation Guards

--- a/stack.yaml
+++ b/stack.yaml
@@ -39,11 +39,10 @@ extra-deps:
 
   # --- Custom Pins --- #
   - github: kadena-io/pact
-    commit: a9c9b92e313a680574479ffda4700533f19d16d5
+    commit: ccce78004d567966f5cfff131287fbdb3bf63121
   - github: kadena-io/chainweb-storage
     commit: 07e7eb7596c7105aee42dbdb6edd10e3f23c0d7e
   - github: kadena-io/rosetta
     commit: 1d69bb4ec46c001f2b501121e6c93e83ac60162b
   - github: kadena-io/kadena-ethereum-bridge
     commit: 9838d1266b9ee43c88af6c01cd819e0c96b685e6
-


### PR DESCRIPTION
With this change all changes to `coin` accounts will be visible via `coin.TRANSFER` events. This is also the model for a new KIP to require `TRANSFER` events for burn and create by using an empty account `""` to indicate:

- Gas payment: transfer from `sender` to miner
- Coinbase: transfer from `""` to miner
- Crosschain step 1: transfer from `sender` to `""`
- Crosschain step 2: transfer from `""` to `receiver`

TODO investigate if allocation release can be detected for generating events.

FORKING CHANGE.