### PR TITLE
Avoid injecting the local peer into the peer db

### DIFF
--- a/chainweb.cabal
+++ b/chainweb.cabal
@@ -162,7 +162,9 @@ library
         , Chainweb.ChainValue
         , Chainweb.Chainweb
         , Chainweb.Chainweb.ChainResources
+        , Chainweb.Chainweb.CheckReachability
         , Chainweb.Chainweb.CutResources
+        , Chainweb.Chainweb.MempoolSyncClient
         , Chainweb.Chainweb.MinerResources
         , Chainweb.Chainweb.PeerResources
         , Chainweb.Chainweb.PruneChainDatabase

--- a/src/Chainweb/Chainweb.hs
+++ b/src/Chainweb/Chainweb.hs
@@ -172,6 +172,7 @@ import Chainweb.BlockHeight
 import Chainweb.ChainId
 import Chainweb.Chainweb.ChainResources
 import Chainweb.Chainweb.CutResources
+import Chainweb.Chainweb.MempoolSyncClient
 import Chainweb.Chainweb.MinerResources
 import Chainweb.Chainweb.PeerResources
 import Chainweb.Chainweb.PruneChainDatabase
@@ -183,7 +184,7 @@ import qualified Chainweb.Mempool.InMemTypes as Mempool
 import qualified Chainweb.Mempool.Mempool as Mempool
 import Chainweb.Mempool.P2pConfig
 import Chainweb.Miner.Config
-import Chainweb.Pact.RestAPI.Server (PactServerData)
+import Chainweb.Pact.RestAPI.Server (PactServerData(..))
 import Chainweb.Pact.Service.Types (PactServiceConfig(..))
 import Chainweb.Pact.Types (defaultReorgLimit)
 import Chainweb.Pact.Utils (fromPactChainId)
@@ -373,7 +374,7 @@ pCutConfig = id
 -- Service API Configuration
 
 data ServiceApiConfig = ServiceApiConfig
-    { _serviceApiConfigPort :: !Chainweb.RestAPI.Port
+    { _serviceApiConfigPort :: !Port
         -- ^ The public host address for service APIs.
         -- A port number of 0 means that a free port is assigned by the system.
         --
@@ -576,7 +577,7 @@ data Chainweb logger cas = Chainweb
     , _chainwebPeer :: !(PeerResources logger)
     , _chainwebPayloadDb :: !(PayloadDb cas)
     , _chainwebManager :: !HTTP.Manager
-    , _chainwebPactData :: [(ChainId, PactServerData logger cas)]
+    , _chainwebPactData :: ![(ChainId, PactServerData logger cas)]
     , _chainwebThrottler :: !(Throttle Address)
     , _chainwebMiningThrottler :: !(Throttle Address)
     , _chainwebPutPeerThrottler :: !(Throttle Address)
@@ -739,8 +740,16 @@ withChainwebInternal conf logger peer serviceSock rocksDb pactDbDir resetDb inne
         -- initialize chains concurrently
         (\cid x -> do
             let mcfg = validatingMempoolConfig cid v (_configBlockGasLimit conf)
-            withChainResources v cid rocksDb peer (chainLogger cid)
-                     mcfg payloadDb pactDbDir pactConfig x
+            withChainResources
+                v
+                cid
+                rocksDb
+                (chainLogger cid)
+                mcfg
+                payloadDb
+                pactDbDir
+                pactConfig
+                x
         )
 
         -- initialize global resources after all chain resources are initialized
@@ -850,14 +859,19 @@ withChainwebInternal conf logger peer serviceSock rocksDb pactDbDir resetDb inne
     withPactData
         :: HM.HashMap ChainId (ChainResources logger)
         -> CutResources logger cas
-        -> ([(ChainId, (CutResources logger cas, ChainResources logger))] -> IO b)
+        -> ([(ChainId, PactServerData logger cas)] -> IO b)
         -> IO b
     withPactData cs cuts m
         | _enableConfigEnabled (_configTransactionIndex conf) = do
               -- TODO: delete this knob
               logg Info "Transaction index enabled"
               let l = sortBy (compare `on` fst) (HM.toList cs)
-              m $ map (\(c, cr) -> (c, (cuts, cr))) l
+              m $ l <&> fmap (\cr -> PactServerData
+                { _pactServerDataCutDb = _cutResCutDb cuts
+                , _pactServerDataMempool = _chainResMempool cr
+                , _pactServerDataLogger = _chainResLogger cr
+                , _pactServerDataPact = _chainResPact cr
+                })
         | otherwise = do
               logg Info "Transaction index disabled"
               m []
@@ -1001,13 +1015,10 @@ runChainweb cw = do
     mempoolsToServe :: [(ChainId, Mempool.MempoolBackend ChainwebTransaction)]
     mempoolsToServe = proj _chainResMempool
 
-    chainP2pToServe :: [(NetworkId, PeerDb)]
-    chainP2pToServe =
-        bimap ChainNetwork (_peerResDb . _chainResPeer) <$> itoList (_chainwebChains cw)
+    peerDb = _peerResDb (_chainwebPeer cw)
 
     memP2pToServe :: [(NetworkId, PeerDb)]
-    memP2pToServe =
-        bimap MempoolNetwork (_peerResDb . _chainResPeer) <$> itoList (_chainwebChains cw)
+    memP2pToServe = (\(i, _) -> (MempoolNetwork i, peerDb)) <$> chains
 
     payloadDbsToServe :: [(ChainId, PayloadDb cas)]
     payloadDbsToServe = itoList (view chainwebPayloadDb cw <$ _chainwebChains cw)
@@ -1034,7 +1045,7 @@ runChainweb cw = do
             , _chainwebServerBlockHeaderDbs = chainDbsToServe
             , _chainwebServerMempools = mempoolsToServe
             , _chainwebServerPayloadDbs = payloadDbsToServe
-            , _chainwebServerPeerDbs = (CutNetwork, cutPeerDb) : chainP2pToServe <> memP2pToServe
+            , _chainwebServerPeerDbs = (CutNetwork, cutPeerDb) : memP2pToServe
             }
 
     httpLog :: Middleware
@@ -1064,7 +1075,7 @@ runChainweb cw = do
             , _chainwebServerBlockHeaderDbs = chainDbsToServe
             , _chainwebServerMempools = mempoolsToServe
             , _chainwebServerPayloadDbs = payloadDbsToServe
-            , _chainwebServerPeerDbs = (CutNetwork, cutPeerDb) : chainP2pToServe <> memP2pToServe
+            , _chainwebServerPeerDbs = (CutNetwork, cutPeerDb) : memP2pToServe
             }
         pactDbsToServe
         (_chainwebCoordinator cw)
@@ -1120,5 +1131,5 @@ runChainweb cw = do
             return []
         enabled conf = do
             logg Info "Mempool p2p sync enabled"
-            return $ map (runMempoolSyncClient mgr conf) chainVals
+            return $ map (runMempoolSyncClient mgr conf (_chainwebPeer cw)) chainVals
 

--- a/src/Chainweb/Chainweb/ChainResources.hs
+++ b/src/Chainweb/Chainweb/ChainResources.hs
@@ -21,68 +21,44 @@
 module Chainweb.Chainweb.ChainResources
 ( ChainResources(..)
 , chainResBlockHeaderDb
-, chainResPeer
 , chainResMempool
 , chainResLogger
 , chainResPact
 , withChainResources
-
--- * Mempool Sync
-, runMempoolSyncClient
 ) where
-
-import Chainweb.Time
 
 import Control.Concurrent.MVar
 import Control.Lens hiding ((.=), (<.>))
-import Control.Monad
-import Control.Monad.Catch
 
 import Data.Maybe
-import qualified Data.Text as T
 
-import qualified Network.HTTP.Client as HTTP
 
 import Prelude hiding (log)
 
-import System.LogLevel
 
 -- internal modules
 
 import Chainweb.BlockHeaderDB
 import Chainweb.ChainId
-import Chainweb.Chainweb.PeerResources
 import Chainweb.Logger
 import qualified Chainweb.Mempool.Consensus as MPCon
 import qualified Chainweb.Mempool.InMem as Mempool
 import qualified Chainweb.Mempool.InMemTypes as Mempool
 import Chainweb.Mempool.Mempool (MempoolBackend)
-import qualified Chainweb.Mempool.Mempool as Mempool
-import Chainweb.Mempool.P2pConfig
-import qualified Chainweb.Mempool.RestAPI.Client as MPC
 import Chainweb.Pact.Service.PactInProcApi
 import Chainweb.Pact.Service.Types
 import Chainweb.Payload.PayloadStore
-import Chainweb.RestAPI.NetworkID
 import Chainweb.Transaction
-import Chainweb.Utils
 import Chainweb.Version
 import Chainweb.WebPactExecutionService
 
 import Data.CAS.RocksDB
 
-import P2P.Node
-import P2P.Node.Configuration
-import P2P.Session
-
-import qualified Servant.Client as Sv
-
 -- -------------------------------------------------------------------------- --
 -- Single Chain Resources
 
 data ChainResources logger = ChainResources
-    { _chainResPeer :: !(PeerResources logger)
-    , _chainResBlockHeaderDb :: !BlockHeaderDb
+    { _chainResBlockHeaderDb :: !BlockHeaderDb
     , _chainResLogger :: !logger
     , _chainResMempool :: !(MempoolBackend ChainwebTransaction)
     , _chainResPact :: PactExecutionService
@@ -106,7 +82,6 @@ withChainResources
     => ChainwebVersion
     -> ChainId
     -> RocksDb
-    -> PeerResources logger
     -> logger
     -> (MVar PactExecutionService -> Mempool.InMemConfig ChainwebTransaction)
     -> PayloadDb cas
@@ -116,7 +91,7 @@ withChainResources
     -> (ChainResources logger -> IO a)
     -> IO a
 withChainResources
-  v cid rdb peer logger mempoolCfg0 payloadDb pactDbDir pactConfig inner =
+  v cid rdb logger mempoolCfg0 payloadDb pactDbDir pactConfig inner =
     withBlockHeaderDb rdb v cid $ \cdb -> do
       pexMv <- newEmptyMVar
       let mempoolCfg = mempoolCfg0 pexMv
@@ -129,8 +104,7 @@ withChainResources
 
             -- run inner
             inner $ ChainResources
-                { _chainResPeer = peer
-                , _chainResBlockHeaderDb = cdb
+                { _chainResBlockHeaderDb = cdb
                 , _chainResLogger = logger
                 , _chainResMempool = mempool
                 , _chainResPact = pex
@@ -146,60 +120,3 @@ withChainResources
         Testnet04 -> mkPactExecutionService requestQ
         Mainnet01 -> mkPactExecutionService requestQ
 
--- -------------------------------------------------------------------------- --
--- Mempool sync.
-
--- | Synchronize the local mempool over the P2P network.
---
-runMempoolSyncClient
-    :: Logger logger
-    => HTTP.Manager
-        -- ^ HTTP connection pool
-    -> MempoolP2pConfig
-    -> ChainResources logger
-        -- ^ chain resources
-    -> IO ()
-runMempoolSyncClient mgr memP2pConfig chain = bracket create destroy go
-  where
-    create = do
-        logg Debug "starting mempool p2p sync"
-        p2pCreateNode v netId peer (logFunction syncLogger) peerDb mgr True $
-            mempoolSyncP2pSession chain (_mempoolP2pConfigPollInterval memP2pConfig)
-    go n = do
-        -- Run P2P client node
-        logg Debug "mempool sync p2p node initialized, starting session"
-        p2pStartNode p2pConfig n
-
-    destroy n = p2pStopNode n `finally` logg Debug "mempool sync p2p node stopped"
-
-    v = _chainwebVersion chain
-    peer = _peerResPeer $ _chainResPeer chain
-    p2pConfig = _peerResConfig (_chainResPeer chain)
-        & set p2pConfigMaxSessionCount (_mempoolP2pConfigMaxSessionCount memP2pConfig)
-        & set p2pConfigSessionTimeout (_mempoolP2pConfigSessionTimeout memP2pConfig)
-    peerDb = _peerResDb $ _chainResPeer chain
-    netId = MempoolNetwork $ _chainId chain
-
-    logg = logFunctionText syncLogger
-    syncLogger = setComponent "mempool-sync" $ _chainResLogger chain
-
-mempoolSyncP2pSession :: ChainResources logger -> Seconds -> P2pSession
-mempoolSyncP2pSession chain (Seconds pollInterval) logg0 env _ = do
-    logg Debug "mempool sync session starting"
-    Mempool.syncMempools' logg syncIntervalUs pool peerMempool
-    logg Debug "mempool sync session finished"
-    return True
-  where
-    peerMempool = MPC.toMempool v cid txcfg env
-
-    -- FIXME Potentially dangerous down-cast.
-    syncIntervalUs :: Int
-    syncIntervalUs = int pollInterval * 500000
-
-    remote = T.pack $ Sv.showBaseUrl $ Sv.baseUrl env
-    logg d m = logg0 d $ T.concat ["[mempool sync@", remote, "]:", m]
-
-    pool = _chainResMempool chain
-    txcfg = Mempool.mempoolTxConfig pool
-    cid = _chainId chain
-    v = _chainwebVersion chain

--- a/src/Chainweb/Chainweb/CheckReachability.hs
+++ b/src/Chainweb/Chainweb/CheckReachability.hs
@@ -1,0 +1,153 @@
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+-- |
+-- Module: Chainweb.Chainweb.CheckReachability
+-- Copyright: Copyright © 2021 Kadena LLC.
+-- License: MIT
+-- Maintainer: Lars Kuhtz <lars@kadena.io>
+-- Stability: experimental
+--
+-- TODO
+--
+module Chainweb.Chainweb.CheckReachability
+( ReachabilityException(..)
+, checkReachability
+) where
+
+import Configuration.Utils hiding (Error, Lens')
+
+import Control.Concurrent.Async
+import Control.Monad
+import Control.Monad.Catch
+
+import Data.Either
+import Data.Foldable
+
+-- import GHC.Generics
+
+import qualified Network.HTTP.Client as HTTP
+import Network.Socket (Socket)
+import qualified Network.Wai.Handler.Warp as W
+
+import Numeric.Natural
+
+import Prelude hiding (log)
+
+import Servant.Client
+
+import System.LogLevel
+
+-- internal modules
+
+import Chainweb.Logger
+import Chainweb.HostAddress
+import Chainweb.RestAPI.NetworkID
+import Chainweb.RestAPI
+import Chainweb.Utils
+import Chainweb.Version
+
+import P2P.Node.PeerDB
+import P2P.Peer
+
+-- -------------------------------------------------------------------------- --
+-- Exceptions
+
+data ReachabilityException = ReachabilityException !(Expected Natural) !(Actual Natural)
+    deriving (Show, Eq, Ord)
+
+instance Exception ReachabilityException
+
+-- -------------------------------------------------------------------------- --
+-- Check Reachability of Node
+
+-- | Checks that that this node is reachable from at least `threshold` portion
+-- of the provided `peers`.
+--
+-- Two checks are performed for each peer:
+--
+-- 1. the peer is reachable.
+-- 2. the peer can reach this node.
+--
+-- The latter is achieved by calling `PUT cut/peer` with the local peer info.
+--
+-- To this end a temporary peer-db server is started on the local host. This also
+-- implicitly checks that an HTTP server can be served on the local socket.
+--
+checkReachability
+    :: Logger logger
+    => Socket
+    -> HTTP.Manager
+    -> ChainwebVersion
+    -> logger
+    -> PeerDb
+    -> [PeerInfo]
+    -> Peer
+    -> Double
+    -> IO ()
+checkReachability sock mgr v logger pdb peers peer threshold = do
+    withPeerDbServer $ do
+        nis <- forConcurrently peers $ \p ->
+            tryAllSynchronous (run p) >>= \case
+                Right (Right x) -> True <$ do
+                    logg Info $ "reachable from " <> toText (_peerAddr p)
+                    logg Info $ sshow x
+                Right (Left e) -> False <$ do
+                    logg Warn $ "failed to be reachabled from " <> toText (_peerAddr p)
+                        <> ": " <> sshow e
+                Left e -> False <$ do
+                    logg Warn $ "failed to be reachabled from " <> toText (_peerAddr p)
+                        <> ": " <> sshow e
+
+        let c = length $ filter id nis
+            required = ceiling (int (length peers) * threshold)
+        if c < required
+          then do
+            logg Warn $ "Only "
+                <> sshow c <> " out of "
+                <> sshow (length peers) <> " bootstrap peers are reachable."
+                <> "Required number of reachable bootstrap nodes: " <> sshow required
+            throwM $ ReachabilityException (Expected $ int required) (Actual $ int c)
+          else do
+            logg Info $ sshow c <> " out of "
+                <> sshow (length peers) <> " peers are reachable"
+        return ()
+  where
+    pinf = _peerInfo peer
+    logg = logFunctionText logger
+
+    run p = runClientM
+        (peerPutClient v CutNetwork pinf)
+        (peerInfoClientEnv mgr p)
+
+    withPeerDbServer inner = withAsync servePeerDb $ const inner
+
+    servePeerDb = servePeerDbSocketTls
+        serverSettings
+        (_peerCertificateChain peer)
+        (_peerKey peer)
+        sock
+        v
+        CutNetwork
+        pdb
+        id -- TODO add middleware for request logging?
+
+    serverSettings :: W.Settings
+    serverSettings = W.setOnException
+        (\r e -> when (W.defaultShouldDisplayException e) (logg Warn $ loggServerError r e))
+        $ peerServerSettings peer
+
+    loggServerError (Just r) e = "HTTP server error: " <> sshow e <> ". Request: " <> sshow r
+    loggServerError Nothing e = "HTTP server error: " <> sshow e
+
+-- TODO move that elsewhere and unify with method from
+-- Chainweb.Chainweb.PeerResources
+--
+peerServerSettings :: Peer -> W.Settings
+peerServerSettings peer
+    = W.setPort (int . _hostAddressPort . _peerAddr $ _peerInfo peer)
+    . W.setHost (_peerInterface peer)
+    $ W.defaultSettings
+

--- a/src/Chainweb/Chainweb/MempoolSyncClient.hs
+++ b/src/Chainweb/Chainweb/MempoolSyncClient.hs
@@ -1,0 +1,113 @@
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+-- |
+-- Module: Chainweb.Chainweb.MempoolSyncClient
+-- Copyright: Copyright © 2021 Kadena LLC.
+-- License: MIT
+-- Maintainer: Lars Kuhtz <lars@kadena.io>
+-- Stability: experimental
+--
+-- Mempool Synchronization Client
+--
+module Chainweb.Chainweb.MempoolSyncClient
+( runMempoolSyncClient
+) where
+
+import Chainweb.Time
+
+import Control.Lens hiding ((.=), (<.>))
+import Control.Monad
+import Control.Monad.Catch
+
+import qualified Data.Text as T
+
+import qualified Network.HTTP.Client as HTTP
+
+import Prelude hiding (log)
+
+import System.LogLevel
+
+-- internal modules
+
+import Chainweb.ChainId
+import Chainweb.Chainweb.ChainResources
+import Chainweb.Chainweb.PeerResources
+import Chainweb.Logger
+import qualified Chainweb.Mempool.Mempool as Mempool
+import Chainweb.Mempool.P2pConfig
+import qualified Chainweb.Mempool.RestAPI.Client as MPC
+import Chainweb.RestAPI.NetworkID
+import Chainweb.Utils
+import Chainweb.Version
+
+import P2P.Node.Configuration
+import P2P.Session
+import P2P.Node
+
+import qualified Servant.Client as Sv
+
+-- -------------------------------------------------------------------------- --
+-- Mempool sync.
+
+-- | Synchronize the local mempool over the P2P network.
+--
+runMempoolSyncClient
+    :: Logger logger
+    => HTTP.Manager
+        -- ^ HTTP connection pool
+    -> MempoolP2pConfig
+    -> PeerResources logger
+    -> ChainResources logger
+        -- ^ chain resources
+    -> IO ()
+runMempoolSyncClient mgr memP2pConfig peerRes chain = bracket create destroy go
+  where
+    create = do
+        logg Debug "starting mempool p2p sync"
+        p2pCreateNode v netId peer (logFunction syncLogger) peerDb mgr True $
+            mempoolSyncP2pSession chain (_mempoolP2pConfigPollInterval memP2pConfig)
+    go n = do
+        -- Run P2P client node
+        logg Debug "mempool sync p2p node initialized, starting session"
+        p2pStartNode p2pConfig n
+
+    destroy n = p2pStopNode n `finally` logg Debug "mempool sync p2p node stopped"
+
+    v = _chainwebVersion chain
+    peer = _peerResPeer peerRes
+    p2pConfig = _peerResConfig peerRes
+        & set p2pConfigMaxSessionCount (_mempoolP2pConfigMaxSessionCount memP2pConfig)
+        & set p2pConfigSessionTimeout (_mempoolP2pConfigSessionTimeout memP2pConfig)
+    peerDb = _peerResDb peerRes
+    netId = MempoolNetwork $ _chainId chain
+
+    logg = logFunctionText syncLogger
+    syncLogger = setComponent "mempool-sync" $ _chainResLogger chain
+
+mempoolSyncP2pSession
+    :: ChainResources logger
+    -> Seconds
+    -> P2pSession
+mempoolSyncP2pSession chain (Seconds pollInterval) logg0 env _ = do
+    logg Debug "mempool sync session starting"
+    Mempool.syncMempools' logg syncIntervalUs pool peerMempool
+    logg Debug "mempool sync session finished"
+    return True
+  where
+    peerMempool = MPC.toMempool v cid txcfg env
+
+    -- FIXME Potentially dangerous down-cast.
+    syncIntervalUs :: Int
+    syncIntervalUs = int pollInterval * 500000
+
+    remote = T.pack $ Sv.showBaseUrl $ Sv.baseUrl env
+    logg d m = logg0 d $ T.concat ["[mempool sync@", remote, "]:", m]
+
+    pool = _chainResMempool chain
+    txcfg = Mempool.mempoolTxConfig pool
+    cid = _chainId chain
+    v = _chainwebVersion chain

--- a/src/Chainweb/Chainweb/PeerResources.hs
+++ b/src/Chainweb/Chainweb/PeerResources.hs
@@ -145,7 +145,7 @@ withPeerResources v conf logger inner = withPeerSocket conf $ \(conf', sock) -> 
 
                 -- check that this node is reachable:
                 let peers = _p2pConfigKnownPeers conf
-                checkReachability sock mgr v logger' peerDb peers
+                checkReachability sock mgr v logger' localDb peers
                     peer
                     (_p2pConfigBootstrapReachability conf'')
 

--- a/src/Chainweb/Chainweb/PeerResources.hs
+++ b/src/Chainweb/Chainweb/PeerResources.hs
@@ -49,6 +49,7 @@ import Control.Monad.Catch
 
 import qualified Data.ByteString.Char8 as B8
 import Data.Either
+import Data.Function
 import qualified Data.HashSet as HS
 import Data.IxSet.Typed (getEQ, getOne)
 import qualified Data.List as L
@@ -142,12 +143,14 @@ withPeerResources v conf logger inner = withPeerSocket conf $ \(conf', sock) -> 
             localDb <- peerDbSetLocalPeer pinf peerDb
 
             withConnectionLogger mgrLogger counter $ do
-
                 -- check that this node is reachable:
-                let peers = _p2pConfigKnownPeers conf
-                checkReachability sock mgr v logger' localDb peers
-                    peer
-                    (_p2pConfigBootstrapReachability conf'')
+                when (_p2pConfigBootstrapReachability conf > 0) $ do
+
+                    let peers = filter (((/=) `on` _peerAddr) pinf)
+                            $ _p2pConfigKnownPeers conf
+                    checkReachability sock mgr v logger' localDb peers
+                        peer
+                        (_p2pConfigBootstrapReachability conf'')
 
                 inner logger' (PeerResources conf'' peer sock localDb mgr logger')
 

--- a/src/Chainweb/Chainweb/PeerResources.hs
+++ b/src/Chainweb/Chainweb/PeerResources.hs
@@ -176,9 +176,12 @@ checkReachability
 checkReachability mgr v logger peers pinf threshold = do
     nis <- forConcurrently peers $ \p ->
         tryAllSynchronous (run p) >>= \case
-            Right x -> True <$ do
+            Right (Right x) -> True <$ do
                 logg Info $ "reachable from " <> toText (_peerAddr p)
                 logg Info $ sshow x
+            Right (Left e) -> False <$ do
+                logg Warn $ "failed to be reachabled from " <> toText (_peerAddr p)
+                    <> ": " <> sshow e
             Left e -> False <$ do
                 logg Warn $ "failed to be reachabled from " <> toText (_peerAddr p)
                     <> ": " <> sshow e

--- a/src/Chainweb/Chainweb/PeerResources.hs
+++ b/src/Chainweb/Chainweb/PeerResources.hs
@@ -49,7 +49,6 @@ import Control.Monad.Catch
 
 import qualified Data.ByteString.Char8 as B8
 import Data.Either
-import Data.Foldable
 import qualified Data.HashSet as HS
 import Data.IxSet.Typed (getEQ, getOne)
 import qualified Data.List as L
@@ -62,17 +61,14 @@ import qualified Network.HTTP.Client as HTTP
 import Network.Socket (Socket)
 import Network.Wai.Handler.Warp (Settings, defaultSettings, setHost, setPort)
 
-import Numeric.Natural
-
 import Prelude hiding (log)
-
-import Servant.Client
 
 import System.LogLevel
 
 -- internal modules
 
 import Chainweb.Counter
+import Chainweb.Chainweb.CheckReachability
 import Chainweb.HostAddress
 import Chainweb.Logger
 import Chainweb.NodeVersion
@@ -86,16 +82,7 @@ import Network.X509.SelfSigned
 import P2P.Node
 import P2P.Node.Configuration
 import P2P.Node.PeerDB
-import P2P.Node.RestAPI.Client
 import P2P.Peer
-
--- -------------------------------------------------------------------------- --
--- Exceptions
-
-data ReachabilityException = ReachabilityException !(Expected Natural) !(Actual Natural)
-    deriving (Show, Eq, Ord)
-
-instance Exception ReachabilityException
 
 -- -------------------------------------------------------------------------- --
 -- Allocate Peer Resources
@@ -158,53 +145,11 @@ withPeerResources v conf logger inner = withPeerSocket conf $ \(conf', sock) -> 
 
                 -- check that this node is reachable:
                 let peers = _p2pConfigKnownPeers conf
-                checkReachability mgr v logger' peers
-                    (_peerInfo peer)
+                checkReachability sock mgr v logger' peerDb peers
+                    peer
                     (_p2pConfigBootstrapReachability conf'')
 
                 inner logger' (PeerResources conf'' peer sock localDb mgr logger')
-
-checkReachability
-    :: Logger logger
-    => HTTP.Manager
-    -> ChainwebVersion
-    -> logger
-    -> [PeerInfo]
-    -> PeerInfo
-    -> Double
-    -> IO ()
-checkReachability mgr v logger peers pinf threshold = do
-    nis <- forConcurrently peers $ \p ->
-        tryAllSynchronous (run p) >>= \case
-            Right (Right x) -> True <$ do
-                logg Info $ "reachable from " <> toText (_peerAddr p)
-                logg Info $ sshow x
-            Right (Left e) -> False <$ do
-                logg Warn $ "failed to be reachabled from " <> toText (_peerAddr p)
-                    <> ": " <> sshow e
-            Left e -> False <$ do
-                logg Warn $ "failed to be reachabled from " <> toText (_peerAddr p)
-                    <> ": " <> sshow e
-
-    let c = length $ filter id nis
-        required = ceiling (int (length peers) * threshold)
-    if c < required
-      then do
-        logg Warn $ "Only "
-            <> sshow c <> " out of "
-            <> sshow (length peers) <> " bootstrap peers are reachable."
-            <> "Required number of reachable bootstrap nodes: " <> sshow required
-        throwM $ ReachabilityException (Expected $ int required) (Actual $ int c)
-      else do
-        logg Info $ sshow c <> " out of "
-            <> sshow (length peers) <> " peers are reachable"
-    return ()
-  where
-    logg = logFunctionText logger
-
-    run peer = runClientM
-        (peerPutClient v CutNetwork pinf)
-        (peerInfoClientEnv mgr peer)
 
 peerServerSettings :: Peer -> Settings
 peerServerSettings peer

--- a/src/Chainweb/Chainweb/PeerResources.hs
+++ b/src/Chainweb/Chainweb/PeerResources.hs
@@ -148,6 +148,10 @@ withPeerResources v conf logger inner = withPeerSocket conf $ \(conf', sock) -> 
                         logger
                 mgrLogger = setComponent "connection-manager" logger'
 
+            -- make sure that the local peer itself isn't in the database that
+            -- we initialized from the configuration.
+            peerDbDelete_ peerDb True {- force deletion of sticky peers -} pinf
+
             withConnectionLogger mgrLogger counter $ do
 
                 -- check that this node is reachable:

--- a/src/Chainweb/Chainweb/PeerResources.hs
+++ b/src/Chainweb/Chainweb/PeerResources.hs
@@ -49,6 +49,7 @@ import Control.Monad.Catch
 
 import qualified Data.ByteString.Char8 as B8
 import Data.Either
+import Data.Foldable
 import qualified Data.HashSet as HS
 import Data.IxSet.Typed (getEQ, getOne)
 import qualified Data.List as L
@@ -148,9 +149,15 @@ withPeerResources v conf logger inner = withPeerSocket conf $ \(conf', sock) -> 
                         logger
                 mgrLogger = setComponent "connection-manager" logger'
 
+            logFunctionText logger Info $ "Local Peer Info: " <> encodeToText pinf
+
             -- make sure that the local peer itself isn't in the database that
             -- we initialized from the configuration.
             peerDbDelete_ peerDb True {- force deletion of sticky peers -} pinf
+
+            -- Log initial peer db
+            db <- peerDbSnapshot peerDb
+            logFunctionText logger Debug $ "Initial Peer DB: " <> encodeToText (toList db)
 
             withConnectionLogger mgrLogger counter $ do
 

--- a/src/Chainweb/Chainweb/PeerResources.hs
+++ b/src/Chainweb/Chainweb/PeerResources.hs
@@ -151,14 +151,6 @@ withPeerResources v conf logger inner = withPeerSocket conf $ \(conf', sock) -> 
 
             logFunctionText logger Info $ "Local Peer Info: " <> encodeToText pinf
 
-            -- make sure that the local peer itself isn't in the database that
-            -- we initialized from the configuration.
-            peerDbDelete_ peerDb True {- force deletion of sticky peers -} pinf
-
-            -- Log initial peer db
-            db <- peerDbSnapshot peerDb
-            logFunctionText logger Debug $ "Initial Peer DB: " <> encodeToText (toList db)
-
             withConnectionLogger mgrLogger counter $ do
 
                 -- check that this node is reachable:

--- a/src/Chainweb/RestAPI.hs
+++ b/src/Chainweb/RestAPI.hs
@@ -33,13 +33,6 @@ module Chainweb.RestAPI
 , ChainwebServerDbs(..)
 , emptyChainwebServerDbs
 
--- -- * Full Chainweb API (only used for generating swagger spec)
--- , someChainwebApi
--- , someChainwebPeerApi
--- , someChainwebServiceApi
--- , prettyShowChainwebApi
--- , apiVersion
--- , prettyApiVersion
 
 -- * Swagger
 , prettyChainwebSwagger
@@ -502,4 +495,3 @@ serveServiceApiSocket
     -> IO ()
 serveServiceApiSocket s sock v dbs pacts mr hs r m =
     runSettingsSocket s sock $ m $ serviceApiApplication v dbs pacts mr hs r
-

--- a/src/Chainweb/Rosetta/RestAPI/Server.hs
+++ b/src/Chainweb/Rosetta/RestAPI/Server.hs
@@ -14,8 +14,9 @@
 -- Stability: experimental
 --
 --
-module Chainweb.Rosetta.RestAPI.Server where
-
+module Chainweb.Rosetta.RestAPI.Server
+( someRosettaServer
+) where
 
 import Control.Error.Util
 import Control.Monad (void, (<$!>))
@@ -45,7 +46,6 @@ import Servant.Server
 
 import Chainweb.BlockHeader (BlockHeader(..))
 import Chainweb.BlockHeader.Genesis (genesisBlockHeader)
-import Chainweb.Chainweb.ChainResources (ChainResources(..))
 import Chainweb.Cut (_cutMap)
 import Chainweb.CutDB
 import Chainweb.HostAddress
@@ -61,6 +61,7 @@ import Chainweb.Transaction (ChainwebTransaction)
 import Chainweb.Utils
 import Chainweb.Utils.Paging
 import Chainweb.Version
+import Chainweb.WebPactExecutionService
 
 import P2P.Node.PeerDB
 import P2P.Node.RestAPI.Server (peerGetHandler)
@@ -69,21 +70,21 @@ import P2P.Peer
 ---
 
 rosettaServer
-    :: forall cas a (v :: ChainwebVersionT)
+    :: forall cas (v :: ChainwebVersionT)
     . PayloadCasLookup cas
     => ChainwebVersion
     -> [(ChainId, PayloadDb cas)]
     -> [(ChainId, MempoolBackend ChainwebTransaction)]
     -> PeerDb
     -> CutDb cas
-    -> [(ChainId, ChainResources a)]
+    -> [(ChainId, PactExecutionService)]
     -> Server (RosettaApi v)
-rosettaServer v ps ms peerDb cutDb cr =
+rosettaServer v ps ms peerDb cutDb pacts =
     -- Account --
-    accountBalanceH v cutDb cr
+    accountBalanceH v cutDb pacts
     -- Blocks --
-    :<|> blockTransactionH v cutDb ps cr
-    :<|> blockH v cutDb ps cr
+    :<|> blockTransactionH v cutDb ps pacts
+    :<|> blockH v cutDb ps pacts
     -- Construction --
     :<|> constructionMetadataH v
     :<|> constructionSubmitH v ms
@@ -91,9 +92,9 @@ rosettaServer v ps ms peerDb cutDb cr =
     :<|> mempoolTransactionH v ms
     :<|> mempoolH v ms
     -- Network --
-    :<|> (networkListH v cutDb)
+    :<|> networkListH v cutDb
     :<|> networkOptionsH v
-    :<|> (networkStatusH v cutDb peerDb)
+    :<|> networkStatusH v cutDb peerDb
 
 someRosettaServer
     :: PayloadCasLookup cas
@@ -101,11 +102,11 @@ someRosettaServer
     -> [(ChainId, PayloadDb cas)]
     -> [(ChainId, MempoolBackend ChainwebTransaction)]
     -> PeerDb
-    -> [(ChainId, ChainResources a)]
+    -> [(ChainId, PactExecutionService)]
     -> CutDb cas
     -> SomeServer
-someRosettaServer v@(FromSingChainwebVersion (SChainwebVersion :: Sing vT)) ps ms pdb crs cdb =
-    SomeServer (Proxy @(RosettaApi vT)) $ rosettaServer v ps ms pdb cdb crs
+someRosettaServer v@(FromSingChainwebVersion (SChainwebVersion :: Sing vT)) ps ms pdb pacts cdb =
+    SomeServer (Proxy @(RosettaApi vT)) $ rosettaServer v ps ms pdb cdb pacts
 
 --------------------------------------------------------------------------------
 -- Account Handlers
@@ -113,11 +114,11 @@ someRosettaServer v@(FromSingChainwebVersion (SChainwebVersion :: Sing vT)) ps m
 accountBalanceH
     :: ChainwebVersion
     -> CutDb cas
-    -> [(ChainId, ChainResources a)]
+    -> [(ChainId, PactExecutionService)]
     -> AccountBalanceReq
     -> Handler AccountBalanceResp
 accountBalanceH _ _ _ (AccountBalanceReq _ (AccountId _ (Just _) _) _) = throwRosetta RosettaSubAcctUnsupported
-accountBalanceH v cutDb crs (AccountBalanceReq net (AccountId acct _ _) pbid) = do
+accountBalanceH v cutDb pacts (AccountBalanceReq net (AccountId acct _ _) pbid) = do
   runExceptT work >>= either throwRosetta pure
   where
     acctBalResp bid bal = AccountBalanceResp
@@ -130,10 +131,10 @@ accountBalanceH v cutDb crs (AccountBalanceReq net (AccountId acct _ _) pbid) = 
     work :: ExceptT RosettaFailure Handler AccountBalanceResp
     work = do
       cid <- validateNetwork v net
-      cr <- lookup cid crs ?? RosettaInvalidChain
+      pact <- lookup cid pacts ?? RosettaInvalidChain
       bh <- findBlockHeaderInCurrFork cutDb cid
         (get _partialBlockId_index pbid) (get _partialBlockId_hash pbid)
-      bal <- getHistoricalLookupBalance (_chainResPact cr) bh acct
+      bal <- getHistoricalLookupBalance pact bh acct
       pure $ acctBalResp (blockId bh) bal
       where
         get _ Nothing = Nothing
@@ -143,15 +144,15 @@ accountBalanceH v cutDb crs (AccountBalanceReq net (AccountId acct _ _) pbid) = 
 -- Block Handlers
 
 blockH
-    :: forall a cas
+    :: forall cas
     . PayloadCasLookup cas
     => ChainwebVersion
     -> CutDb cas
     -> [(ChainId, PayloadDb cas)]
-    -> [(ChainId, ChainResources a)]
+    -> [(ChainId, PactExecutionService)]
     -> BlockReq
     -> Handler BlockResp
-blockH v cutDb ps crs (BlockReq net (PartialBlockId bheight bhash)) =
+blockH v cutDb ps pacts (BlockReq net (PartialBlockId bheight bhash)) =
   runExceptT work >>= either throwRosetta pure
   where
     block :: BlockHeader -> [Transaction] -> Block
@@ -166,11 +167,11 @@ blockH v cutDb ps crs (BlockReq net (PartialBlockId bheight bhash)) =
     work :: ExceptT RosettaFailure Handler BlockResp
     work = do
       cid <- validateNetwork v net
-      cr <- lookup cid crs ?? RosettaInvalidChain
+      pact <- lookup cid pacts ?? RosettaInvalidChain
       payloadDb <- lookup cid ps ?? RosettaInvalidChain
       bh <- findBlockHeaderInCurrFork cutDb cid bheight bhash
       (coinbase, txs) <- getBlockOutputs payloadDb bh
-      logs <- getTxLogs (_chainResPact cr) bh
+      logs <- getTxLogs pact bh
       trans <- hoistEither $ matchLogs FullLogs bh logs coinbase txs
       pure $ BlockResp
         { _blockResp_block = Just $ block bh trans
@@ -178,15 +179,15 @@ blockH v cutDb ps crs (BlockReq net (PartialBlockId bheight bhash)) =
         }
 
 blockTransactionH
-    :: forall a cas
+    :: forall cas
     . PayloadCasLookup cas
     => ChainwebVersion
     -> CutDb cas
     -> [(ChainId, PayloadDb cas)]
-    -> [(ChainId, ChainResources a)]
+    -> [(ChainId, PactExecutionService)]
     -> BlockTransactionReq
     -> Handler BlockTransactionResp
-blockTransactionH v cutDb ps crs (BlockTransactionReq net bid t) =
+blockTransactionH v cutDb ps pacts (BlockTransactionReq net bid t) =
   runExceptT work >>= either throwRosetta pure
   where
     BlockId bheight bhash = bid
@@ -195,12 +196,12 @@ blockTransactionH v cutDb ps crs (BlockTransactionReq net bid t) =
     work :: ExceptT RosettaFailure Handler BlockTransactionResp
     work = do
       cid <- validateNetwork v net
-      cr <- lookup cid crs ?? RosettaInvalidChain
+      pact <- lookup cid pacts ?? RosettaInvalidChain
       payloadDb <- lookup cid ps ?? RosettaInvalidChain
       bh <- findBlockHeaderInCurrFork cutDb cid (Just bheight) (Just bhash)
-      rkTarget <- (hush $ fromText' rtid) ?? RosettaUnparsableTransactionId
+      rkTarget <- hush (fromText' rtid) ?? RosettaUnparsableTransactionId
       (coinbase, txs) <- getBlockOutputs payloadDb bh
-      logs <- getTxLogs (_chainResPact cr) bh
+      logs <- getTxLogs pact bh
 
       tran <- hoistEither $ matchLogs
               (SingleLog rkTarget) bh logs coinbase txs
@@ -298,7 +299,7 @@ mempoolTransactionH v ms mtr = runExceptT work >>= either throwRosetta pure
     work = do
         cid <- validateNetwork v net
         mp <- lookup cid ms ?? RosettaInvalidChain
-        th <- (hush $ fromText ti) ?? RosettaUnparsableTransactionId
+        th <- hush (fromText ti) ?? RosettaUnparsableTransactionId
         lrs <- liftIO . mempoolLookup mp $ V.singleton th
         (lrs V.!? 0 >>= f) ?? RosettaMempoolBadTx
 
@@ -315,7 +316,7 @@ networkListH v cutDb _ = runExceptT work >>= either throwRosetta pure
       -- the current cut.
       -- NOTE: This ensures only returning chains that are "active" at
       -- the current time.
-      let networkIds = map f $! sort $! (HM.keys (_cutMap c))
+      let networkIds = map f $! sort $! HM.keys (_cutMap c)
       pure $ NetworkListResp networkIds
 
     f :: ChainId -> NetworkId

--- a/src/P2P/Node.hs
+++ b/src/P2P/Node.hs
@@ -721,10 +721,6 @@ p2pCreateNode
     -> P2pSession
     -> IO P2pNode
 p2pCreateNode cv nid peer logfun db mgr doPeerSync session = do
-
-    -- set local peer (prefents it from being added to the peer database)
-    localDb <- peerDbSetLocalPeer myInfo db
-
     -- intialize P2P State
     sessionsVar <- newTVarIO mempty
     statsVar <- newTVarIO emptyP2pNodeStats
@@ -734,7 +730,7 @@ p2pCreateNode cv nid peer logfun db mgr doPeerSync session = do
                 { _p2pNodeNetworkId = nid
                 , _p2pNodeChainwebVersion = cv
                 , _p2pNodePeerInfo = myInfo
-                , _p2pNodePeerDb = localDb
+                , _p2pNodePeerDb = db
                 , _p2pNodeSessions = sessionsVar
                 , _p2pNodeManager = mgr
                 , _p2pNodeLogFunction = logfun

--- a/src/P2P/Node.hs
+++ b/src/P2P/Node.hs
@@ -389,7 +389,7 @@ guardPeerDbOfNode
     -> IO (Maybe PeerInfo)
 guardPeerDbOfNode node pinf = go >>= \case
     Left e -> do
-        logg node Warn $ "failed to validate peer " <> showInfo pinf <> ": " <> T.pack (displayException e)
+        logg node Info $ "failed to validate peer " <> showInfo pinf <> ": " <> T.pack (displayException e)
         return Nothing
     Right x -> return (Just x)
   where

--- a/src/P2P/Node/Configuration.hs
+++ b/src/P2P/Node/Configuration.hs
@@ -28,6 +28,7 @@ module P2P.Node.Configuration
 , p2pConfigSessionTimeout
 , p2pConfigKnownPeers
 , p2pConfigIgnoreBootstrapNodes
+, p2pConfigBootstrapReachability
 , defaultP2pConfiguration
 , validateP2pConfiguration
 , pP2pConfiguration

--- a/src/P2P/Node/RestAPI/Client.hs
+++ b/src/P2P/Node/RestAPI/Client.hs
@@ -59,3 +59,4 @@ peerPutClient (FromSingChainwebVersion (SChainwebVersion :: Sing v)) = f
     f (FromSingNetworkId (SChainNetwork SChainId :: Sing n)) = client $ peerPutApi @v @n
     f (FromSingNetworkId (SMempoolNetwork SChainId :: Sing n)) = client $ peerPutApi @v @n
     f (FromSingNetworkId (SCutNetwork :: Sing n)) = client $ peerPutApi @v @n
+

--- a/src/P2P/Node/RestAPI/Server.hs
+++ b/src/P2P/Node/RestAPI/Server.hs
@@ -193,3 +193,4 @@ serveP2pSocket
     -> [(NetworkId, PeerDb)]
     -> IO ()
 serveP2pSocket s sock v = runSettingsSocket s sock . someServerApplication . someP2pServers v
+

--- a/test/Chainweb/Test/MultiNode.hs
+++ b/test/Chainweb/Test/MultiNode.hs
@@ -140,8 +140,8 @@ multiConfig v n = defaultChainwebConfiguration v
         -- Use short sessions to cover session timeouts and setup logic in the
         -- test.
 
-    & set (configP2p . p2pConfigBootstrapReachability) 0.5
-        -- don't require half of the bootstraps to be reachable
+    & set (configP2p . p2pConfigBootstrapReachability) 0
+        -- disable reachability test, which is unreliable during testing
 
     & set (configMining . miningCoordination . coordinationEnabled) True
     & set (configMining . miningInNode) miner

--- a/test/Chainweb/Test/MultiNode.hs
+++ b/test/Chainweb/Test/MultiNode.hs
@@ -140,6 +140,9 @@ multiConfig v n = defaultChainwebConfiguration v
         -- Use short sessions to cover session timeouts and setup logic in the
         -- test.
 
+    & set (configP2p . p2pConfigBootstrapReachability) 0.5
+        -- don't require half of the bootstraps to be reachable
+
     & set (configMining . miningCoordination . coordinationEnabled) True
     & set (configMining . miningInNode) miner
 


### PR DESCRIPTION
This PR involves some long pending code cleanup in order to avoid cyclic dependencies. While touches a lot of code the changes are mostly straight forward.

* [x] cleanup use of `*Resources` datastructures. These data structure are meant as temporary collections of different resources during node initialization. They shouldn't be used after the services are started. Usage outside of initialization code can lead to dependency cycles and can also keep data alive that otherwise could be GCed.
* [x] start temporary P2P peer endpoints during initial reachability test of node.
* [x] avoid injection of the local peer into the peer db
