### PR TITLE
fix mining newWork function

### DIFF
--- a/src/Chainweb/Miner/Coordinator.hs
+++ b/src/Chainweb/Miner/Coordinator.hs
@@ -38,7 +38,6 @@ module Chainweb.Miner.Coordinator
 -- ** Internal Functions
 , newWork
 , publish
-, removePrimed
 ) where
 
 import Control.Concurrent.STM (atomically)


### PR DESCRIPTION
This fixes a condition in the newWork method that cause the mining coordinator to get stuck on an outdated primed work item.