### PR TITLE
Hidden option to disable TLS for peer API

### DIFF
--- a/src/Chainweb/Chainweb/PeerResources.hs
+++ b/src/Chainweb/Chainweb/PeerResources.hs
@@ -223,6 +223,7 @@ getHost mgr ver logger peers = do
                     $ "failed to get remote info from " <> toText (_peerAddr p)
                     <> ": " <> sshow e
 
+    -- TODO: use quorum here? Fitler out local network addresses?
     let hostnames = L.nub $ L.sort $ view remoteNodeInfoHostname <$> catMaybes nis
     return $! case hostnames of
         [x] -> Right x

--- a/test/Chainweb/Test/Orphans/Internal.hs
+++ b/test/Chainweb/Test/Orphans/Internal.hs
@@ -190,7 +190,7 @@ instance Arbitrary P2pConfiguration where
     arbitrary = P2pConfiguration
         <$> arbitrary <*> arbitrary <*> arbitrary
         <*> arbitrary <*> arbitrary <*> arbitrary
-        <*> arbitrary <*> arbitrary
+        <*> arbitrary <*> arbitrary <*> arbitrary
 
 instance Arbitrary PeerEntry where
     arbitrary = PeerEntry


### PR DESCRIPTION
Allow an expert user to run the peer API of an chainweb-node without TLS behind a reverse proxy.