### PR TITLE
a few eta-expansions for ghc-9

### DIFF
--- a/node/ChainwebNode.hs
+++ b/node/ChainwebNode.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
@@ -279,12 +280,15 @@ runAmberdataBlockMonitor config logger db
 
 -- This instances are OK, since this is the "Main" module of an application
 --
+#if !MIN_VERSION_base(4,15,0)
 deriving instance Generic GCDetails
-deriving instance NFData GCDetails
-deriving instance ToJSON GCDetails
-
 deriving instance Generic RTSStats
+#endif
+
+deriving instance NFData GCDetails
 deriving instance NFData RTSStats
+
+deriving instance ToJSON GCDetails
 deriving instance ToJSON RTSStats
 
 runRtsMonitor :: Logger logger => logger -> IO ()

--- a/src/Chainweb/Chainweb/PeerResources.hs
+++ b/src/Chainweb/Chainweb/PeerResources.hs
@@ -323,7 +323,7 @@ withConnectionLogger
     -> IO a
     -> IO a
 withConnectionLogger logger counter inner =
-    withAsyncWithUnmask runLogClientConnections $ const inner
+    withAsyncWithUnmask (\u -> runLogClientConnections u) $ const inner
   where
     logClientConnections = forever $ do
         approximateThreadDelay 60000000 {- 1 minute -}

--- a/src/Chainweb/CutDB.hs
+++ b/src/Chainweb/CutDB.hs
@@ -335,10 +335,11 @@ withCutDb
     -> RocksDbCas CutHashes
     -> (forall cas' . PayloadCasLookup cas' => CutDb cas' -> IO a)
     -> IO a
-withCutDb config logfun headerStore payloadStore cutHashesStore
+withCutDb config logfun headerStore payloadStore cutHashesStore a
     = bracket
         (startCutDb config logfun headerStore payloadStore cutHashesStore)
         stopCutDb
+        a
 
 -- | Start a CutDB. This loads the initial cut from the database (falling back
 -- to the configured initial cut loading fails) and starts the cut validation

--- a/src/Chainweb/Pact/PactService/Checkpointer.hs
+++ b/src/Chainweb/Pact/PactService/Checkpointer.hs
@@ -133,7 +133,7 @@ withPactState inner = bracket captureState releaseState $ \ref -> do
 exitOnRewindLimitExceeded :: PactServiceM cas a -> PactServiceM cas a
 exitOnRewindLimitExceeded = handle $ \case
     e@RewindLimitExceeded{} -> do
-        killFunction <- asks _psOnFatalError
+        killFunction <- asks (\x -> _psOnFatalError x)
         liftIO $ killFunction e (encodeToText $ msg e)
     e -> throwM e
   where

--- a/src/Chainweb/Pact/Service/PactInProcApi.hs
+++ b/src/Chainweb/Pact/Service/PactInProcApi.hs
@@ -129,7 +129,7 @@ pactMemPoolGetBlock mpc theLogger validate height hash _bHeader = do
     mempoolGetBlock (mpcMempool mpc) validate height hash
   where
    logFn :: Logger l => l -> LogFunctionText -- just for giving GHC some type hints
-   logFn = logFunction
+   logFn l = logFunction l
 
 
 pactProcessFork

--- a/src/Chainweb/Utils.hs
+++ b/src/Chainweb/Utils.hs
@@ -434,7 +434,7 @@ class IxedGet a where
     ixg :: Index a -> Fold a (IxValue a)
 
     default ixg :: Ixed a => Index a -> Fold a (IxValue a)
-    ixg = ix
+    ixg i = ix i
     {-# INLINE ixg #-}
 
 -- -------------------------------------------------------------------------- --

--- a/src/Control/Concurrent/FixedThreadPool.hs
+++ b/src/Control/Concurrent/FixedThreadPool.hs
@@ -51,7 +51,7 @@ newThreadPool :: Int -> IO ThreadPool
 newThreadPool n = do
     chan <- atomically $ TBMChan.newTBMChan n
     mvars <- V.replicateM n newEmptyMVar
-    threads <- V.mapM (\m -> forkIOWithUnmask $ worker chan m) mvars
+    threads <- V.mapM (\m -> forkIOWithUnmask $ \u -> worker chan m u) mvars
     let joins = V.map takeMVar mvars
     return $! ThreadPool threads joins chan
 

--- a/src/P2P/Node.hs
+++ b/src/P2P/Node.hs
@@ -276,7 +276,7 @@ updateActiveCount node = do
 -- | Monomorphized LogFunction
 --
 logg :: P2pNode -> LogLevel -> T.Text -> IO ()
-logg = _p2pNodeLogFunction
+logg n = _p2pNodeLogFunction n
 
 loggFun :: P2pNode -> LogFunction
 loggFun = _p2pNodeLogFunction

--- a/test/Chainweb/Test/Mempool/RestAPI.hs
+++ b/test/Chainweb/Test/Mempool/RestAPI.hs
@@ -55,7 +55,7 @@ newTestServer = mask_ $ do
     let inMemCfg = InMemConfig txcfg mockBlockGasLimit 2048 Right (checkMvFunc checkMv) (1024 * 10)
     inmemMv <- newEmptyMVar
     envMv <- newEmptyMVar
-    tid <- forkIOWithUnmask $ server inMemCfg inmemMv envMv
+    tid <- forkIOWithUnmask $ \u -> server inMemCfg inmemMv envMv u
     inmem <- takeMVar inmemMv
     env <- takeMVar envMv
     let remoteMp0 = MClient.toMempool version chain txcfg env


### PR DESCRIPTION
GHC-9 is a bit less lenient and requires more explicit eta expansions.

Also, base-4.15 comes with `Generic` instances for `GCDetails` and `RTSStats`. So, we can omit the orphan instances.