### PR TITLE
Version 2.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # `chainweb-node` Changelog
 
+## 2.9 (2021-08-12)
+
+This version replaces all previous versions. Any prior version will stop working
+on **2021-08-19T00:00:00Z**. Node administrators must upgrade to this version
+before that date.
+
+This version will stop working on **2021-09-30T00:00:00Z**.
+
+Changes:
+
+This is a maintenance release without breaking changes.
+
+*   Use `0.0.0.0` as default P2P host address, which enables auto-detection of
+    the IP address of the node. (#1245)
+*   Build and link Pact without CLI tools support. (#1246)
+*   Limit batch size of payload REST API requests 1000 items. (#1258)
+*   Removed several external dependencies from the code base.
+
 ## 2.8 (2021-06-05)
 
 This version replaces all previous versions. Any prior version will stop working

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ This version replaces all previous versions. Any prior version will stop working
 on **2021-08-19T00:00:00Z**. Node administrators must upgrade to this version
 before that date.
 
-This version will stop working on **2021-09-30T00:00:00Z**.
+This version will stop working on **2021-10-14T00:00:00Z**.
 
 Changes:
 

--- a/chainweb.cabal
+++ b/chainweb.cabal
@@ -1,7 +1,7 @@
 cabal-version: 2.4
 
 name:         chainweb
-version:      2.8
+version:      2.9
 synopsis:     A Proof-of-Work Parallel-Chain Architecture for Massive Throughput
 description:  A Proof-of-Work Parallel-Chain Architecture for Massive Throughput.
 homepage:     https://github.com/kadena-io/chainweb
@@ -15,7 +15,8 @@ category:     Blockchain, Currency, Bitcoin
 build-type:   Custom
 
 tested-with:
-    GHC == 8.10.4
+    GHC == 9.0.1
+    GHC == 8.10.5
     GHC == 8.8.4
     GHC == 8.6.5
 

--- a/node/ChainwebNode.hs
+++ b/node/ChainwebNode.hs
@@ -456,10 +456,10 @@ pkgInfoScopes =
 -- -------------------------------------------------------------------------- --
 -- main
 
--- KILLSWITCH for version 2.8
+-- KILLSWITCH for version 2.9
 --
 killSwitchDate :: Maybe String
-killSwitchDate = Just "2021-08-19T00:00:00Z"
+killSwitchDate = Just "2021-09-30T00:00:00Z"
 
 mainInfo :: ProgramInfo ChainwebNodeConfiguration
 mainInfo = programInfoValidate

--- a/node/ChainwebNode.hs
+++ b/node/ChainwebNode.hs
@@ -459,7 +459,7 @@ pkgInfoScopes =
 -- KILLSWITCH for version 2.9
 --
 killSwitchDate :: Maybe String
-killSwitchDate = Just "2021-09-30T00:00:00Z"
+killSwitchDate = Just "2021-10-14T00:00:00Z"
 
 mainInfo :: ProgramInfo ChainwebNodeConfiguration
 mainInfo = programInfoValidate


### PR DESCRIPTION
Bumps the killswitch date by 8 weeks, i.e. Thursday, 2021-10-14.

TODO:

* [x] decide on final killswitch date for version 2.9