### PR TITLE
Release candidate/2.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # `chainweb-node` Changelog
 
+## 2.9 (2021-08-12)
+
+This version replaces all previous versions. Any prior version will stop working
+on **2021-08-19T00:00:00Z**. Node administrators must upgrade to this version
+before that date.
+
+This version will stop working on **2021-09-30T00:00:00Z**.
+
+Changes:
+
+This is a maintenance release without breaking changes.
+
+*   Use `0.0.0.0` as default P2P host address, which enables auto-detection of
+    the IP address of the node. (#1245)
+*   Build and link Pact without CLI tools support. (#1246)
+*   Limit batch size of payload REST API requests 1000 items. (#1258)
+*   Removed several external dependencies from the code base.
+
 ## 2.8 (2021-06-05)
 
 This version replaces all previous versions. Any prior version will stop working

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ This version replaces all previous versions. Any prior version will stop working
 on **2021-08-19T00:00:00Z**. Node administrators must upgrade to this version
 before that date.
 
-This version will stop working on **2021-09-30T00:00:00Z**.
+This version will stop working on **2021-10-14T00:00:00Z**.
 
 Changes:
 

--- a/chainweb.cabal
+++ b/chainweb.cabal
@@ -1,7 +1,7 @@
 cabal-version: 2.4
 
 name:         chainweb
-version:      2.8
+version:      2.9
 synopsis:     A Proof-of-Work Parallel-Chain Architecture for Massive Throughput
 description:  A Proof-of-Work Parallel-Chain Architecture for Massive Throughput.
 homepage:     https://github.com/kadena-io/chainweb
@@ -15,7 +15,8 @@ category:     Blockchain, Currency, Bitcoin
 build-type:   Custom
 
 tested-with:
-    GHC == 8.10.4
+    GHC == 9.0.1
+    GHC == 8.10.5
     GHC == 8.8.4
     GHC == 8.6.5
 

--- a/node/ChainwebNode.hs
+++ b/node/ChainwebNode.hs
@@ -456,10 +456,10 @@ pkgInfoScopes =
 -- -------------------------------------------------------------------------- --
 -- main
 
--- KILLSWITCH for version 2.8
+-- KILLSWITCH for version 2.9
 --
 killSwitchDate :: Maybe String
-killSwitchDate = Just "2021-08-19T00:00:00Z"
+killSwitchDate = Just "2021-09-30T00:00:00Z"
 
 mainInfo :: ProgramInfo ChainwebNodeConfiguration
 mainInfo = programInfoValidate

--- a/node/ChainwebNode.hs
+++ b/node/ChainwebNode.hs
@@ -459,7 +459,7 @@ pkgInfoScopes =
 -- KILLSWITCH for version 2.9
 --
 killSwitchDate :: Maybe String
-killSwitchDate = Just "2021-09-30T00:00:00Z"
+killSwitchDate = Just "2021-10-14T00:00:00Z"
 
 mainInfo :: ProgramInfo ChainwebNodeConfiguration
 mainInfo = programInfoValidate


### PR DESCRIPTION
# Release Info

version: 2.9
Revision: 1cf40e7db83861dec83f0fecbe312b2f90cafd82

*Docker:*

*   end-user ubuntu image: 
    *  `docker pull kadena/chainweb-node:2.9`
    *   documentation: https://hub.docker.com/r/kadena/chainweb-node

*  binary-only images: 
    *   ubuntu: `docker pull ghcr.io/kadena-io/chainweb-node/ubuntu:2.9`
    *   alpine: `docker pull ghcr.io/kadena-io/chainweb-node/alpine:2.9`
    *   documentation: https://github.com/orgs/kadena-io/packages/

*Ubuntu binaries:*

*   ubuntu-18.04 ghc-8.10.5: https://kadena-cabal-cache.s3.amazonaws.com/chainweb-node/chainweb.8.10.5.ubuntu-18.04.1cf40e7.tar.gz
*   ubuntu-20.04 ghc-8.10.5: https://kadena-cabal-cache.s3.amazonaws.com/chainweb-node/chainweb.8.10.5.ubuntu-20.04.1cf40e7.tar.gz
*   macOS ghc-9.0.1: https://kadena-cabal-cache.s3.amazonaws.com/chainweb-node/chainweb.9.0.1.macOS-latest.1cf40e7.tar.gz

Github Actions build: https://github.com/kadena-io/chainweb-node/actions/runs/1121772836

*Nix pins:*

* linux: /nix/store/chsi88dh9nprqhzqr355h88i9hdsacij-chainweb-2.9
* mac: /nix/store/mb1ik17jgrvmxifwbwx0bsky7ricqkn5-chainweb-2.9

# PRs

* [x] #1260
* [x] #1257
* [x] #1264

Dropped:

* [ ] #1255
* [ ] Delete old cuts during database pruning (or in the background). Reduces db sizes by 30%.
* [ ] #1265

# Testing

- [x] full CI build passed with all checks
    - [x] release candidate
    - [x] final build
- [x] Mainnet pact replay complete
    - [x] ghcr.io/kadena-io/chainweb-node
    - [x] ghcr.io/kadena-io/chainweb-node-alpine
- [x] Mainnet header validation complete
    - [x] ghcr.io/kadena-io/chainweb-node
    - [x] ghcr.io/kadena-io/chainweb-node-alpine
- [x] test block explorer
    - [x] testnet
    - [x] main-net
- [ ] run regression test suite on devnet
- [ ] run regression test suite on testnet

# Deployment

### Testnet

- [x] Rolled out release candidate to all Testnet nodes
    - [x] deploy to half of the testnet nodes
- [x] Rolled out final release to all Testnet nodes

### Mainnet

- [x] Roll out to bootstrap nodes
    - [x] `*1.chainweb.com`
    - [x] `*2.chainweb.com`
    - [x] `*3.chainweb.com` 
- [x] deployed release candidate to Kubernetes clusters
    - [x] api.chainweb.com
    - [x] us-east1.api.chainweb.com
- [x] Tested with block explorer
    - [x] mainnet
    - [x] testnet
- [x] tested APIs
    - [x] api.chainweb.com
    - [x] api.testnet.chainweb.com 
- [ ] Upgraded all other nodes 
    - [x] db synchronization
    - [x] data.chainweb.com
    - [ ] etc

# Relase

* [x] collect finally builds
* [x] validate final builds
    * [x] pact history replay
        * [x] alpine docker image
        * [x] 8.10.5 ubuntu-20.4
    * [x] merkle tree validation 
        * [x] alpine docker image
        * [x] 8.10.5 ubuntu-20.4
* [x] publish and tag docker images
    * [x] kadena/chainweb-node 
    * [x] ghcr.io/kadena-io/chainweb-node/ubuntu 
    * [x] ghcr.io/kadena-io/chainweb-node/alpine
* [x] Double check freeze files of all builds
* [x] double check database snapshot (possibly update links in docker image and documentation)
* [x] Prepare Release
    * [x] create binary packages
    * [x] create git tag
    * [x] draft release
    * [x] publish release
* [ ] Make Announcements
* [ ] final builds are deployed everywhere

# Dependency Updates:

See comments below