### PR TITLE
Hide PactQueue behind PactQueueAccess datatype

### DIFF
--- a/bench/Chainweb/Pact/Backend/ForkingBench.hs
+++ b/bench/Chainweb/Pact/Backend/ForkingBench.hs
@@ -233,7 +233,7 @@ mineBlock
 mineBlock parent nonce pdb bhdb r = do
 
      -- assemble block without nonce and timestamp
-     mv <- newBlock noMiner parent (newBlockQueue r)
+     mv <- newBlock noMiner parent (_newBlockQueue r)
 
      payload <- assertNotLeft =<< takeMVar mv
 
@@ -252,7 +252,7 @@ mineBlock parent nonce pdb bhdb r = do
 
      T2 (SolvedWork newHeader) _ <- usePowHash testVer $ \(_ :: Proxy a) -> mine @a (_blockNonce bh) work
 
-     mv' <- validateBlock (newHeader { _blockCreationTime = creationTime}) (payloadWithOutputsToPayloadData payload) (validateBlockQueue r)
+     mv' <- validateBlock (newHeader { _blockCreationTime = creationTime}) (payloadWithOutputsToPayloadData payload) (_validateBlockQueue r)
 
      void $ assertNotLeft =<< takeMVar mv'
 
@@ -275,7 +275,7 @@ noMineBlock validate parent nonce r = do
 
      -- assemble block without nonce and timestamp
 
-     mv <- newBlock noMiner parent (newBlockQueue r)
+     mv <- newBlock noMiner parent (_newBlockQueue r)
 
      payload <- assertNotLeft =<< takeMVar mv
 
@@ -288,7 +288,7 @@ noMineBlock validate parent nonce r = do
               parent
 
      when validate $ do
-       mv' <- validateBlock bh (payloadWithOutputsToPayloadData payload) (validateBlockQueue r)
+       mv' <- validateBlock bh (payloadWithOutputsToPayloadData payload) (_validateBlockQueue r)
 
        void $ assertNotLeft =<< takeMVar mv'
 
@@ -357,9 +357,9 @@ withResources trunkLength logLevel f = C.envWithCleanup create destroy unwrap
            nbQueue <- newTBQueue pactQueueSize
            omQueue <- newTBQueue pactQueueSize
            return PactQueues {
-                validateBlockQueue = vbQueue
-              , newBlockQueue = nbQueue
-              , otherMsgsQueue = omQueue
+                _validateBlockQueue = vbQueue
+              , _newBlockQueue = nbQueue
+              , _otherMsgsQueue = omQueue
               }
         a <- async $ initPactService version cid l reqsQ mempool bhdb pdb sqlEnv defaultPactServiceConfig
         return (a, reqsQ)

--- a/src/Chainweb/Pact/Service/BlockValidation.hs
+++ b/src/Chainweb/Pact/Service/BlockValidation.hs
@@ -45,97 +45,97 @@ import Chainweb.Payload
 import Chainweb.Transaction
 
 
-newBlock :: Miner -> ParentHeader -> PactQueue ->
+newBlock :: Miner -> ParentHeader -> PactQueueAccess ->
             IO (MVar (Either PactException PayloadWithOutputs))
-newBlock mi bHeader reqQ = do
+newBlock mi bHeader pqa = do
     !resultVar <- newEmptyMVar :: IO (MVar (Either PactException PayloadWithOutputs))
     let !msg = NewBlockMsg NewBlockReq
           { _newBlockHeader = bHeader
           , _newMiner = mi
           , _newResultVar = resultVar }
-    addRequest reqQ msg
+    addRequest pqa msg
     return resultVar
 
 validateBlock
     :: BlockHeader
     -> PayloadData
-    -> PactQueue
+    -> PactQueueAccess
     -> IO (MVar (Either PactException PayloadWithOutputs))
-validateBlock bHeader plData reqQ = do
+validateBlock bHeader plData pqa = do
     !resultVar <- newEmptyMVar :: IO (MVar (Either PactException PayloadWithOutputs))
     let !msg = ValidateBlockMsg ValidateBlockReq
           { _valBlockHeader = bHeader
           , _valResultVar = resultVar
           , _valPayloadData = plData }
-    addRequest reqQ msg
+    addRequest pqa msg
     return resultVar
 
-local :: ChainwebTransaction -> PactQueue -> IO (MVar (Either PactException (CommandResult Hash)))
-local ct reqQ = do
+local :: ChainwebTransaction -> PactQueueAccess -> IO (MVar (Either PactException (CommandResult Hash)))
+local ct pq = do
     !resultVar <- newEmptyMVar
     let !msg = LocalMsg LocalReq
           { _localRequest = ct
           , _localResultVar = resultVar }
-    addRequest reqQ msg
+    addRequest pq msg
     return resultVar
 
 lookupPactTxs
     :: Rewind
     -> Vector PactHash
-    -> PactQueue
+    -> PactQueueAccess
     -> IO (MVar (Either PactException (Vector (Maybe (T2 BlockHeight BlockHash)))))
-lookupPactTxs restorePoint txs reqQ = do
+lookupPactTxs restorePoint txs pq = do
     resultVar <- newEmptyMVar
     let !req = LookupPactTxsReq restorePoint txs resultVar
     let !msg = LookupPactTxsMsg req
-    addRequest reqQ msg
+    addRequest pq msg
     return resultVar
 
 pactPreInsertCheck
     :: Vector ChainwebTransaction
-    -> PactQueue
+    -> PactQueueAccess
     -> IO (MVar (Either PactException (Vector (Either InsertError ()))))
-pactPreInsertCheck txs reqQ = do
+pactPreInsertCheck txs pq = do
     resultVar <- newEmptyMVar
     let !req = PreInsertCheckReq txs resultVar
     let !msg = PreInsertCheckMsg req
-    addRequest reqQ msg
+    addRequest pq msg
     return resultVar
 
 pactBlockTxHistory
   :: BlockHeader
   -> Domain'
-  -> PactQueue
+  -> PactQueueAccess
   -> IO (MVar (Either PactException BlockTxHistory))
-pactBlockTxHistory bh d reqQ = do
+pactBlockTxHistory bh d pqa = do
   resultVar <- newEmptyMVar
   let !req = BlockTxHistoryReq bh d resultVar
   let !msg = BlockTxHistoryMsg req
-  addRequest reqQ msg
+  addRequest pqa msg
   return resultVar
 
 pactHistoricalLookup
     :: BlockHeader
     -> Domain'
     -> RowKey
-    -> PactQueue
+    -> PactQueueAccess
     -> IO (MVar (Either PactException (Maybe (TxLog Value))))
-pactHistoricalLookup bh d k reqQ = do
+pactHistoricalLookup bh d k pqa = do
   resultVar <- newEmptyMVar
   let !req = HistoricalLookupReq bh d k resultVar
   let !msg = HistoricalLookupMsg req
-  addRequest reqQ msg
+  addRequest pqa msg
   return resultVar
 
 pactSyncToBlock
     :: BlockHeader
-    -> PactQueue
+    -> PactQueueAccess
     -> IO (MVar (Either PactException ()))
-pactSyncToBlock bh reqQ = do
+pactSyncToBlock bh pqa = do
     !resultVar <- newEmptyMVar
     let !msg = SyncToBlockMsg SyncToBlockReq
           { _syncToBlockHeader = bh
           , _syncToResultVar = resultVar
           }
-    addRequest reqQ msg
+    addRequest pqa msg
     return resultVar

--- a/src/Chainweb/Pact/Service/PactInProcApi.hs
+++ b/src/Chainweb/Pact/Service/PactInProcApi.hs
@@ -95,9 +95,9 @@ withPactService' ver cid logger memPoolAccess bhDb pdb sqlenv config action = do
        nbQueue <- newTBQueue (_pactQueueSize config)
        omQueue <- newTBQueue (_pactQueueSize config)
        return PactQueues {
-            validateBlockQueue = vbQueue
-          , newBlockQueue = nbQueue
-          , otherMsgsQueue = omQueue
+            _validateBlockQueue = vbQueue
+          , _newBlockQueue = nbQueue
+          , _otherMsgsQueue = omQueue
           }
     race (server reqQs) (client reqQs) >>= \case
         Left () -> error "pact service terminated unexpectedly"

--- a/src/Chainweb/Pact/Service/PactQueue.hs
+++ b/src/Chainweb/Pact/Service/PactQueue.hs
@@ -8,55 +8,20 @@
 -- Pact execution service queue for Chainweb
 
 module Chainweb.Pact.Service.PactQueue
-    ( addRequest
-    , getNextRequest
-    , PactQueue
-    , PactQueues(..)
-    , validateBlockQueue
-    , newBlockQueue
-    , otherMsgsQueue
+    (
+      PactQueue
+    , PactQueueAccess(..)
     ) where
 
-import Control.Applicative ((<|>))
-import Control.Lens (lens, Lens)
 import Control.Concurrent.STM.TBQueue
-import Control.Monad.STM
 
 import Chainweb.Pact.Service.Types
 
 -- | The type of the Pact Queue
 type PactQueue = TBQueue RequestMsg
 
-
--- ACHTUNG: Make sure that only execValidateBlock msgs are found in the "validateBlockQueue" Queue
--- ACHTUNG: Make sure that only execNewBlock msgs are found in the "newBlockQueue" Queue
--- ACHTUNG: Make sure that neither execValidateBlock & execNewBlock msgs are found in the "otherMsgsQueue" Queue
-data PactQueues = PactQueues {
-     _validateBlockQueue :: PactQueue
-   , _newBlockQueue :: PactQueue
-   , _otherMsgsQueue :: PactQueue
- }
-
-
-validateBlockQueue :: Lens PactQueues PactQueues PactQueue PactQueue
-validateBlockQueue = lens _validateBlockQueue (\s b -> s { _validateBlockQueue = b})
-
-newBlockQueue :: Lens PactQueues PactQueues PactQueue PactQueue
-newBlockQueue = lens _newBlockQueue (\s b -> s { _newBlockQueue = b})
-
-otherMsgsQueue :: Lens PactQueues PactQueues PactQueue PactQueue
-otherMsgsQueue = lens _otherMsgsQueue (\s b -> s { _otherMsgsQueue = b})
-
--- | Add a request to the Pact execution queue
-addRequest :: PactQueue -> RequestMsg -> IO ()
-addRequest q msg = atomically $ writeTBQueue q msg
-
--- | Get the next available request from the Pact execution queue
-getNextRequest :: PactQueues -> IO RequestMsg
-getNextRequest qs = atomically $ do
-    vb <- tryReadTBQueue $ _validateBlockQueue qs
-    nb <- tryReadTBQueue $ _newBlockQueue qs
-    om <- tryReadTBQueue $ _otherMsgsQueue qs
-    case vb <|> nb <|> om of
-      Nothing -> retry
-      Just msg -> return msg
+data PactQueueAccess = PactQueueAccess
+  {
+    addRequest :: RequestMsg -> IO ()
+  , getNextRequest :: IO RequestMsg
+  }

--- a/src/Chainweb/Pact/Service/PactQueue.hs
+++ b/src/Chainweb/Pact/Service/PactQueue.hs
@@ -11,6 +11,7 @@ module Chainweb.Pact.Service.PactQueue
     ( addRequest
     , getNextRequest
     , PactQueue
+    , PactQueues(..)
     ) where
 
 import Control.Concurrent.STM.TBQueue
@@ -20,6 +21,16 @@ import Chainweb.Pact.Service.Types
 
 -- | The type of the Pact Queue
 type PactQueue = TBQueue RequestMsg
+
+
+-- ACHTUNG: Make sure that only execValidateBlock msgs are found in the "validateBlockQueue" Queue
+-- ACHTUNG: Make sure that only execNewBlock msgs are found in the "newBlockQueue" Queue
+-- ACHTUNG: Make sure that neither execValidateBlock & execNewBlock msgs are found in the "otherMsgsQueue" Queue
+data PactQueues = PactQueues {
+     validateBlockQueue :: PactQueue
+   , newBlockQueue :: PactQueue
+   , otherMsgsQueue :: PactQueue
+ }
 
 -- | Add a request to the Pact execution queue
 addRequest :: PactQueue -> RequestMsg -> IO ()

--- a/src/Chainweb/Pact/Service/PactQueue.hs
+++ b/src/Chainweb/Pact/Service/PactQueue.hs
@@ -9,11 +9,15 @@
 
 module Chainweb.Pact.Service.PactQueue
     (
-      PactQueue
+      newPactQueueAccess
+    , PactQueue
     , PactQueueAccess(..)
     ) where
 
+import Control.Applicative
+import Control.Monad.STM
 import Control.Concurrent.STM.TBQueue
+import Numeric.Natural
 
 import Chainweb.Pact.Service.Types
 
@@ -25,3 +29,23 @@ data PactQueueAccess = PactQueueAccess
     addRequest :: RequestMsg -> IO ()
   , getNextRequest :: IO RequestMsg
   }
+
+newPactQueueAccess :: Natural -> STM PactQueueAccess
+newPactQueueAccess sz = do
+  vQueue <- newTBQueue sz
+  nQueue <- newTBQueue sz
+  oQueue <- newTBQueue sz
+  return PactQueueAccess
+    {
+      addRequest = \reqMsg -> atomically $ case reqMsg of
+        ValidateBlockMsg {} -> writeTBQueue vQueue reqMsg
+        NewBlockMsg {} -> writeTBQueue nQueue reqMsg
+        _ -> writeTBQueue oQueue reqMsg
+    , getNextRequest = atomically $ do
+        v <- tryReadTBQueue vQueue
+        n <- tryReadTBQueue nQueue
+        o <- tryReadTBQueue oQueue
+        case v <|> n <|> o of
+          Nothing -> retry
+          Just msg -> return msg
+    }

--- a/src/Chainweb/Pact/Service/PactQueue.hs
+++ b/src/Chainweb/Pact/Service/PactQueue.hs
@@ -12,9 +12,13 @@ module Chainweb.Pact.Service.PactQueue
     , getNextRequest
     , PactQueue
     , PactQueues(..)
+    , validateBlockQueue
+    , newBlockQueue
+    , otherMsgsQueue
     ) where
 
 import Control.Applicative ((<|>))
+import Control.Lens (lens, Lens)
 import Control.Concurrent.STM.TBQueue
 import Control.Monad.STM
 
@@ -28,10 +32,20 @@ type PactQueue = TBQueue RequestMsg
 -- ACHTUNG: Make sure that only execNewBlock msgs are found in the "newBlockQueue" Queue
 -- ACHTUNG: Make sure that neither execValidateBlock & execNewBlock msgs are found in the "otherMsgsQueue" Queue
 data PactQueues = PactQueues {
-     validateBlockQueue :: PactQueue
-   , newBlockQueue :: PactQueue
-   , otherMsgsQueue :: PactQueue
+     _validateBlockQueue :: PactQueue
+   , _newBlockQueue :: PactQueue
+   , _otherMsgsQueue :: PactQueue
  }
+
+
+validateBlockQueue :: Lens PactQueues PactQueues PactQueue PactQueue
+validateBlockQueue = lens _validateBlockQueue (\s b -> s { _validateBlockQueue = b})
+
+newBlockQueue :: Lens PactQueues PactQueues PactQueue PactQueue
+newBlockQueue = lens _newBlockQueue (\s b -> s { _newBlockQueue = b})
+
+otherMsgsQueue :: Lens PactQueues PactQueues PactQueue PactQueue
+otherMsgsQueue = lens _otherMsgsQueue (\s b -> s { _otherMsgsQueue = b})
 
 -- | Add a request to the Pact execution queue
 addRequest :: PactQueue -> RequestMsg -> IO ()
@@ -40,9 +54,9 @@ addRequest q msg = atomically $ writeTBQueue q msg
 -- | Get the next available request from the Pact execution queue
 getNextRequest :: PactQueues -> IO RequestMsg
 getNextRequest qs = atomically $ do
-    vb <- tryReadTBQueue $ validateBlockQueue qs
-    nb <- tryReadTBQueue $ newBlockQueue qs
-    om <- tryReadTBQueue $ otherMsgsQueue qs
+    vb <- tryReadTBQueue $ _validateBlockQueue qs
+    nb <- tryReadTBQueue $ _newBlockQueue qs
+    om <- tryReadTBQueue $ _otherMsgsQueue qs
     case vb <|> nb <|> om of
       Nothing -> retry
       Just msg -> return msg

--- a/src/Chainweb/WebPactExecutionService.hs
+++ b/src/Chainweb/WebPactExecutionService.hs
@@ -148,26 +148,26 @@ mkPactExecutionService
     -> PactExecutionService
 mkPactExecutionService qs = PactExecutionService
     { _pactValidateBlock = \h pd -> do
-        mv <- validateBlock h pd (validateBlockQueue qs)
+        mv <- validateBlock h pd (_validateBlockQueue qs)
         r <- takeMVar mv
         case r of
           Right (!pdo) -> return pdo
           Left e -> throwM e
     , _pactNewBlock = \m h -> do
-        mv <- newBlock m h (newBlockQueue qs)
+        mv <- newBlock m h (_newBlockQueue qs)
         r <- takeMVar mv
         either throwM evaluate r
     , _pactLocal = \ct ->
-        local ct (otherMsgsQueue qs) >>= takeMVar
+        local ct (_otherMsgsQueue qs) >>= takeMVar
     , _pactLookup = \h txs ->
-        lookupPactTxs h txs (otherMsgsQueue qs) >>= takeMVar
+        lookupPactTxs h txs (_otherMsgsQueue qs) >>= takeMVar
     , _pactPreInsertCheck = \_ txs ->
-        pactPreInsertCheck txs (otherMsgsQueue qs) >>= takeMVar
+        pactPreInsertCheck txs (_otherMsgsQueue qs) >>= takeMVar
     , _pactBlockTxHistory = \h d ->
-        pactBlockTxHistory h d (otherMsgsQueue qs) >>= takeMVar
+        pactBlockTxHistory h d (_otherMsgsQueue qs) >>= takeMVar
     , _pactHistoricalLookup = \h d k ->
-        pactHistoricalLookup h d k (otherMsgsQueue qs) >>= takeMVar
-    , _pactSyncToBlock = \h -> pactSyncToBlock h (otherMsgsQueue qs) >>= takeMVar >>= \case
+        pactHistoricalLookup h d k (_otherMsgsQueue qs) >>= takeMVar
+    , _pactSyncToBlock = \h -> pactSyncToBlock h (_otherMsgsQueue qs) >>= takeMVar >>= \case
         Right () -> return ()
         Left e -> throwM e
     }

--- a/test/Chainweb/Test/Pact/PactReplay.hs
+++ b/test/Chainweb/Test/Pact/PactReplay.hs
@@ -189,7 +189,7 @@ serviceInitializationAfterFork mpio genesisBlock iop = do
     restartPact :: IO ()
     restartPact = do
         q <- fst <$> iop
-        addRequest (otherMsgsQueue q) CloseMsg
+        addRequest (_otherMsgsQueue q) CloseMsg
 
     pruneDbs = forM_ cids $ \c -> do
         dbs <- snd <$> iop
@@ -312,7 +312,7 @@ mineBlock ph nonce iop = timeout 5000000 go >>= \case
 
       -- assemble block without nonce and timestamp
       let r = fst <$> iop
-      mv <- r >>= newBlock noMiner ph . newBlockQueue
+      mv <- r >>= newBlock noMiner ph . _newBlockQueue
       payload <- assertNotLeft =<< takeMVar mv
 
       let bh = newBlockHeader
@@ -322,7 +322,7 @@ mineBlock ph nonce iop = timeout 5000000 go >>= \case
                creationTime
                ph
 
-      mv' <- r >>= validateBlock bh (payloadWithOutputsToPayloadData payload) . validateBlockQueue
+      mv' <- r >>= validateBlock bh (payloadWithOutputsToPayloadData payload) . _validateBlockQueue
       void $ assertNotLeft =<< takeMVar mv'
 
       bdb <- snd <$> iop

--- a/test/Chainweb/Test/Pact/PactReplay.hs
+++ b/test/Chainweb/Test/Pact/PactReplay.hs
@@ -91,7 +91,7 @@ tests rdb =
 
 onRestart
     :: IO (IORef MemPoolAccess)
-    -> IO (PactQueue,TestBlockDb)
+    -> IO (PactQueues,TestBlockDb)
     -> (String -> IO ())
     -> Assertion
 onRestart mpio iop step = do
@@ -160,7 +160,7 @@ dupegenMemPoolAccess = mempty
 serviceInitializationAfterFork
     :: IO (IORef MemPoolAccess)
     -> BlockHeader
-    -> IO (PactQueue,TestBlockDb)
+    -> IO (PactQueues,TestBlockDb)
     -> Assertion
 serviceInitializationAfterFork mpio genesisBlock iop = do
     setMempool mpio testMemPoolAccess
@@ -189,7 +189,7 @@ serviceInitializationAfterFork mpio genesisBlock iop = do
     restartPact :: IO ()
     restartPact = do
         q <- fst <$> iop
-        addRequest q CloseMsg
+        addRequest (otherMsgsQueue q) CloseMsg
 
     pruneDbs = forM_ cids $ \c -> do
         dbs <- snd <$> iop
@@ -202,7 +202,7 @@ serviceInitializationAfterFork mpio genesisBlock iop = do
 firstPlayThrough
     :: IO (IORef MemPoolAccess)
     -> BlockHeader
-    -> IO (PactQueue,TestBlockDb)
+    -> IO (PactQueues,TestBlockDb)
     -> Assertion
 firstPlayThrough mpio genesisBlock iop = do
     setMempool mpio testMemPoolAccess
@@ -228,7 +228,7 @@ firstPlayThrough mpio genesisBlock iop = do
 testDupes
   :: IO (IORef MemPoolAccess)
   -> BlockHeader
-  -> IO (PactQueue,TestBlockDb)
+  -> IO (PactQueues,TestBlockDb)
   -> Assertion
 testDupes mpio genesisBlock iop = do
     setMempool mpio dupegenMemPoolAccess
@@ -259,7 +259,7 @@ testDupes mpio genesisBlock iop = do
 testDeepForkLimit
   :: IO (IORef MemPoolAccess)
   -> Word64
-  -> IO (PactQueue,TestBlockDb)
+  -> IO (PactQueues,TestBlockDb)
   -> (String -> IO ())
   -> Assertion
 testDeepForkLimit mpio deepForkLimit iop step = do
@@ -302,7 +302,7 @@ testDeepForkLimit mpio deepForkLimit iop step = do
 mineBlock
     :: ParentHeader
     -> Nonce
-    -> IO (PactQueue,TestBlockDb)
+    -> IO (PactQueues,TestBlockDb)
     -> IO (T3 ParentHeader BlockHeader PayloadWithOutputs)
 mineBlock ph nonce iop = timeout 5000000 go >>= \case
     Nothing -> error "PactReplay.mineBlock: Test timeout. Most likely a test case caused a pact service failure that wasn't caught, and the test was blocked while waiting for the result"
@@ -312,7 +312,7 @@ mineBlock ph nonce iop = timeout 5000000 go >>= \case
 
       -- assemble block without nonce and timestamp
       let r = fst <$> iop
-      mv <- r >>= newBlock noMiner ph
+      mv <- r >>= newBlock noMiner ph . newBlockQueue
       payload <- assertNotLeft =<< takeMVar mv
 
       let bh = newBlockHeader
@@ -322,7 +322,7 @@ mineBlock ph nonce iop = timeout 5000000 go >>= \case
                creationTime
                ph
 
-      mv' <- r >>= validateBlock bh (payloadWithOutputsToPayloadData payload)
+      mv' <- r >>= validateBlock bh (payloadWithOutputsToPayloadData payload) . validateBlockQueue
       void $ assertNotLeft =<< takeMVar mv'
 
       bdb <- snd <$> iop

--- a/test/Chainweb/Test/Pact/TTL.hs
+++ b/test/Chainweb/Test/Pact/TTL.hs
@@ -221,7 +221,7 @@ doNewBlock ctxIO mempool parent nonce t = do
      ctx <- ctxIO
      unlessM (tryPutMVar (_ctxMempool ctx) mempool) $
         error "Test failure: mempool access is not empty. Some previous test step failed unexpectedly"
-     mv <- newBlock noMiner parent $ _ctxQueue ctx
+     mv <- newBlock noMiner parent $ newBlockQueue $ _ctxQueues ctx
      payload <- assertNotLeft =<< takeMVar mv
 
      let bh = newBlockHeader
@@ -247,7 +247,7 @@ doValidateBlock
     -> IO ()
 doValidateBlock ctxIO header payload = do
     ctx <- ctxIO
-    _mv' <- validateBlock header (payloadWithOutputsToPayloadData payload) $ _ctxQueue ctx
+    _mv' <- validateBlock header (payloadWithOutputsToPayloadData payload) $ validateBlockQueue $ _ctxQueues ctx
     addNewPayload (_ctxPdb ctx) payload
     unsafeInsertBlockHeaderDb (_ctxBdb ctx) header
     -- FIXME FIXME FIXME: do at least some checks?
@@ -271,7 +271,7 @@ assertDoPreBlockFailure action = try @_ @PactException action >>= \case
 
 data Ctx = Ctx
     { _ctxMempool :: !(MVar MemPoolAccess)
-    , _ctxQueue :: !PactQueue
+    , _ctxQueues :: !PactQueues
     , _ctxPdb :: !(PayloadDb RocksDbCas)
     , _ctxBdb :: !BlockHeaderDb
     }
@@ -284,10 +284,10 @@ withTestPact rdb test =
   withResource newEmptyMVar (const $ return ()) $ \mempoolVarIO ->
     withPactTestBlockDb testVer cid Quiet rdb (mempool mempoolVarIO) defaultPactServiceConfig $ \ios ->
       test $ do
-        (pq,bdb) <- ios
+        (pqs,bdb) <- ios
         mp <- mempoolVarIO
         bhdb <- getBlockHeaderDb cid bdb
-        return $ Ctx mp pq (_bdbPayloadDb bdb) bhdb
+        return $ Ctx mp pqs (_bdbPayloadDb bdb) bhdb
   where
     cid = someChainId testVer
     mempool mempoolVarIO = return $ mempty

--- a/test/Chainweb/Test/Pact/TTL.hs
+++ b/test/Chainweb/Test/Pact/TTL.hs
@@ -221,7 +221,7 @@ doNewBlock ctxIO mempool parent nonce t = do
      ctx <- ctxIO
      unlessM (tryPutMVar (_ctxMempool ctx) mempool) $
         error "Test failure: mempool access is not empty. Some previous test step failed unexpectedly"
-     mv <- newBlock noMiner parent $ newBlockQueue $ _ctxQueues ctx
+     mv <- newBlock noMiner parent $ _newBlockQueue $ _ctxQueues ctx
      payload <- assertNotLeft =<< takeMVar mv
 
      let bh = newBlockHeader
@@ -247,7 +247,7 @@ doValidateBlock
     -> IO ()
 doValidateBlock ctxIO header payload = do
     ctx <- ctxIO
-    _mv' <- validateBlock header (payloadWithOutputsToPayloadData payload) $ validateBlockQueue $ _ctxQueues ctx
+    _mv' <- validateBlock header (payloadWithOutputsToPayloadData payload) $ _validateBlockQueue $ _ctxQueues ctx
     addNewPayload (_ctxPdb ctx) payload
     unsafeInsertBlockHeaderDb (_ctxBdb ctx) header
     -- FIXME FIXME FIXME: do at least some checks?

--- a/test/Chainweb/Test/Pact/TTL.hs
+++ b/test/Chainweb/Test/Pact/TTL.hs
@@ -221,7 +221,7 @@ doNewBlock ctxIO mempool parent nonce t = do
      ctx <- ctxIO
      unlessM (tryPutMVar (_ctxMempool ctx) mempool) $
         error "Test failure: mempool access is not empty. Some previous test step failed unexpectedly"
-     mv <- newBlock noMiner parent $ _newBlockQueue $ _ctxQueues ctx
+     mv <- newBlock noMiner parent $ _ctxQueueAccess ctx
      payload <- assertNotLeft =<< takeMVar mv
 
      let bh = newBlockHeader
@@ -247,7 +247,7 @@ doValidateBlock
     -> IO ()
 doValidateBlock ctxIO header payload = do
     ctx <- ctxIO
-    _mv' <- validateBlock header (payloadWithOutputsToPayloadData payload) $ _validateBlockQueue $ _ctxQueues ctx
+    _mv' <- validateBlock header (payloadWithOutputsToPayloadData payload) $ _ctxQueueAccess ctx
     addNewPayload (_ctxPdb ctx) payload
     unsafeInsertBlockHeaderDb (_ctxBdb ctx) header
     -- FIXME FIXME FIXME: do at least some checks?
@@ -271,7 +271,7 @@ assertDoPreBlockFailure action = try @_ @PactException action >>= \case
 
 data Ctx = Ctx
     { _ctxMempool :: !(MVar MemPoolAccess)
-    , _ctxQueues :: !PactQueues
+    , _ctxQueueAccess :: !PactQueueAccess
     , _ctxPdb :: !(PayloadDb RocksDbCas)
     , _ctxBdb :: !BlockHeaderDb
     }

--- a/test/Chainweb/Test/Pact/Utils.hs
+++ b/test/Chainweb/Test/Pact/Utils.hs
@@ -660,9 +660,9 @@ withPactTestBlockDb version cid logLevel rdb mempoolIO pactConfig f =
             nbQueue <- newTBQueue 2000
             omQueue <- newTBQueue 2000
             return PactQueues {
-                  validateBlockQueue = vbQueue
-                , newBlockQueue = nbQueue
-                , otherMsgsQueue = omQueue
+                  _validateBlockQueue = vbQueue
+                , _newBlockQueue = nbQueue
+                , _otherMsgsQueue = omQueue
                 }
         dir <- iodir
         bdb <- bdbio


### PR DESCRIPTION
This PR includes work that considers prioritizing certain messages placed in the PactService queue. More specifically, instead of replacing the current single queue with a priority queue, we use multiple queues: one for validateBlock messages, another for newBlock messages, and a final queue for the rest of the message types. 