### PR TITLE
PactQueue redesign

### DIFF
--- a/bench/Chainweb/Pact/Backend/ForkingBench.hs
+++ b/bench/Chainweb/Pact/Backend/ForkingBench.hs
@@ -17,7 +17,6 @@ module Chainweb.Pact.Backend.ForkingBench ( bench ) where
 
 import Control.Concurrent.Async
 import Control.Concurrent.MVar
-import Control.Concurrent.STM.TBQueue
 import Control.Lens hiding (elements, from, to, (.=))
 import Control.Monad
 import Control.Monad.Catch
@@ -352,7 +351,7 @@ withResources trunkLength logLevel f = C.envWithCleanup create destroy unwrap
     logger = genericLogger logLevel T.putStrLn
 
     startPact version l bhdb pdb mempool sqlEnv = do
-        reqQ <- atomically $ newTBQueue pactQueueSize
+        reqQ <- atomically $ newPactQueue pactQueueSize
         a <- async $ initPactService version cid l reqQ mempool bhdb pdb sqlEnv defaultPactServiceConfig
         return (a, reqQ)
 

--- a/src/Chainweb/Pact/Service/PactInProcApi.hs
+++ b/src/Chainweb/Pact/Service/PactInProcApi.hs
@@ -23,7 +23,6 @@ module Chainweb.Pact.Service.PactInProcApi
     ) where
 
 import Control.Concurrent.Async
-import Control.Concurrent.STM.TBQueue
 import Control.Monad.STM
 
 import qualified Data.ByteString.Short as SB
@@ -90,7 +89,7 @@ withPactService'
     -> (PactQueue -> IO a)
     -> IO a
 withPactService' ver cid logger memPoolAccess bhDb pdb sqlenv config action = do
-    reqQ <- atomically $ newTBQueue (_pactQueueSize config)
+    reqQ <- atomically $ newPactQueue (_pactQueueSize config)
     race (server reqQ) (client reqQ) >>= \case
         Left () -> error "pact service terminated unexpectedly"
         Right a -> return a

--- a/src/Chainweb/Pact/Service/PactQueue.hs
+++ b/src/Chainweb/Pact/Service/PactQueue.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE RecordWildCards #-}
 -- |
 -- Module: Chainweb.Pact.Service.PactQueue
 -- Copyright: Copyright © 2018 Kadena LLC.
@@ -10,21 +11,47 @@
 module Chainweb.Pact.Service.PactQueue
     ( addRequest
     , getNextRequest
+    , newPactQueue
     , PactQueue
     ) where
 
+import Control.Applicative
 import Control.Concurrent.STM.TBQueue
 import Control.Monad.STM
+import Numeric.Natural
 
 import Chainweb.Pact.Service.Types
 
 -- | The type of the Pact Queue
-type PactQueue = TBQueue RequestMsg
+-- type PactQueue = TBQueue RequestMsg
+data PactQueue = PactQueue
+  {
+    _pactQueueValidateBlock :: !(TBQueue RequestMsg)
+  , _pactQueueNewBlock :: !(TBQueue RequestMsg)
+  , _pactQueueOtherMsg :: !(TBQueue RequestMsg)
+  }
+
+newPactQueue :: Natural -> STM PactQueue
+newPactQueue sz = do
+  _pactQueueValidateBlock <- newTBQueue sz
+  _pactQueueNewBlock <- newTBQueue sz
+  _pactQueueOtherMsg <- newTBQueue sz
+  return PactQueue {..}
 
 -- | Add a request to the Pact execution queue
 addRequest :: PactQueue -> RequestMsg -> IO ()
-addRequest q msg = atomically $ writeTBQueue q msg
+addRequest q msg = atomically $
+  case msg of
+    ValidateBlockMsg {} -> writeTBQueue (_pactQueueValidateBlock q) msg
+    NewBlockMsg {} -> writeTBQueue (_pactQueueNewBlock q) msg
+    _ -> writeTBQueue (_pactQueueOtherMsg q) msg
 
 -- | Get the next available request from the Pact execution queue
 getNextRequest :: PactQueue -> IO RequestMsg
-getNextRequest q = atomically $ readTBQueue q
+getNextRequest q = atomically $ do
+  v <- tryReadTBQueue (_pactQueueValidateBlock q)
+  b <- tryReadTBQueue (_pactQueueNewBlock q)
+  o <- tryReadTBQueue (_pactQueueOtherMsg q)
+  case v <|> o <|> b of
+    Nothing -> retry
+    Just msg -> return msg

--- a/test/Chainweb/Test/Pact/Utils.hs
+++ b/test/Chainweb/Test/Pact/Utils.hs
@@ -655,7 +655,7 @@ withPactTestBlockDb version cid logLevel rdb mempoolIO pactConfig f =
   withResource (startPact bdbio iodir) stopPact $ f . fmap (view _3)
   where
     startPact bdbio iodir = do
-        reqQ <- atomically $ newTBQueue 2000
+        reqQ <- atomically $ newPactQueue 2000
         dir <- iodir
         bdb <- bdbio
         mempool <- mempoolIO


### PR DESCRIPTION
This PR re-implements the PactQueue type as a simple "priority" queue. We've made changes so that the API is unscathed elsewhere in the codebase.