### PR TITLE
Enforce keyset formats

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -36,7 +36,7 @@ debug-info: True
 source-repository-package
     type: git
     location: https://github.com/kadena-io/pact.git
-    tag: 019440d45703b605adb7f5f306768ce3cd619290
+    tag: dfc2d208af13fe0469776cd375f48b322e23971b
 
 source-repository-package
     type: git

--- a/chainweb.cabal
+++ b/chainweb.cabal
@@ -378,7 +378,7 @@ library
         , mwc-probability >= 2.0 && <2.4
         , network >= 2.6 && < 3.1.1 || >= 3.1.2
         , optparse-applicative >= 0.14
-        , pact == 4.1.1
+        , pact == 4.1.2
         , pem >=0.2
         , rosetta >= 1.0
         , safe-exceptions >= 0.1

--- a/project.nix
+++ b/project.nix
@@ -49,8 +49,8 @@ proj = kpkgs.rp.project ({ pkgs, hackGet, ... }: with pkgs.haskell.lib;
       pact = dontCheck (appendConfigureFlag (self.callCabal2nix "pact" (pkgs.fetchFromGitHub {
         owner = "kadena-io";
         repo = "pact";
-        rev = "019440d45703b605adb7f5f306768ce3cd619290";
-        sha256 = "0qk8hfpgcwg6s6ny71hnk1w4pwlrcy4bbba2riwmiiha7bapj3n2";
+        rev = "dfc2d208af13fe0469776cd375f48b322e23971b";
+        sha256 = "1zm5s58i7xgwm1b0c9zz5rzb7pdk7hfnpk4ncacahky7s6sv4xfp";
       }) {}) "-f-build-tool");
 
       ethereum = dontCheck (self.callCabal2nix "ethereum" (pkgs.fetchFromGitHub {

--- a/src/Chainweb/Pact/PactService.hs
+++ b/src/Chainweb/Pact/PactService.hs
@@ -547,7 +547,8 @@ execLocal cmd = withDiscardedBatch $ do
     spv <- use psSpvSupport
     let execConfig = P.mkExecutionConfig $
             [ P.FlagAllowReadInLocal | _psAllowReadsInLocal ] ++
-            enablePactEvents' pd
+            enablePactEvents' pd ++
+            enforceKeysetFormats' pd
         logger = P.newLogger _psLoggers "execLocal"
     withCurrentCheckpointer "execLocal" $ \(PactDbEnv' pdbenv) -> do
         r <- liftIO $

--- a/src/Chainweb/Pact/TransactionExec.hs
+++ b/src/Chainweb/Pact/TransactionExec.hs
@@ -28,6 +28,7 @@ module Chainweb.Pact.TransactionExec
 , runPayload
 , readInitModules
 , enablePactEvents'
+, enforceKeysetFormats'
 , disablePact40Natives
 
   -- * Gas Execution
@@ -163,6 +164,7 @@ applyCmd v logger pdbenv miner gasModel txCtx spv cmdIn mcache0 =
           ++ [ FlagPreserveNsModuleInstallBug | not isModuleNameFix2 ]
           ++ enablePactEvents' txCtx
           ++ enablePact40 txCtx
+          ++ enforceKeysetFormats' txCtx
         )
 
     cenv = TransactionEnv Transactional pdbenv logger (ctxToPublicData txCtx) spv nid gasPrice
@@ -616,6 +618,11 @@ enablePactEvents' :: TxContext -> [ExecutionFlag]
 enablePactEvents' tc
     | enablePactEvents (ctxVersion tc) (ctxCurrentBlockHeight tc) = []
     | otherwise = [FlagDisablePactEvents]
+
+enforceKeysetFormats' :: TxContext -> [ExecutionFlag]
+enforceKeysetFormats' tc
+    | enforceKeysetFormats (ctxVersion tc) (ctxCurrentBlockHeight tc) = [FlagEnforceKeyFormats]
+    | otherwise = []
 
 
 enablePact40 :: TxContext -> [ExecutionFlag]

--- a/src/Chainweb/Version.hs
+++ b/src/Chainweb/Version.hs
@@ -57,6 +57,7 @@ module Chainweb.Version
 , enablePactEvents
 , enableSPVBridge
 , pact4coin3Upgrade
+, enforceKeysetFormats
 , AtOrAfter(..)
 
 -- ** BlockHeader Validation Guards
@@ -886,6 +887,12 @@ pact4coin3Upgrade aoa v h = case aoa of
     go f Development = f 80
     go f (FastTimedCPM g) | g == petersonChainGraph = f 20
     go _f _ = const False
+
+enforceKeysetFormats :: ChainwebVersion -> BlockHeight -> Bool
+enforceKeysetFormats Mainnet01 = (>= 2_162_000) -- 2021-11-18T20:06:55
+enforceKeysetFormats Testnet04 = (>= 1_701_000) -- 2021-11-18T17:54:36
+enforceKeysetFormats Development = (>= 100)
+enforceKeysetFormats _ = const True
 
 -- -------------------------------------------------------------------------- --
 -- Header Validation Guards


### PR DESCRIPTION
Enables pact flag to enforce valid keys in `read-keyset`. Before the switch any key value used in `read-keyset` will succeed; after, only valid Pact public key values will work.

Development block height is 100.