### PR TITLE
remove legacy CPP macros and raise lower bounds

### DIFF
--- a/chainweb.cabal
+++ b/chainweb.cabal
@@ -74,13 +74,6 @@ flag ghc-flags
     default: False
     manual: True
 
-flag random-1_2
-    description:
-        random package version >= 1.2 is available. This version is currently not
-        available for the nix builds.
-    default: True
-    manual: False
-
 common debugging-flags
     if flag(debug)
         ghc-options:
@@ -356,7 +349,7 @@ library
         , ethereum >= 0.1
         , exceptions >= 0.8
         , file-embed >= 0.0
-        , hashable >= 1.2 && < 1.3.1
+        , hashable >= 1.3 && < 1.3.1
         , heaps >= 0.3
         , hourglass >=0.2
         , http-client >= 0.5
@@ -365,7 +358,7 @@ library
         , http-types >= 0.12
         , iproute >= 1.7
         , ixset-typed >= 0.4
-        , lens >= 4.16
+        , lens >= 4.17
         , loglevel >= 0.1
         , memory >=0.14
         , merkle-log
@@ -374,17 +367,18 @@ library
         , mtl >= 2.2
         , mwc-random >= 0.13
         , mwc-probability >= 2.0 && <2.4
-        , network >= 2.6 && < 3.1.1 || >= 3.1.2
+        , network >= 3.1.2
         , optparse-applicative >= 0.14
         , pact == 4.1.2
         , pem >=0.2
+        , random >= 1.2
         , rosetta >= 1.0
         , safe-exceptions >= 0.1
         , scheduler >= 1.4
-        , servant >= 0.16.2
-        , servant-client >= 0.16.0.1
-        , servant-client-core >= 0.16
-        , servant-server >= 0.16.2
+        , servant >= 0.18.2
+        , servant-client >= 0.18.2
+        , servant-client-core >= 0.18.2
+        , servant-server >= 0.18.2
         , stm >= 2.4
         , stm-chans
         , stopwatch >= 0.1
@@ -408,7 +402,7 @@ library
         , wai-app-static >= 3.1.6.3
         , wai-cors >= 0.2.7
         , wai-extra >= 3.0.28
-        , vector >= 0.12
+        , vector >= 0.12.2
         , vector-algorithms >= 0.7
         , wai-middleware-throttle >= 0.3
         , warp >= 3.3.6
@@ -425,14 +419,6 @@ library
         build-tool-depends: hsinspect:hsinspect
         ghc-options: -fplugin GhcFlags.Plugin
         build-depends: ghcflags
-
-    if flag(random-1_2)
-        build-depends:
-            random >= 1.2
-    else
-        build-depends:
-              random >= 1.1
-            , random-bytestring >= 0.1
 
 -- -------------------------------------------------------------------------- --
 -- Chainweb Test suite
@@ -512,7 +498,7 @@ test-suite chainweb-tests
 
         -- external
         , Decimal >= 0.4.2
-        , QuickCheck >= 2.12.6
+        , QuickCheck >= 2.14
         , aeson >= 1.4.3
         , aeson-pretty
         , async >= 2.2
@@ -535,25 +521,26 @@ test-suite chainweb-tests
         , ethereum
         , exceptions
         , extra >= 1.6
-        , hashable >= 1.2 && < 1.3.1
+        , hashable >= 1.3 && < 1.3.1
         , http-client >= 0.5
         , http-types >= 0.12
-        , lens >= 4.16
+        , lens >= 4.17
         , lens-aeson >= 1.1
         , loglevel >= 0.1
         , merkle-log
         , mtl >= 2.2
-        , network >= 2.6 && < 3.1.1 || >= 3.1.2
+        , network >= 3.1.2
         , http-client-tls >=0.3
         , pact
         , quickcheck-instances >= 0.3
+        , random >= 1.2
         , resource-pool >= 0.2
         , retry >= 0.7
         , rosetta >= 1.0
         , scheduler >= 1.4
-        , servant >= 0.16
-        , servant-client >= 0.16
-        , servant-client-core >= 0.16
+        , servant >= 0.18.2
+        , servant-client >= 0.18.2
+        , servant-client-core >= 0.18.2
         , statistics >= 0.15
         , string-conv >= 0.1
         , stm
@@ -571,7 +558,7 @@ test-suite chainweb-tests
         , time >= 1.8
         , transformers >= 0.5
         , unordered-containers >= 0.2
-        , vector >= 0.12
+        , vector >= 0.12.2
         , wai >= 3.2
         , warp >= 3.3.5
         , warp-tls >= 3.2.9
@@ -580,14 +567,6 @@ test-suite chainweb-tests
 
     if flag(ed25519)
         cpp-options: -DWITH_ED25519=1
-
-    if flag(random-1_2)
-        build-depends:
-            random >= 1.2
-    else
-        build-depends:
-              random >= 1.1
-            , random-bytestring >= 0.1
 
 -- -------------------------------------------------------------------------- --
 -- Chainweb Node Application
@@ -625,7 +604,7 @@ executable chainweb-node
         , directory >= 1.3
         , http-client >= 0.5
         , http-client-tls >=0.3
-        , lens >= 4.16
+        , lens >= 4.17
         , loglevel >= 0.1
         , managed >= 1.0
         , streaming >= 0.2
@@ -674,7 +653,7 @@ executable cwtool
           chainweb
 
         -- external
-        , QuickCheck >= 2.12.6
+        , QuickCheck >= 2.14
         , aeson >= 1.4
         , aeson-pretty >= 0.8
         , lens-aeson >= 1.1
@@ -702,21 +681,21 @@ executable cwtool
         , http-client >= 0.5
         , http-client-tls >=0.3
         , http-types >= 0.12
-        , lens >= 4.16
+        , lens >= 4.17
         , loglevel >= 0.1
         , memory >=0.14
         , merkle-log
         , mtl >= 2.2
-        , network >= 2.6 && < 3.1.1 || >= 3.1.2
+        , network >= 3.1.2
         , optparse-applicative >= 0.14
         , pact
         , process >= 1.5
         , quickcheck-instances >= 0.3
-        , random >= 1.1
+        , random >= 1.2
         , rocksdb-haskell >= 1.0
         , safe-exceptions >= 0.1
-        , servant-client >= 0.16
-        , servant-client-core >= 0.16
+        , servant-client >= 0.18.2
+        , servant-client-core >= 0.18.2
         , streaming >= 0.2.2
         , streaming-commons >= 0.2
         , strict-tuple
@@ -729,7 +708,7 @@ executable cwtool
         , text >= 1.2
         , transformers >= 0.5
         , unordered-containers >= 0.2
-        , vector >= 0.12
+        , vector >= 0.12.2
         , wai >= 3.2
         , warp >= 3.3.5
         , warp-tls >= 3.2.9
@@ -774,36 +753,24 @@ benchmark bench
         , exceptions >= 0.8
         , extra >= 1.6
         , file-embed >= 0.0
-        , lens >= 4.16
+        , lens >= 4.17
         , loglevel >= 0.1
         , merkle-log
         , mtl >= 2.2
         , pact
-        , random >= 1.1
+        , random >= 1.2
         , strict-tuple >= 0.1.3
         , string-conv >= 0.1
         , temporary >= 1.3
         , text >= 1.2
-        , vector >= 0.12
+        , vector >= 0.12.2
         , yaml >= 0.11
 
         -- from test
-        , QuickCheck >= 2.12.6
-        , bytes >= 0.15
-        , connection >=0.2
+        , QuickCheck >= 2.14
         , cryptonite >= 0.25
-        , http-client >= 0.5
-        , http-client-tls >=0.3
-        , network >= 2.6 && < 3.1.1 || >= 3.1.2
         , quickcheck-instances >= 0.3
-        , servant-client >= 0.16.0.1
         , streaming-commons >= 0.2
-        , tasty >= 1.0
-        , tasty-golden >= 2.3
-        , tasty-hunit >= 0.9
-        , tasty-quickcheck >= 0.9
         , unordered-containers >= 0.2
-        , wai >= 3.2
-        , warp >= 3.3.6
-        , warp-tls >= 3.2.10
         , yet-another-logger >= 0.4
+

--- a/src/Chainweb/Crypto/MerkleLog.hs
+++ b/src/Chainweb/Crypto/MerkleLog.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE BangPatterns #-}
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
@@ -16,10 +15,6 @@
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
-
-#if __GLASGOW_HASKELL__ < 806
-{-# LANGUAGE TypeInType #-}
-#endif
 
 -- |
 -- Module: Chainweb.Crypto.MerkleLog

--- a/src/Chainweb/Payload/RestAPI/Server.hs
+++ b/src/Chainweb/Payload/RestAPI/Server.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE ExistentialQuantification #-}
 {-# LANGUAGE LambdaCase #-}
@@ -32,9 +31,6 @@ import Control.Monad.Trans.Maybe
 
 import Data.Aeson
 import Data.Function
-#if ! MIN_VERSION_vector(0,12,2)
-import qualified Data.Maybe as M
-#endif
 import Data.Proxy
 import qualified Data.Text.IO as T
 import qualified Data.Vector as V
@@ -68,11 +64,7 @@ err404Msg :: ToJSON msg  => msg -> ServerError
 err404Msg msg = err404 { errBody = encode msg }
 
 catMaybes :: V.Vector (Maybe a) -> V.Vector a
-#if MIN_VERSION_vector(0,12,2)
 catMaybes = V.catMaybes
-#else
-catMaybes = V.fromList . M.catMaybes . V.toList
-#endif
 
 -- -------------------------------------------------------------------------- --
 -- GET Payload Handler

--- a/src/Chainweb/RestAPI/NetworkID.hs
+++ b/src/Chainweb/RestAPI/NetworkID.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DeriveGeneric #-}
@@ -48,9 +47,6 @@ import Control.Monad.Catch
 
 import Data.Hashable
 import Data.Proxy
-#if !MIN_VERSION_base(4,11,0)
-import Data.Semigroup hiding (option)
-#endif
 import qualified Data.Text as T
 
 import GHC.Generics (Generic)

--- a/src/Servant/Client_.hs
+++ b/src/Servant/Client_.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE DeriveFunctor #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE FlexibleContexts #-}
@@ -73,21 +72,12 @@ instance MonadReader ClientEnv ClientM_ where
     {-# INLINE local #-}
 
 instance RunClient ClientM_ where
-#if MIN_VERSION_servant_client_core(0,18,1)
     runRequestAcceptStatus s req = ClientM_ $ do
         e <- ask
         req' <- liftIO $ _modReq e req
         res <- lift (runRequestAcceptStatus s req')
         liftIO $ _modRes e res
     {-# INLINE runRequestAcceptStatus #-}
-#else
-    runRequest req = ClientM_ $ do
-        e <- ask
-        req' <- liftIO $ _modReq e req
-        res <- lift (runRequest req')
-        liftIO $ _modRes e res
-    {-# INLINE runRequest #-}
-#endif
 
     throwClientError = throwError
     {-# INLINE throwClientError #-}

--- a/test/Chainweb/Test/Cut.hs
+++ b/test/Chainweb/Test/Cut.hs
@@ -98,7 +98,6 @@ import Chainweb.Cut
 import Chainweb.Cut.Create
 import Chainweb.Graph
 import Chainweb.Payload
-import Chainweb.Test.Utils (genEnum)
 import Chainweb.Test.Utils.BlockHeader
 import Chainweb.Time (Micros(..), Time, TimeSpan)
 import qualified Chainweb.Time as Time (second)
@@ -140,7 +139,7 @@ arbitraryBlockTimeOffset
     -> TimeSpan Micros
     -> T.Gen GenBlockTime
 arbitraryBlockTimeOffset lower upper = do
-    t <- genEnum (lower, upper)
+    t <- T.chooseEnum (lower, upper)
     return $ offsetBlockTime t
 
 -- | Solve Work. Doesn't check that the nonce and the time are valid.
@@ -278,7 +277,7 @@ arbitraryCut
     => ChainwebVersion
     -> T.Gen Cut
 arbitraryCut v = T.sized $ \s -> do
-    k <- genEnum (0,s)
+    k <- T.chooseEnum (0,s)
     fst <$> foldlM (\x _ -> genCut x) (genesis, initDb) [0..(k-1)]
   where
     genesis = genesisCut v
@@ -328,7 +327,7 @@ arbitraryWebChainCut_
         -- ^ A seed for the nonce which can used to enforce forks
     -> T.PropertyM IO Cut
 arbitraryWebChainCut_ wdb initialCut seed = do
-    k <- T.pick $ T.sized $ \s -> genEnum (0,s)
+    k <- T.pick $ T.sized $ \s -> T.chooseEnum (0,s)
     foldlM (\c _ -> genCut c) initialCut [0..(k-1)]
   where
     genCut c = do

--- a/test/Chainweb/Test/Orphans/Internal.hs
+++ b/test/Chainweb/Test/Orphans/Internal.hs
@@ -140,7 +140,6 @@ import Chainweb.SPV.OutputProof
 import Chainweb.SPV.PayloadProof
 import Chainweb.Test.Orphans.Pact
 import Chainweb.Test.Orphans.Time ()
-import Chainweb.Test.Utils (genEnum)
 import Chainweb.Time
 import Chainweb.Utils
 import Chainweb.Utils.Paging
@@ -359,7 +358,7 @@ arbitraryBlockHeaderVersionHeightChain
     -> Gen BlockHeader
 arbitraryBlockHeaderVersionHeightChain v h cid
     | isWebChain (chainGraphAt v h) cid = do
-        t <- genEnum (epoch, add (scaleTimeSpan @Int (365 * 200) day) epoch)
+        t <- chooseEnum (epoch, add (scaleTimeSpan @Int (365 * 200) day) epoch)
         fromLog @ChainwebMerkleHashAlgorithm . newMerkleLog <$> entries t
     | otherwise = discard
   where
@@ -373,7 +372,7 @@ arbitraryBlockHeaderVersionHeightChain v h cid
         $ liftA2 (:+:) arbitrary -- weight
         $ liftA2 (:+:) (pure h) -- height
         $ liftA2 (:+:) (pure v) -- version
-        $ liftA2 (:+:) (EpochStartTime <$> genEnum (toEnum 0, t)) -- epoch start
+        $ liftA2 (:+:) (EpochStartTime <$> chooseEnum (toEnum 0, t)) -- epoch start
         $ liftA2 (:+:) (Nonce <$> chooseAny) -- nonce
         $ fmap (MerkleLogBody . blockHashRecordToVector)
             (arbitraryBlockHashRecordVersionHeightChain v h cid) -- adjacents

--- a/test/Chainweb/Test/Utils.hs
+++ b/test/Chainweb/Test/Utils.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE MultiWayIf #-}
 {-# LANGUAGE NumericUnderscores #-}
@@ -106,9 +105,6 @@ module Chainweb.Test.Utils
 , runSchedRocks
 , withArgs
 , matchTest
-
--- * Misc
-, genEnum
 
 -- * Multi-node testing utils
 , ChainwebNetwork(..)
@@ -224,16 +220,6 @@ import Network.X509.SelfSigned
 import P2P.Node.Configuration
 import qualified P2P.Node.PeerDB as P2P
 import P2P.Peer
-
--- -------------------------------------------------------------------------- --
--- Misc
-
-genEnum :: Enum a => (a, a) -> Gen a
-#if MIN_VERSION_QuickCheck(2,14,0)
-genEnum = chooseEnum
-#else
-genEnum (l, u) = toEnum <$> choose (fromEnum l, fromEnum u)
-#endif
 
 -- -------------------------------------------------------------------------- --
 -- Intialize Test BlockHeader DB

--- a/test/Chainweb/Test/Utils/TestHeader.hs
+++ b/test/Chainweb/Test/Utils/TestHeader.hs
@@ -44,6 +44,7 @@ import Debug.Trace
 import GHC.Generics
 import GHC.Stack
 
+import Test.QuickCheck (chooseEnum)
 import Test.QuickCheck.Arbitrary (arbitrary)
 import Test.QuickCheck.Gen (Gen)
 
@@ -55,7 +56,6 @@ import Chainweb.BlockHeader.Genesis
 import Chainweb.BlockHeight
 import Chainweb.ChainValue
 import Chainweb.Test.Orphans.Internal
-import Chainweb.Test.Utils (genEnum)
 import Chainweb.Test.Utils.ApiQueries
 import Chainweb.Version
 
@@ -136,7 +136,7 @@ testHeader v = case fromJSON (object v) of
 --
 arbitraryTestHeader :: ChainwebVersion -> ChainId -> Gen TestHeader
 arbitraryTestHeader v cid = do
-    h <- genEnum (genesisHeight v cid, maxBound `div` 2)
+    h <- chooseEnum (genesisHeight v cid, maxBound `div` 2)
     arbitraryTestHeaderHeight v cid h
 {-# INLINE arbitraryTestHeader #-}
 
@@ -158,7 +158,7 @@ arbitraryTestHeaderHeight v cid h = do
     payloadHash <- arbitrary
     let pt = maximum $ _bct . _blockCreationTime
             <$> HM.insert cid (_parentHeader parent) as
-    t <- BlockCreationTime <$> genEnum (pt, maxBound)
+    t <- BlockCreationTime <$> chooseEnum (pt, maxBound)
     return $ TestHeader
         { _testHeaderHdr = newBlockHeader (ParentHeader <$> as) payloadHash nonce t parent
         , _testHeaderParent = parent


### PR DESCRIPTION
Remove some legacy CPP macros and lower bounds that are now obsolete since the nix builds use GHC-8.10.