### PR TITLE
Tighter bound on unordered-containers

### DIFF
--- a/chainweb.cabal
+++ b/chainweb.cabal
@@ -397,7 +397,7 @@ library
         , tls-session-manager >= 0.0
         , token-bucket >= 0.1
         , transformers >= 0.5
-        , unordered-containers >= 0.2
+        , unordered-containers == 0.2.15.0
         , wai >= 3.2.2.1
         , wai-app-static >= 3.1.6.3
         , wai-cors >= 0.2.7
@@ -557,7 +557,7 @@ test-suite chainweb-tests
         , text >=1.2
         , time >= 1.8
         , transformers >= 0.5
-        , unordered-containers >= 0.2
+        , unordered-containers == 0.2.15.0
         , vector >= 0.12.2
         , wai >= 3.2
         , warp >= 3.3.5
@@ -707,7 +707,7 @@ executable cwtool
         , temporary >= 1.3
         , text >= 1.2
         , transformers >= 0.5
-        , unordered-containers >= 0.2
+        , unordered-containers == 0.2.15.0
         , vector >= 0.12.2
         , wai >= 3.2
         , warp >= 3.3.5
@@ -771,6 +771,6 @@ benchmark bench
         , cryptonite >= 0.25
         , quickcheck-instances >= 0.3
         , streaming-commons >= 0.2
-        , unordered-containers >= 0.2
+        , unordered-containers == 0.2.15.0
         , yet-another-logger >= 0.4
 


### PR DESCRIPTION
[0.2.16.0 added this](https://github.com/haskell-unordered-containers/unordered-containers/pull/317) which probably totally breaks everything.