### PR TITLE
Fix and cleanup PactQueue Statistics Logging

### DIFF
--- a/src/Chainweb/Pact/Service/PactInProcApi.hs
+++ b/src/Chainweb/Pact/Service/PactInProcApi.hs
@@ -108,11 +108,9 @@ runPactServiceQueueMonitor l pq = do
     let lf = logFunction l
     logFunctionText l Info "Initialized PactQueueMonitor"
     runForeverThrottled lf "Chainweb.Pact.Service.PactInProcApi.runPactServiceQueueMonitor" 10 (10 * mega) $ do
-            PactQueueStats validateblock_stats newblock_stats other_stats <- getPactQueueStats pq
+            queueStats <- getPactQueueStats pq
             logFunctionText l Debug "got latest set of stats from PactQueueMonitor"
-            logFunctionJson l Info validateblock_stats
-            logFunctionJson l Info newblock_stats
-            logFunctionJson l Info other_stats
+            logFunctionJson l Info queueStats
             resetPactQueueStats pq
             approximateThreadDelay 60_000_000 {- 1 minute -}
 

--- a/src/Chainweb/Pact/Service/PactQueue.hs
+++ b/src/Chainweb/Pact/Service/PactQueue.hs
@@ -1,49 +1,58 @@
-{-# LANGUAGE DeriveGeneric             #-}
-{-# LANGUAGE DeriveAnyClass            #-}
-{-# LANGUAGE DerivingStrategies        #-}
-{-# LANGUAGE LambdaCase                #-}
-{-# LANGUAGE OverloadedStrings         #-}
-{-# LANGUAGE TypeApplications          #-}
-{-# LANGUAGE ViewPatterns              #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE ViewPatterns #-}
+
 -- |
 -- Module: Chainweb.Pact.Service.PactQueue
--- Copyright: Copyright © 2018 Kadena LLC.
+-- Copyright: Copyright © 2022 Kadena LLC.
 -- License: See LICENSE file
 -- Maintainer: Mark Nichols <mark@kadena.io>
 -- Stability: experimental
 --
 -- Pact execution service queue for Chainweb
-
+--
 module Chainweb.Pact.Service.PactQueue
-    ( addRequest
-    , getNextRequest
-    , getPactQueueStats
-    , newPactQueue
-    , resetPactQueueStats
-    , PactQueue
-    , PactQueueStats(..)
-    ) where
+( addRequest
+, getNextRequest
+, getPactQueueStats
+, newPactQueue
+, resetPactQueueStats
+, PactQueue
+, PactQueueStats(..)
+) where
 
-import Data.Aeson
 import Control.Applicative
 import Control.Concurrent.STM.TBQueue
 import Control.DeepSeq (NFData)
 import Control.Lens (each)
 import Control.Monad ((>=>))
 import Control.Monad.STM
+
+import Data.Aeson
 import Data.IORef
 import Data.Text (Text)
+
 import GHC.Generics
+
 import Numeric.Natural
+
+-- internal modules
+
 import Chainweb.Pact.Service.Types
 import Chainweb.Time
 import Chainweb.Utils
 
--- | The type of the Pact Queue
--- type PactQueue = TBQueue RequestMsg
+-- -------------------------------------------------------------------------- --
+-- Pact Queue
+
+-- | The type of the Pact Queue type PactQueue = TBQueue RequestMsg
+--
 data PactQueue = PactQueue
-    {
-      _pactQueueValidateBlock :: !(TBQueue (T2 RequestMsg (Time Micros)))
+    { _pactQueueValidateBlock :: !(TBQueue (T2 RequestMsg (Time Micros)))
     , _pactQueueNewBlock :: !(TBQueue (T2 RequestMsg (Time Micros)))
     , _pactQueueOtherMsg :: !(TBQueue (T2 RequestMsg (Time Micros)))
     , _pactQueuePactQueueValidateBlockMsgStats :: !PactQueueStats'
@@ -53,8 +62,7 @@ data PactQueue = PactQueue
 
 initPactQueueCounters :: PactQueueCounters
 initPactQueueCounters = PactQueueCounters
-    {
-      _pactQueueCountersCount = 0
+    { _pactQueueCountersCount = 0
     , _pactQueueCountersSum = 0
     , _pactQueueCountersMin = maxBound
     , _pactQueueCountersMax = 0
@@ -66,78 +74,81 @@ newPactQueue sz = do
     pactQueuePactQueueValidateBlockMsgStats <- do
         counters <- newIORef initPactQueueCounters
         return PactQueueStats'
-          {
-            _pactQueueStatsQueueName = "ValidateBlockMsg"
-          , _pactQueueStatsCounters = counters
-          }
+            { _pactQueueStatsQueueName = "ValidateBlockMsg"
+            , _pactQueueStatsCounters = counters
+            }
     pactQueuePactQueueNewBlockMsgStats <- do
         counters <- newIORef initPactQueueCounters
         return PactQueueStats'
-          {
-            _pactQueueStatsQueueName = "NewBlockMsg"
-          , _pactQueueStatsCounters = counters
-          }
+            { _pactQueueStatsQueueName = "NewBlockMsg"
+            , _pactQueueStatsCounters = counters
+            }
     pactQueuePactQueueOtherMsgStats <- do
         counters <- newIORef initPactQueueCounters
         return PactQueueStats'
-          {
-            _pactQueueStatsQueueName = "OtherMsg"
-          , _pactQueueStatsCounters = counters
-          }
+            { _pactQueueStatsQueueName = "OtherMsg"
+            , _pactQueueStatsCounters = counters
+            }
     return PactQueue
-      {
-        _pactQueueValidateBlock = pactQueueValidateBlock
-      , _pactQueueNewBlock = pactQueueNewBlock
-      , _pactQueueOtherMsg = pactQueueOtherMsg
-      , _pactQueuePactQueueValidateBlockMsgStats = pactQueuePactQueueValidateBlockMsgStats
-      , _pactQueuePactQueueNewBlockMsgStats = pactQueuePactQueueNewBlockMsgStats
-      , _pactQueuePactQueueOtherMsgStats = pactQueuePactQueueOtherMsgStats
-      }
+        { _pactQueueValidateBlock = pactQueueValidateBlock
+        , _pactQueueNewBlock = pactQueueNewBlock
+        , _pactQueueOtherMsg = pactQueueOtherMsg
+        , _pactQueuePactQueueValidateBlockMsgStats = pactQueuePactQueueValidateBlockMsgStats
+        , _pactQueuePactQueueNewBlockMsgStats = pactQueuePactQueueNewBlockMsgStats
+        , _pactQueuePactQueueOtherMsgStats = pactQueuePactQueueOtherMsgStats
+        }
 
 -- | Add a request to the Pact execution queue
+--
 addRequest :: PactQueue -> RequestMsg -> IO ()
 addRequest q msg =  do
     entranceTime <- getCurrentTimeIntegral
     atomically $ writeTBQueue priority (T2 msg entranceTime)
-    where
-      priority = case msg of
+  where
+    priority = case msg of
         ValidateBlockMsg {} -> _pactQueueValidateBlock q
         NewBlockMsg {} -> _pactQueueNewBlock q
         _ -> _pactQueueOtherMsg q
 
 -- | Get the next available request from the Pact execution queue
+--
 getNextRequest :: PactQueue -> IO RequestMsg
 getNextRequest q = do
-    (T2 req entranceTime) <- atomically $
-      tryReadTBQueueOrRetry (_pactQueueValidateBlock q)
-      <|> tryReadTBQueueOrRetry (_pactQueueNewBlock q)
-      <|> tryReadTBQueueOrRetry (_pactQueueOtherMsg q)
+    T2 req entranceTime <- atomically
+        $ tryReadTBQueueOrRetry (_pactQueueValidateBlock q)
+        <|> tryReadTBQueueOrRetry (_pactQueueNewBlock q)
+        <|> tryReadTBQueueOrRetry (_pactQueueOtherMsg q)
     exitTime <- getCurrentTimeIntegral
     let requestTime = exitTime `diff` entranceTime
         stats = case req of
-          ValidateBlockMsg {} -> _pactQueuePactQueueValidateBlockMsgStats q
-          NewBlockMsg {} -> _pactQueuePactQueueNewBlockMsgStats q
-          _ -> _pactQueuePactQueueOtherMsgStats q
+            ValidateBlockMsg {} -> _pactQueuePactQueueValidateBlockMsgStats q
+            NewBlockMsg {} -> _pactQueuePactQueueNewBlockMsgStats q
+            _ -> _pactQueuePactQueueOtherMsgStats q
     updatePactQueueStats stats requestTime
     return req
-      where
-        tryReadTBQueueOrRetry = tryReadTBQueue >=> \case
-          Nothing -> retry
-          Just msg -> return msg
+  where
+    tryReadTBQueueOrRetry = tryReadTBQueue >=> \case
+        Nothing -> retry
+        Just msg -> return msg
 
+-- -------------------------------------------------------------------------- --
+-- Pact Queue Telemetry
 
+-- | Statistics for a single Pact queue priority
+--
 data PactQueueStats' = PactQueueStats'
-    {
-      _pactQueueStatsQueueName :: !Text
+    { _pactQueueStatsQueueName :: !Text -- TODO this is unused
     , _pactQueueStatsCounters  :: !(IORef PactQueueCounters)
     }
 
+-- | Statistics for all Pact queue priorities
+--
 data PactQueueStats = PactQueueStats
-    {
-      _validateblock :: !PactQueueCounters
+    { _validateblock :: !PactQueueCounters
     , _newblock :: !PactQueueCounters
     , _othermsg :: !PactQueueCounters
-    } deriving (Generic, NFData)
+    }
+    deriving (Generic, NFData)
 
 instance ToJSON PactQueueStats where
     toJSON = object . pactQueueStatsProperties
@@ -151,13 +162,13 @@ pactQueueStatsProperties o =
     ]
 
 data PactQueueCounters = PactQueueCounters
-    {
-      _pactQueueCountersCount :: {-# UNPACK #-} !Int
-    , _pactQueueCountersSum   :: {-# UNPACK #-} !Micros
-    , _pactQueueCountersMin   :: {-# UNPACK #-} !Micros
-    , _pactQueueCountersMax   :: {-# UNPACK #-} !Micros
-    } deriving (Show, Generic)
-      deriving anyclass NFData
+    { _pactQueueCountersCount :: {-# UNPACK #-} !Int
+    , _pactQueueCountersSum :: {-# UNPACK #-} !Micros
+    , _pactQueueCountersMin :: {-# UNPACK #-} !Micros
+    , _pactQueueCountersMax :: {-# UNPACK #-} !Micros
+    }
+    deriving (Show, Generic)
+    deriving anyclass NFData
 
 
 instance ToJSON PactQueueCounters where
@@ -167,29 +178,28 @@ instance ToJSON PactQueueCounters where
 pactQueueCountersProperties :: KeyValue kv => PactQueueCounters -> [kv]
 pactQueueCountersProperties pqc =
     [ "count" .= _pactQueueCountersCount pqc
-    , "sum"   .= _pactQueueCountersSum pqc
-    , "min"   .= _pactQueueCountersMin pqc
-    , "max"   .= _pactQueueCountersMax pqc
-    , "avg"   .= avg
+    , "sum" .= _pactQueueCountersSum pqc
+    , "min" .= _pactQueueCountersMin pqc
+    , "max" .= _pactQueueCountersMax pqc
+    , "avg" .= avg
     ]
-      where
-          avg :: Maybe Double
-          avg = if _pactQueueCountersCount pqc == 0 then Nothing
-            else Just $ fromIntegral (_pactQueueCountersSum pqc) / fromIntegral (_pactQueueCountersCount pqc)
-
-
+  where
+    avg :: Maybe Double
+    avg = if _pactQueueCountersCount pqc == 0
+        then Nothing
+        else Just $ fromIntegral (_pactQueueCountersSum pqc) / fromIntegral (_pactQueueCountersCount pqc)
 
 updatePactQueueStats :: PactQueueStats' -> TimeSpan Micros -> IO ()
 updatePactQueueStats stats (timeSpanToMicros -> timespan) = do
     atomicModifyIORef' (_pactQueueStatsCounters stats) $ \ctrs ->
-      (PactQueueCounters
-      {
-          _pactQueueCountersCount = _pactQueueCountersCount ctrs + 1
-        , _pactQueueCountersSum = _pactQueueCountersSum ctrs + timespan
-        , _pactQueueCountersMin = _pactQueueCountersMin ctrs `min` timespan
-        , _pactQueueCountersMax = _pactQueueCountersMax ctrs `max` timespan
-      }
-      , ())
+        ( PactQueueCounters
+            { _pactQueueCountersCount = _pactQueueCountersCount ctrs + 1
+            , _pactQueueCountersSum = _pactQueueCountersSum ctrs + timespan
+            , _pactQueueCountersMin = _pactQueueCountersMin ctrs `min` timespan
+            , _pactQueueCountersMax = _pactQueueCountersMax ctrs `max` timespan
+            }
+        , ()
+        )
 
 resetPactQueueStats :: PactQueue -> IO ()
 resetPactQueueStats q = do
@@ -198,28 +208,33 @@ resetPactQueueStats q = do
     resetPactQueueStats' (_pactQueuePactQueueOtherMsgStats q)
 
 resetPactQueueStats' :: PactQueueStats' -> IO ()
-resetPactQueueStats' stats = atomicWriteIORef (_pactQueueStatsCounters stats) initPactQueueCounters
+resetPactQueueStats' stats =
+    atomicWriteIORef (_pactQueueStatsCounters stats) initPactQueueCounters
 
 getPactQueueStats :: PactQueue -> IO PactQueueStats
-getPactQueueStats = getPactQueueStats' >=> \(vstats,nbstats,ostats) -> return
+getPactQueueStats = getPactQueueStats' >=> \(vstats, nbstats, ostats) -> return
     PactQueueStats
-      {
-        _validateblock = vstats
-      , _newblock = nbstats
-      , _othermsg = ostats
-      }
+        { _validateblock = vstats
+        , _newblock = nbstats
+        , _othermsg = ostats
+        }
 
-getPactQueueStats' :: PactQueue -> IO (PactQueueCounters, PactQueueCounters, PactQueueCounters)
+getPactQueueStats'
+    :: PactQueue
+    -> IO (PactQueueCounters, PactQueueCounters, PactQueueCounters)
 getPactQueueStats' q = (,,)
     <$> getValidateBlockMsgPactQueueCounters q
     <*> getNewBlockMsgPactQueueCounters q
     <*> getOtherMsgPactQueueCounters q
 
 getValidateBlockMsgPactQueueCounters :: PactQueue -> IO PactQueueCounters
-getValidateBlockMsgPactQueueCounters pq = readIORef (_pactQueueStatsCounters $ _pactQueuePactQueueValidateBlockMsgStats pq)
+getValidateBlockMsgPactQueueCounters pq =
+    readIORef (_pactQueueStatsCounters $ _pactQueuePactQueueValidateBlockMsgStats pq)
 
 getNewBlockMsgPactQueueCounters :: PactQueue -> IO PactQueueCounters
-getNewBlockMsgPactQueueCounters pq = readIORef (_pactQueueStatsCounters $ _pactQueuePactQueueNewBlockMsgStats pq)
+getNewBlockMsgPactQueueCounters pq =
+    readIORef (_pactQueueStatsCounters $ _pactQueuePactQueueNewBlockMsgStats pq)
 
 getOtherMsgPactQueueCounters :: PactQueue -> IO PactQueueCounters
-getOtherMsgPactQueueCounters pq = readIORef (_pactQueueStatsCounters $ _pactQueuePactQueueOtherMsgStats pq)
+getOtherMsgPactQueueCounters pq =
+    readIORef (_pactQueueStatsCounters $ _pactQueuePactQueueOtherMsgStats pq)


### PR DESCRIPTION
* [x] Format code consistently and consistent with other chainweb code (indentation, ordered imports, etc.)
* [x] Simplify logic for pact queue statistics (in particular remove redundant PactQueueStats' data type and inline JSON encoding properties)
* [x] Fix logging of `PactQueueStats`

This PR has been tested on testnet.