### PR TITLE
create rocksDbCheckpoints directory if needed

### DIFF
--- a/node/ChainwebNode.hs
+++ b/node/ChainwebNode.hs
@@ -323,8 +323,9 @@ node conf logger = do
 
 makeCheckpoint :: FilePath -> RocksDb -> IO ()
 makeCheckpoint checkpointDir rocksDb = do
-    Time (epochToNow :: TimeSpan Integer) <- getCurrentTimeIntegral 
-    -- 0 ~ never flush WAL log before checkpoint, to avoid making extra work 
+    createDirectoryIfMissing False checkpointDir
+    Time (epochToNow :: TimeSpan Integer) <- getCurrentTimeIntegral
+    -- 0 ~ never flush WAL log before checkpoint, to avoid making extra work
     checkpointRocksDb rocksDb maxBound (checkpointDir </> T.unpack (microsToText $ timeSpanToMicros epochToNow))
 
 withNodeLogger


### PR DESCRIPTION
It seems that `checkpointRocksDb` expects that the directory where the checkpoint is created exists. This PR creates `checkpointDir` if it doesn't already exist.

Tested on testnet (us1.testnet.chainweb.com)