### PR TITLE
cleap use of temporary sqlite databases in tests

### DIFF
--- a/chainweb.cabal
+++ b/chainweb.cabal
@@ -514,7 +514,6 @@ test-suite chainweb-tests
         , directory >= 1.2
         , ethereum
         , exceptions
-        , extra >= 1.6
         , hashable >= 1.3 && < 1.3.1
         , http-client >= 0.5
         , http-types >= 0.12
@@ -667,7 +666,6 @@ executable cwtool
         , errors >= 2.3
         , file-embed
         , exceptions >= 0.8
-        , extra >= 1.6
         , file-embed >= 0.0
         , http-client >= 0.5
         , http-client-tls >=0.3
@@ -738,7 +736,6 @@ benchmark bench
         , deepseq >= 1.4
         , directory >= 1.3
         , exceptions >= 0.8
-        , extra >= 1.6
         , file-embed >= 0.0
         , lens >= 4.17
         , loglevel >= 0.1

--- a/src/Chainweb/Pact/Backend/Utils.hs
+++ b/src/Chainweb/Pact/Backend/Utils.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
@@ -51,6 +52,7 @@ module Chainweb.Pact.Backend.Utils
   , openSQLiteConnection
   , closeSQLiteConnection
   , withTempSQLiteConnection
+  , withInMemSQLiteConnection
   -- * SQLite Pragmas
   , chainwebPragmas
   ) where
@@ -75,7 +77,6 @@ import Prelude hiding (log)
 
 import System.Directory
 import System.FilePath
-import System.IO.Temp
 import System.LogLevel
 
 -- pact
@@ -296,8 +297,7 @@ startSqliteDb cid logger dbDir doResetDb = do
   where
     textLog = logFunctionText logger
     resetDb = removeDirectoryRecursive dbDir
-    sqliteFile =
-        dbDir </> chainDbFileName cid
+    sqliteFile = dbDir </> chainDbFileName cid
 
 chainDbFileName :: ChainId -> FilePath
 chainDbFileName cid = fold
@@ -309,19 +309,12 @@ chainDbFileName cid = fold
 stopSqliteDb :: SQLiteEnv -> IO ()
 stopSqliteDb = closeSQLiteConnection
 
-withSQLiteConnection :: String -> [Pragma] -> Bool -> (SQLiteEnv -> IO c) -> IO c
-withSQLiteConnection file ps todelete action =
-  bracket (openSQLiteConnection file ps) closer action
-  where
-    closer c = do
-      closeSQLiteConnection c
-      when todelete (removeFile file)
+withSQLiteConnection :: String -> [Pragma] -> (SQLiteEnv -> IO c) -> IO c
+withSQLiteConnection file ps =
+    bracket (openSQLiteConnection file ps) closeSQLiteConnection
 
 openSQLiteConnection :: String -> [Pragma] -> IO SQLiteEnv
-openSQLiteConnection file ps = do
-  -- e <- open (fromString file) -- old way
-  e <- open2 file -- new way
-  case e of
+openSQLiteConnection file ps = open2 file >>= \case
     Left (err, msg) ->
       internalError $
       "withSQLiteConnection: Can't open db with "
@@ -334,13 +327,28 @@ openSQLiteConnection file ps = do
 closeSQLiteConnection :: SQLiteEnv -> IO ()
 closeSQLiteConnection c = void $ close_v2 $ _sConn c
 
+-- passing the empty string as filename causes sqlite to use a temporary file
+-- that is deleted when the connection is closed. In practice, unless the database becomes
+-- very large, the database will reside memory and no data will be written to disk.
+--
+-- Cf. https://www.sqlite.org/inmemorydb.html
+--
 withTempSQLiteConnection :: [Pragma] -> (SQLiteEnv -> IO c) -> IO c
-withTempSQLiteConnection ps action =
-  withSystemTempFile "sqlite-tmp" (\file _ -> withSQLiteConnection file ps False action)
+withTempSQLiteConnection = withSQLiteConnection ""
+
+-- Using the special file name @:memory:@ causes sqlite to create a temporary in-memory
+-- database.
+--
+-- Cf. https://www.sqlite.org/inmemorydb.html
+--
+withInMemSQLiteConnection :: [Pragma] -> (SQLiteEnv -> IO c) -> IO c
+withInMemSQLiteConnection = withSQLiteConnection ":memory:"
 
 open2 :: String -> IO (Either (Error, Utf8) Database)
-open2 file = open_v2 (fromString file) (collapseFlags [sqlite_open_readwrite , sqlite_open_create , sqlite_open_fullmutex]) Nothing
--- Nothing corresponds to the nullPtr
+open2 file = open_v2
+    (fromString file)
+    (collapseFlags [sqlite_open_readwrite , sqlite_open_create , sqlite_open_fullmutex])
+    Nothing -- Nothing corresponds to the nullPtr
 
 collapseFlags :: [SQLiteFlag] -> SQLiteFlag
 collapseFlags xs =

--- a/test/Chainweb/Test/Pact/Checkpointer.hs
+++ b/test/Chainweb/Test/Pact/Checkpointer.hs
@@ -76,7 +76,7 @@ tests = testGroupSch "Checkpointer"
 -- Module Name Test
 
 testModuleName :: TestTree
-testModuleName = withResource initializeSQLite freeSQLiteResource $
+testModuleName = withTempSQLiteResource $
     runSQLite' $ \resIO -> testCase "testModuleName" $ do
 
         (CheckpointEnv {..}, SQLiteEnv {..}) <- resIO
@@ -584,17 +584,17 @@ runTwice step action = do
   action
 
 runSQLite
-    :: (IO (CheckpointEnv) -> TestTree)
-    -> IO (IO (), SQLiteEnv)
+    :: (IO CheckpointEnv -> TestTree)
+    -> IO SQLiteEnv
     -> TestTree
 runSQLite f = runSQLite' (f . fmap fst)
 
 runSQLite'
     :: (IO (CheckpointEnv,SQLiteEnv) -> TestTree)
-    -> IO (IO (), SQLiteEnv)
+    -> IO SQLiteEnv
     -> TestTree
 runSQLite' runTest sqlEnvIO = runTest $ do
-    (_,sqlenv) <- sqlEnvIO
+    sqlenv <- sqlEnvIO
     cp <- initRelationalCheckpointer initialBlockState sqlenv logger testVer testChainId
     return (cp, sqlenv)
   where

--- a/test/Chainweb/Test/Pact/PactExec.hs
+++ b/test/Chainweb/Test/Pact/PactExec.hs
@@ -34,8 +34,6 @@ import qualified Data.Yaml as Y
 
 import GHC.Generics (Generic)
 
-import System.IO.Extra (readFile')
-
 import Test.Tasty
 import Test.Tasty.HUnit
 

--- a/test/Chainweb/Test/Pact/PactInProcApi.hs
+++ b/test/Chainweb/Test/Pact/PactInProcApi.hs
@@ -42,7 +42,6 @@ import qualified Data.Text as T
 import qualified Data.Vector as V
 import qualified Data.Yaml as Y
 
-import System.IO.Extra
 import System.LogLevel
 
 import Test.Tasty

--- a/test/Chainweb/Test/Utils.hs
+++ b/test/Chainweb/Test/Utils.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE MultiWayIf #-}
 {-# LANGUAGE NumericUnderscores #-}
@@ -20,12 +21,20 @@
 --
 module Chainweb.Test.Utils
 (
-  testRocksDb
+-- * Misc
+  readFile'
+
+-- * Test RocksDb
+, testRocksDb
 
 -- * Intialize Test BlockHeader DB
 , testBlockHeaderDb
 , withTestBlockHeaderDb
 , withBlockHeaderDbsResource
+
+-- * SQLite Database Test Resource
+, withTempSQLiteResource
+, withInMemSQLiteResource
 
 -- * Data Generation
 , toyBlockHeaderDb
@@ -127,10 +136,12 @@ module Chainweb.Test.Utils
 
 import Control.Concurrent
 import Control.Concurrent.Async
-import Control.Exception (bracket)
+#if !MIN_VERSION_base(4,15,0)
+import Control.Exception (evaluate)
+#endif
 import Control.Lens
 import Control.Monad
-import Control.Monad.Catch (MonadThrow, finally)
+import Control.Monad.Catch (MonadThrow, finally, bracket)
 import Control.Monad.IO.Class
 
 import Data.Aeson (FromJSON, ToJSON)
@@ -163,7 +174,7 @@ import Servant.Client (BaseUrl(..), ClientEnv, Scheme(..), mkClientEnv)
 
 import System.Directory
 import System.Environment (withArgs)
-import qualified System.IO.Extra as Extra
+import System.IO
 import System.IO.Temp
 import System.LogLevel
 import System.Random (randomIO)
@@ -205,6 +216,8 @@ import Chainweb.Mempool.Mempool (MempoolBackend(..), TransactionHash(..), BlockF
 import Chainweb.MerkleUniverse
 import Chainweb.Miner.Config
 import Chainweb.Miner.Pact
+import Chainweb.Pact.Backend.Types (SQLiteEnv(..))
+import Chainweb.Pact.Backend.Utils (openSQLiteConnection, closeSQLiteConnection, chainwebPragmas)
 import Chainweb.Payload.PayloadStore
 import Chainweb.RestAPI
 import Chainweb.RestAPI.NetworkID
@@ -224,6 +237,18 @@ import Network.X509.SelfSigned
 import P2P.Node.Configuration
 import qualified P2P.Node.PeerDB as P2P
 import P2P.Peer
+
+-- -------------------------------------------------------------------------- --
+-- Misc
+
+#if !MIN_VERSION_base(4,15,0)
+-- | Guarantee that the
+readFile' :: FilePath -> IO String
+readFile' fp = withFile fp ReadMode $ \h -> do
+    s <- hGetContents h
+    void $ evaluate $ length s
+    return s
+#endif
 
 -- -------------------------------------------------------------------------- --
 -- Intialize Test BlockHeader DB
@@ -274,6 +299,26 @@ withRocksResource m = withResource create destroy wrap
           `catchAllSynchronous` (const $ return ())
     wrap ioact = let io' = snd <$> ioact in m io'
 
+-- -------------------------------------------------------------------------- --
+-- SQLite DB Test Resource
+
+-- | This function doesn't delete the database file after use.
+--
+-- You should use 'withTempSQLiteResource' or 'withInMemSQLiteResource' instead.
+--
+withSQLiteResource
+    :: String
+    -> (IO SQLiteEnv -> TestTree)
+    -> TestTree
+withSQLiteResource file = withResource
+    (openSQLiteConnection file chainwebPragmas)
+    closeSQLiteConnection
+
+withTempSQLiteResource :: (IO SQLiteEnv -> TestTree) -> TestTree
+withTempSQLiteResource = withSQLiteResource ""
+
+withInMemSQLiteResource :: (IO SQLiteEnv -> TestTree) -> TestTree
+withInMemSQLiteResource = withSQLiteResource ":memory:"
 
 -- -------------------------------------------------------------------------- --
 -- Toy Values
@@ -1011,8 +1056,8 @@ node
     -> IO ()
 node testLabel rdb rawLogger peerInfoVar conf nid = do
     rocksDb <- testRocksDb (testLabel <> T.encodeUtf8 (toText nid)) rdb
-    Extra.withTempDir $ \backupDir ->
-        Extra.withTempDir $ \dir ->
+    withSystemTempDirectory "test-backupdir" $ \backupDir ->
+        withSystemTempDirectory "test-rocksdb" $ \dir ->
             withChainweb conf logger rocksDb backupDir dir False $ \cw -> do
 
                 -- If this is the bootstrap node we extract the port number and publish via an MVar.

--- a/tools/db-checksum/CheckpointerDBChecksum.hs
+++ b/tools/db-checksum/CheckpointerDBChecksum.hs
@@ -80,7 +80,7 @@ type TableContents = B.ByteString
 -- this will produce both the raw bytes for all of the tables concatenated
 -- together, and the raw bytes of each individual table (this is over a single chain)
 work :: Args -> IO (Builder, Map TableName TableContents)
-work args = withSQLiteConnection (_sqliteFile args) chainwebPragmas False (runReaderT go)
+work args = withSQLiteConnection (_sqliteFile args) chainwebPragmas (runReaderT go)
   where
     low = _startBlockHeight args
     high = case _endBlockHeight args of


### PR DESCRIPTION
SQLite has built-in support for temporary (and in-memory) database. When the database file is the empty string, a temporary database file is used that is removed when the connection is closed (cf. https://www.sqlite.org/inmemorydb.html).

The PR does the following:

* Simplify test code by using sqlite's built-in support for temporary database files.
* Remove the used `todelete` flag from `withSQLiteConnection`
* Drop dependency on `extra` package by using temporary directory creation form the `temporary` package