### PR TITLE
Fix reset to block height

### DIFF
--- a/src/Chainweb/CutDB.hs
+++ b/src/Chainweb/CutDB.hs
@@ -456,7 +456,7 @@ startCutDb config logfun headerStore payloadStore cutHashesStore = mask_ $ do
                             Nothing -> return hm
                             Just h -> do
                                 let
-                                    cutHeightTarget = min 0 $
+                                    cutHeightTarget = max 0 $
                                         avgCutHeightAt v h -
                                             CutHeight (int $ diameterAtCutHeight v (maxBound :: CutHeight) * chainCountAt v (maxBound :: BlockHeight))
                                 limitCutHeaders wbhdb cutHeightTarget hm


### PR DESCRIPTION
That `min 0` made it in at the last minute, should've been tested again.