### PR TITLE
fail early during p2p peer selection

### DIFF
--- a/src/P2P/Node.hs
+++ b/src/P2P/Node.hs
@@ -78,7 +78,6 @@ import Control.Monad.STM
 import Control.Scheduler (Comp(..), traverseConcurrently)
 
 import Data.Aeson hiding (Error)
-import Data.Foldable
 import Data.Function
 import Data.Hashable
 import qualified Data.HashSet as HS

--- a/src/P2P/Node.hs
+++ b/src/P2P/Node.hs
@@ -491,6 +491,8 @@ findNextPeer conf node = do
             return $ shift i s
 
     let (p0, p1) = L.partition (\p -> _peerEntryActiveSessionCount p > 0 && _peerEntrySuccessiveFailures p <= 1) candidates
+
+        -- this ix expensive but lazy and only forced if p0 is empty
         p2 = L.groupBy ((==) `on` _peerEntrySuccessiveFailures) p1
 
     -- note that @p0 : p1@ is guaranteed to be non-empty


### PR DESCRIPTION
This PR is greatly motivated by the ideas and insights from #1470:

*   Moving the `_p2pConfigMaxSessionCount` check out of the fold will cause the transaction to fail early and prevent retrying the transaction for each single peer in the peer database.

    Ideally this reduces the overhead of P2P session creation by a factor of that is equal to the number of peers in the peer database. The current median number of peers on mainnet nodes is 360.

*   The latest iteration of this PR uses STM only for awaiting a non-empty set of candidate peers. The actual peer selection is not transactional, which is supposed to greatly reduce contention.

*   Expensive transactional computations that are also less likely to fail and cause retries are moved towards the end of the STM transaction.

*   The PRNG is stored in an `IORef` and accessed via `atomicModifyIORef'`. This should further reduce contention, because the PRNG if accessed and mutated by all all peer selection calls but shouldn't actually cause a transaction to retry.
