### PR TITLE
Remove uses of unsafeThaw in the mempool and checkpointer

### DIFF
--- a/chainweb.cabal
+++ b/chainweb.cabal
@@ -372,6 +372,7 @@ library
         , optparse-applicative >= 0.14
         , pact >= 4.2.0.1
         , pem >=0.2
+        , primitive >= 0.7.4.0
         , random >= 1.2
         , rosetta >= 1.0
         , safe-exceptions >= 0.1

--- a/src/Chainweb/Mempool/InMem.hs
+++ b/src/Chainweb/Mempool/InMem.hs
@@ -488,7 +488,7 @@ getBlockInMem logg cfg lock (BlockFill gasLimit txHashes _)  txValidate bheight 
         let !psq'' = V.foldl' ins (HashMap.union seen psq') out
         writeIORef (_inmemPending mdata) $! force psq''
         writeIORef (_inmemBadMap mdata) $! force badmap'
-        mout <- V.unsafeThaw $ V.map (snd . snd) out
+        mout <- V.thaw $ V.map (snd . snd) out
         TimSort.sortBy (compareOnGasPrice txcfg) mout
         V.unsafeFreeze mout
 
@@ -555,8 +555,8 @@ getBlockInMem logg cfg lock (BlockFill gasLimit txHashes _)  txValidate bheight 
         -> GasLimit
         -> IO [(TransactionHash, (SB.ShortByteString, t))]
     nextBatch !psq !remainingGas = do
-        let !pendingTxs0 = V.fromList $ HashMap.toList psq
-        mPendingTxs <- V.unsafeThaw pendingTxs0
+        let !pendingTxs0 = HashMap.toList psq
+        mPendingTxs <- mutableVectorFromList pendingTxs0
         TimSort.sortBy (compare `on` snd) mPendingTxs
         !pendingTxs <- V.unsafeFreeze mPendingTxs
         return $! getBatch pendingTxs remainingGas [] 0

--- a/src/Chainweb/Pact/Backend/RelationalCheckpointer.hs
+++ b/src/Chainweb/Pact/Backend/RelationalCheckpointer.hs
@@ -167,7 +167,7 @@ doSave dbenv hash = runBlockEnv dbenv $ do
     prepChunk chunk@(h:_) = (Utf8 $ _deltaTableName h, V.fromList chunk)
 
     toVectorChunks writes = liftIO $ do
-        mv <- V.unsafeThaw . V.fromList . DL.toList . DL.concat $
+        mv <- mutableVectorFromList . DL.toList . DL.concat $
               HashMap.elems writes
         TimSort.sort mv
         l' <- V.toList <$> V.unsafeFreeze mv

--- a/src/Chainweb/Pact/PactService.hs
+++ b/src/Chainweb/Pact/PactService.hs
@@ -170,7 +170,7 @@ initializeLatestBlock unlimitedRewind = findLatestValidBlock >>= \case
     Nothing -> return ()
     Just b -> withBatch $ rewindTo initialRewindLimit (Just $ ParentHeader b)
   where
-    initialRewindLimit = 1000 <$ guard (not unlimitedRewind) 
+    initialRewindLimit = 1000 <$ guard (not unlimitedRewind)
 
 initialPayloadState
     :: Logger logger


### PR DESCRIPTION
I am pretty sure writing to an `unsafeThaw`ed vector is never safe, and there is no way for it to improve our performance here anyway... more likely it worsens our performance. I get not having `mutableVectorFromList` is annoying though, so I added that.

(see https://stackoverflow.com/questions/54041813/just-how-unsafe-are-data-vectors-unsafefreeze-unsafethaw)
