### PR TITLE
Use singletonChainGraph in ForkingBench

### DIFF
--- a/bench/Chainweb/Pact/Backend/ForkingBench.hs
+++ b/bench/Chainweb/Pact/Backend/ForkingBench.hs
@@ -380,7 +380,7 @@ cid :: ChainId
 cid = someChainId testVer
 
 testVer :: ChainwebVersion
-testVer = FastTimedCPM petersonChainGraph
+testVer = FastTimedCPM singletonChainGraph
 
 assertNotLeft :: (MonadThrow m, Exception e) => Either e a -> m a
 assertNotLeft (Left l) = throwM l


### PR DESCRIPTION
Now that we know what the issue was with ForkingBench, we know that the headers are being created with no adjacent hashes anyway, so we have to use a `singletonChainGraph`.