### PR TITLE
Disable now-unnecessary warp bound

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -111,5 +111,3 @@ constraints: base64-bytestring <1.1
 -- TODO remove once the bounds are upgraded in pact.
 allow-newer: pact:direct-sqlite
 
--- warp-tls is broken with the newest warp...
-constraints: warp <3.3.22


### PR DESCRIPTION
A new warp-tls has been released that works with the new warp version, making the CI fix from yesterday unnecessary.