### PR TITLE
Fix nix-build by updating pact to 4.4

### DIFF
--- a/dep/pact/github.json
+++ b/dep/pact/github.json
@@ -3,6 +3,6 @@
   "repo": "pact",
   "branch": "master",
   "private": false,
-  "rev": "6e25691b5fc22792b6b56c3e1891d10f0c1d82de",
-  "sha256": "1bi6r8rdnn69xaz1nknw47c93pbi56ngar9rpxpz4rgncyid87jn"
+  "rev": "c2fcb547e3293a38c3cd0fa428ca1e139d727630",
+  "sha256": "08zasfiwv2v7kknncb4x951rdcmarm7cl91445f75d4drcb1mm9j"
 }


### PR DESCRIPTION
This is the nix counterpart to https://github.com/kadena-io/chainweb-node/commit/ead9b16dd3d407cd61c942b3cb464398f2e3ea64#diff-b8ed06757045fac949c89f2139a862498ad2b6d1f82c61a31e7c91d6cf0eaa70R57