### PR TITLE
Re-enable cabal cache

### DIFF
--- a/.github/workflows/applications.yml
+++ b/.github/workflows/applications.yml
@@ -327,7 +327,7 @@ jobs:
       with:
         bucket: "kadena-cabal-cache"
         region: "us-east-1"
-        folder: "${{ matrix.os }}"
+        folder: "${{ matrix.os }}-${{ matrix.ghc }}"
         aws_access_key_id: "${{ secrets.kadena_cabal_cache_aws_access_key_id }}"
         aws_secret_access_key: "${{ secrets.kadena_cabal_cache_aws_secret_access_key }}"
     - name: Install build dependencies


### PR DESCRIPTION
Seems like installing deps takes like an hour now so the github cache isn't doing its job properly, I think this will re-enable the cabal cache but I'll check how long build takes.