### PR TITLE
Fix replaying via config file

### DIFF
--- a/src/Chainweb/Chainweb/Configuration.hs
+++ b/src/Chainweb/Chainweb/Configuration.hs
@@ -246,9 +246,9 @@ pCutConfig = id
     <*< cutFetchTimeout .:: option auto
         % long "cut-fetch-timeout"
         <> help "The timeout for processing new cuts in microseconds"
-    <*< cutInitialBlockHeightLimit .:: optional % fmap BlockHeight . option auto
+    <*< cutInitialBlockHeightLimit .:: fmap (Just . BlockHeight) . option auto
         % long "initial-block-height-limit"
-    <*< cutFastForwardBlockHeightLimit .:: optional % fmap BlockHeight . option auto
+    <*< cutFastForwardBlockHeightLimit .:: fmap (Just . BlockHeight) . option auto
         % long "fast-forward-block-height-limit"
 
 -- -------------------------------------------------------------------------- --


### PR DESCRIPTION
Setting `initialBlockHeightLimit` in the config file was broken, this fixes it. A subtle cause; 
`optional $ BlockHeight <$> option Auto (long "initial-block-height-limit")` will *always succeed*, so if the CLI option is not provided, `Nothing` will override the existing config file flag. 