### PR TITLE
withSavepoint now catches SomeAsyncException

### DIFF
--- a/src/Chainweb/Pact/Backend/Utils.hs
+++ b/src/Chainweb/Pact/Backend/Utils.hs
@@ -57,7 +57,7 @@ module Chainweb.Pact.Backend.Utils
   , chainwebPragmas
   ) where
 
-import Control.Exception (AsyncException, evaluate)
+import Control.Exception (SomeAsyncException, evaluate)
 import Control.Exception.Safe (tryAny)
 import Control.Lens
 import Control.Monad
@@ -166,7 +166,7 @@ withSavepoint name action = mask $ \resetMask -> do
         liftIO $ evaluate r
     throwErr s = internalError $ "withSavepoint (" <> toText name <> "): " <> s
     handlers = [ Handler $ \(e :: PactException) -> throwErr (sshow e)
-               , Handler $ \(e :: AsyncException) -> throwM e
+               , Handler $ \(e :: SomeAsyncException) -> throwM e
                , Handler $ \(e :: SomeException) -> throwErr ("non-pact exception: " <> sshow e)
                ]
 

--- a/src/Chainweb/Pact/PactService.hs
+++ b/src/Chainweb/Pact/PactService.hs
@@ -340,7 +340,7 @@ serviceRequests logFn memPoolAccess reqQ = do
         (evalPactOnThread (post <$> m) >>= (liftIO . putMVar mvar))
         `catches`
             [ Handler $ \(e :: SomeAsyncException) -> do
-                logError $ mconcat
+                logWarn $ mconcat
                     [ "Received asynchronous exception running pact service ("
                     , which
                     , "): "

--- a/src/Chainweb/Pact/PactService.hs
+++ b/src/Chainweb/Pact/PactService.hs
@@ -340,7 +340,7 @@ serviceRequests logFn memPoolAccess reqQ = do
         (evalPactOnThread (post <$> m) >>= (liftIO . putMVar mvar))
         `catches`
             [ Handler $ \(e :: SomeAsyncException) -> do
-                logWarn $ mconcat
+                logError $ mconcat
                     [ "Received asynchronous exception running pact service ("
                     , which
                     , "): "


### PR DESCRIPTION
`withSavepoint` here is trying to rethrow asynchronous exceptions but fails because it catches `AsyncException` instead of `SomeAsyncException`. I noticed this looking at the logs which show `non-pact exception: AsyncCancelled`.