### PR TITLE
Add Warning System to `/local` preflight

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -55,7 +55,7 @@ package yet-another-logger
 source-repository-package
     type: git
     location: https://github.com/kadena-io/pact.git
-    tag: 21340f5952c167056afcf84bee4686f70e86a207
+    tag: 60087f3b15f19ec103211a697cd8bfb6e0a38415
 
 source-repository-package
     type: git

--- a/cabal.project
+++ b/cabal.project
@@ -55,7 +55,7 @@ package yet-another-logger
 source-repository-package
     type: git
     location: https://github.com/kadena-io/pact.git
-    tag: 60087f3b15f19ec103211a697cd8bfb6e0a38415
+    tag: 64d58454d277394bfcbfc1882cdd2af343f8dd81
 
 source-repository-package
     type: git

--- a/cabal.project
+++ b/cabal.project
@@ -55,7 +55,7 @@ package yet-another-logger
 source-repository-package
     type: git
     location: https://github.com/kadena-io/pact.git
-    tag: bb6476de0fe56858a80f179d256809676885d0cb
+    tag: 21340f5952c167056afcf84bee4686f70e86a207
 
 source-repository-package
     type: git

--- a/src/Chainweb/Pact/PactService.hs
+++ b/src/Chainweb/Pact/PactService.hs
@@ -438,6 +438,7 @@ attemptBuyGas miner (PactDbEnv' dbEnv) txs = do
                 , _txGasUsed = 0
                 , _txGasId = Nothing
                 , _txGasModel = P._geGasModel P.freeGasEnv
+                , _txWarnings = mempty
                 }
 
         buyGasEnv <- createGasEnv db cmd gasPrice gasLimit

--- a/src/Chainweb/Pact/PactService.hs
+++ b/src/Chainweb/Pact/PactService.hs
@@ -68,6 +68,7 @@ import qualified Pact.Types.Hash as P
 import qualified Pact.Types.Logger as P
 import qualified Pact.Types.Runtime as P
 import qualified Pact.Types.SPV as P
+import qualified Pact.Types.Pretty as P
 
 import Chainweb.BlockHash
 import Chainweb.BlockHeader
@@ -675,7 +676,8 @@ execLocal cwtx preflight sigVerify rdepth = withDiscardedBatch $ do
                   initialGas mc ApplyLocal
 
                 let cr' = toHashCommandResult cr
-                pure $ LocalResultWithWarns cr' warns
+                    warns' = P.renderCompactText <$> toList warns
+                pure $ LocalResultWithWarns cr' warns'
               Left e -> pure $ MetadataValidationFailure e
           _ ->  liftIO $ do
             cr <- applyLocal

--- a/src/Chainweb/Pact/PactService.hs
+++ b/src/Chainweb/Pact/PactService.hs
@@ -437,6 +437,7 @@ attemptBuyGas miner (PactDbEnv' dbEnv) txs = do
                 , _txGasUsed = 0
                 , _txGasId = Nothing
                 , _txGasModel = P._geGasModel P.freeGasEnv
+                , _txWarnings = mempty
                 }
 
         buyGasEnv <- createGasEnv db cmd gasPrice gasLimit
@@ -630,7 +631,7 @@ execLocal
       -- ^ turn off signature verification checks?
     -> Maybe BlockHeight
       -- ^ rewind depth (note: this is a *depth*, not an absolute height)
-    -> PactServiceM tbl (Either MetadataValidationFailure (P.CommandResult P.Hash))
+    -> PactServiceM tbl LocalResult
 execLocal cwtx preflight sigVerify rdepth = withDiscardedBatch $ do
     PactServiceEnv{..} <- ask
 
@@ -668,20 +669,24 @@ execLocal cwtx preflight sigVerify rdepth = withDiscardedBatch $ do
           Just PreflightSimulation -> do
             assertLocalMetadata cmd ctx sigVerify >>= \case
               Right{} -> do
-                T2 cr _mc' <- liftIO $ applyCmd
+                T3 cr _mc warns <- liftIO $ applyCmd
                   _psVersion logger _psGasLogger pdbenv
                   noMiner chainweb213GasModel ctx spv cmd
                   initialGas mc ApplyLocal
-                pure $ Right cr
-              Left e -> pure $ Left e
+
+                let cr' = toHashCommandResult cr
+                pure $ LocalResultWithWarns cr' warns
+              Left e -> pure $ MetadataValidationFailure e
           _ ->  liftIO $ do
             cr <- applyLocal
               logger _psGasLogger pdbenv
               chainweb213GasModel ctx spv
               cwtx mc execConfig
-            pure $ Right cr
 
-        return $ Discard (toHashCommandResult <$> r)
+            let cr' = toHashCommandResult cr
+            pure $ LocalResultLegacy cr'
+
+        return $ Discard r
 
 execSyncToBlock
     :: CanReadablePayloadCas tbl

--- a/src/Chainweb/Pact/PactService.hs
+++ b/src/Chainweb/Pact/PactService.hs
@@ -438,7 +438,6 @@ attemptBuyGas miner (PactDbEnv' dbEnv) txs = do
                 , _txGasUsed = 0
                 , _txGasId = Nothing
                 , _txGasModel = P._geGasModel P.freeGasEnv
-                , _txWarnings = mempty
                 }
 
         buyGasEnv <- createGasEnv db cmd gasPrice gasLimit

--- a/src/Chainweb/Pact/PactService/ExecBlock.hs
+++ b/src/Chainweb/Pact/PactService/ExecBlock.hs
@@ -423,7 +423,8 @@ applyPactCmd isGenesis env miner txTimeLimit cmd = StateT $ \(T2 mcache maybeBlo
             Nothing -> id
             Just limit ->
                maybe (throwM timeoutError) return <=< timeout (fromIntegral limit)
-        liftIO $! txTimeout $ applyCmd v logger gasLogger env miner (gasModel pd) pd spv gasLimitedCmd initialGas mcache ApplySend
+        T3 r c _warns <- liftIO $! txTimeout $ applyCmd v logger gasLogger env miner (gasModel pd) pd spv gasLimitedCmd initialGas mcache ApplySend
+        pure $ T2 r c
 
     if isGenesis
     then updateInitCache mcache'

--- a/src/Chainweb/Pact/RestAPI.hs
+++ b/src/Chainweb/Pact/RestAPI.hs
@@ -54,6 +54,9 @@ module Chainweb.Pact.RestAPI
 ) where
 
 
+import Data.Text (Text)
+
+import qualified Pact.Types.Command as Pact
 import Pact.Server.API as API
 
 import Servant
@@ -131,10 +134,12 @@ pactPollApi = Proxy
 -- POST Queries for Pact Local Pre-flight
 
 type PactLocalWithQueryApi_
-    = QueryParam "preflight" LocalPreflightSimulation
+    = "local"
+    :> QueryParam "preflight" LocalPreflightSimulation
     :> QueryParam "signatureVerification" LocalSignatureVerification
     :> QueryParam "rewindDepth" BlockHeight
-    :> ApiLocal
+    :> ReqBody '[JSON] (Pact.Command Text)
+    :> Post '[JSON] LocalResult
 
 type PactLocalWithQueryApi v c = PactV1ApiEndpoint v c PactLocalWithQueryApi_
 

--- a/src/Chainweb/Pact/RestAPI/Client.hs
+++ b/src/Chainweb/Pact/RestAPI/Client.hs
@@ -160,7 +160,7 @@ pactLocalWithQueryApiClient_
     -> Maybe LocalSignatureVerification
     -> Maybe BlockHeight
     -> Command T.Text
-    -> ClientM (CommandResult Hash)
+    -> ClientM LocalResult
 pactLocalWithQueryApiClient_ = client (pactLocalWithQueryApi @v @c)
 
 pactLocalWithQueryApiClient
@@ -170,7 +170,7 @@ pactLocalWithQueryApiClient
     -> Maybe LocalSignatureVerification
     -> Maybe BlockHeight
     -> Command T.Text
-    -> ClientM (CommandResult Hash)
+    -> ClientM LocalResult
 pactLocalWithQueryApiClient
     (FromSingChainwebVersion (SChainwebVersion :: Sing v))
     (FromSingChainId (SChainId :: Sing c))

--- a/src/Chainweb/Pact/RestAPI/Server.hs
+++ b/src/Chainweb/Pact/RestAPI/Server.hs
@@ -355,9 +355,13 @@ localHandler logger pact preflight sigVerify rewindDepth cmd = do
     case r of
       Left err -> throwError $ err400
         { errBody = "Execution failed: " <> BSL8.pack (show err) }
-      Right (Left (MetadataValidationFailure e)) -> throwError $ err400
-        { errBody = "Metadata validation failed: " <> BSL8.pack (show e) }
-      Right (Right resp) -> pure resp
+      Right (MetadataValidationFailure e) -> do
+        throwError $ err400
+          { errBody = "Metadata validation failed: " <> BSL8.pack (show e) }
+      Right (LocalResultWithWarns _cr warns) -> do
+        let _prettyWarns = pretty <$> toList warns
+        pure undefined
+      Right (LocalResultLegacy cr) -> pure cr
   where
     logg = logFunctionJson (setComponent "local-handler" logger)
 

--- a/src/Chainweb/Pact/RestAPI/Server.hs
+++ b/src/Chainweb/Pact/RestAPI/Server.hs
@@ -343,7 +343,7 @@ localHandler
     -> Maybe BlockHeight
       -- ^ Rewind depth
     -> Command Text
-    -> Handler (CommandResult Hash)
+    -> Handler LocalResult
 localHandler logger pact preflight sigVerify rewindDepth cmd = do
     liftIO $ logg Info $ PactCmdLogLocal cmd
     cmd' <- case doCommandValidation cmd of
@@ -358,10 +358,7 @@ localHandler logger pact preflight sigVerify rewindDepth cmd = do
       Right (MetadataValidationFailure e) -> do
         throwError $ err400
           { errBody = "Metadata validation failed: " <> BSL8.pack (show e) }
-      Right (LocalResultWithWarns _cr warns) -> do
-        let _prettyWarns = pretty <$> toList warns
-        pure undefined
-      Right (LocalResultLegacy cr) -> pure cr
+      Right lr -> pure lr
   where
     logg = logFunctionJson (setComponent "local-handler" logger)
 

--- a/src/Chainweb/Pact/Service/BlockValidation.hs
+++ b/src/Chainweb/Pact/Service/BlockValidation.hs
@@ -29,7 +29,6 @@ import Control.Concurrent.MVar.Strict
 import Data.Aeson (Value)
 import Data.Vector (Vector)
 
-import Pact.Types.Command
 import Pact.Types.Hash
 import Pact.Types.Persistence (RowKey, TxLog)
 
@@ -76,7 +75,7 @@ local
     -> Maybe BlockHeight
     -> ChainwebTransaction
     -> PactQueue
-    -> IO (MVar (Either PactException (Either MetadataValidationFailure (CommandResult Hash))))
+    -> IO (MVar (Either PactException LocalResult))
 local preflight sigVerify rd ct reqQ = do
     !resultVar <- newEmptyMVar
     let !msg = LocalMsg LocalReq

--- a/src/Chainweb/Pact/Service/Types.hs
+++ b/src/Chainweb/Pact/Service/Types.hs
@@ -9,6 +9,7 @@
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE ExistentialQuantification #-}
+{-# LANGUAGE TemplateHaskell #-}
 -- |
 -- Module: Chainweb.Pact.Service.Types
 -- Copyright: Copyright © 2018 Kadena LLC.
@@ -22,6 +23,7 @@ module Chainweb.Pact.Service.Types where
 
 import Control.DeepSeq
 import Control.Concurrent.MVar.Strict
+import Control.Lens hiding ((.=))
 import Control.Monad.Catch
 import Control.Applicative
 
@@ -109,6 +111,13 @@ data LocalResult
     | LocalResultWithWarns !(CommandResult Hash) ![Text]
     | LocalResultLegacy !(CommandResult Hash)
     deriving (Show, Generic)
+
+makePrisms ''LocalResult
+
+instance NFData LocalResult where
+    rnf (MetadataValidationFailure t) = rnf t
+    rnf (LocalResultWithWarns cr ws) = rnf cr `seq` rnf ws
+    rnf (LocalResultLegacy cr) = rnf cr
 
 instance ToJSON LocalResult where
   toJSON (MetadataValidationFailure e) = object

--- a/src/Chainweb/Pact/TransactionExec.hs
+++ b/src/Chainweb/Pact/TransactionExec.hs
@@ -105,7 +105,7 @@ import Chainweb.Pact.Templates
 import Chainweb.Pact.Transactions.UpgradeTransactions
 import Chainweb.Pact.Types hiding (logError)
 import Chainweb.Transaction
-import Chainweb.Utils (encodeToByteString, sshow, tryAllSynchronous, T2(..))
+import Chainweb.Utils (encodeToByteString, sshow, tryAllSynchronous, T2(..), T3(..))
 import Chainweb.Version as V
 
 
@@ -158,14 +158,20 @@ applyCmd
       -- ^ cached module state
     -> ApplyCmdExecutionContext
       -- ^ is this a local or send execution context?
-    -> IO (T2 (CommandResult [TxLog Value]) ModuleCache)
-applyCmd v logger gasLogger pdbenv miner gasModel txCtx spv cmd initialGas mcache0 callCtx =
-    second _txCache <$!>
-      runTransactionM cenv txst applyBuyGas
+    -> IO (T3 (CommandResult [TxLog Value]) ModuleCache (S.Set PactWarning))
+applyCmd v logger gasLogger pdbenv miner gasModel txCtx spv cmd initialGas mcache0 callCtx = do
+    T2 cr st <- runTransactionM cenv txst applyBuyGas
+
+    let cache = _txCache st
+        warns = _txWarnings st
+
+    pure $ T3 cr cache warns
   where
-    txst = TransactionState mcache0 mempty 0 Nothing $
-      if chainweb217Pact' then gasModel
-      else _geGasModel freeGasEnv
+    stGasModel
+      | chainweb217Pact' = gasModel
+      | otherwise = _geGasModel freeGasEnv
+    txst = TransactionState mcache0 mempty 0 Nothing stGasModel mempty
+
 
     executionConfigNoHistory = mkExecutionConfig
       $ FlagDisableHistoryInTransactionalMode
@@ -292,6 +298,7 @@ applyGenesisCmd logger dbEnv spv cmd =
         , _txGasUsed = 0
         , _txGasId = Nothing
         , _txGasModel = _geGasModel freeGasEnv
+        , _txWarnings = mempty
         }
 
     interp = initStateInterpreter
@@ -352,7 +359,7 @@ applyCoinbase v logger dbEnv (Miner mid mks@(MinerKeys mk)) reward@(ParsedDecima
       enablePact45 txCtx
     tenv = TransactionEnv Transactional dbEnv logger Nothing (ctxToPublicData txCtx) noSPVSupport
            Nothing 0.0 rk 0 ec
-    txst = TransactionState mc mempty 0 Nothing (_geGasModel freeGasEnv)
+    txst = TransactionState mc mempty 0 Nothing (_geGasModel freeGasEnv) mempty
     initState = setModuleCache mc $ initCapabilities [magic_COINBASE]
     rk = RequestKey chash
     parent = _tcParentHeader txCtx
@@ -430,7 +437,7 @@ applyLocal logger gasLogger dbEnv gasModel txCtx spv cmdIn mc execConfig =
     gasLimit = view cmdGasLimit cmd
     tenv = TransactionEnv Local dbEnv logger gasLogger (ctxToPublicData txCtx) spv nid gasPrice
            rk (fromIntegral gasLimit) execConfig
-    txst = TransactionState mc mempty 0 Nothing gasModel
+    txst = TransactionState mc mempty 0 Nothing gasModel mempty
     gas0 = initialGasOf (_cmdPayload cmdIn)
 
     applyPayload m = do
@@ -476,7 +483,7 @@ readInitModules logger dbEnv txCtx
     chash = pactInitialHash
     tenv = TransactionEnv Local dbEnv logger Nothing (ctxToPublicData txCtx) noSPVSupport nid 0.0
            rk 0 def
-    txst = TransactionState mempty mempty 0 Nothing (_geGasModel freeGasEnv)
+    txst = TransactionState mempty mempty 0 Nothing (_geGasModel freeGasEnv) mempty
     interp = defaultInterpreter
     die msg = throwM $ PactInternalError $ "readInitModules: " <> msg
     mkCmd = buildExecParsedCode (Just (v, h)) Nothing
@@ -663,6 +670,7 @@ runPayload cmd nsp = do
       Continuation ym ->
         applyContinuation g0 interp ym signers chash nsp
 
+
   where
     signers = _pSigners $ _cmdPayload cmd
     chash = toUntypedHash $ _cmdHash cmd
@@ -700,6 +708,10 @@ applyExec initialGas interp em senderSigs hsh nsp = do
     for_ _erLogGas $ \gl -> gasLog $ "gas logs: " <> sshow gl
     logs <- use txLogs
     rk <- view txRequestKey
+
+    -- set tx warnings to eval warnings
+    txWarnings .= _erWarnings
+
     -- applyExec enforces non-empty expression set so `last` ok
     -- forcing it here for lazy errors. TODO NFData the Pacts
     lastResult <- return $!! last _erOutput
@@ -807,6 +819,10 @@ applyContinuation initialGas interp cm senderSigs hsh nsp = do
     for_ _erLogGas $ \gl -> gasLog $ "gas logs: " <> sshow gl
     logs <- use txLogs
     rk <- view txRequestKey
+
+    -- set tx warnings to eval warnings
+    txWarnings .= _erWarnings
+
     -- last safe here because cont msg is guaranteed one exp
     return $! (CommandResult rk _erTxId (PactResult (Right (last _erOutput)))
       _erGas (Just logs) _erExec Nothing) _erEvents

--- a/src/Chainweb/Pact/TransactionExec.hs
+++ b/src/Chainweb/Pact/TransactionExec.hs
@@ -6,7 +6,6 @@
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TupleSections #-}
 -- |
 -- Module      :  Chainweb.Pact.TransactionExec
 -- Copyright   :  Copyright © 2018 Kadena LLC.
@@ -61,6 +60,7 @@ import Control.Monad.Trans.Maybe
 
 import Data.Aeson hiding ((.=))
 import qualified Data.Aeson as A
+import Data.Bifunctor
 import qualified Data.ByteString as B
 import qualified Data.ByteString.Short as SB
 import Data.Decimal (Decimal, roundTo)
@@ -160,16 +160,17 @@ applyCmd
       -- ^ is this a local or send execution context?
     -> IO (T3 (CommandResult [TxLog Value]) ModuleCache (S.Set PactWarning))
 applyCmd v logger gasLogger pdbenv miner gasModel txCtx spv cmd initialGas mcache0 callCtx = do
-    T2 (cr, warns) st <- runTransactionM cenv txst applyBuyGas
+    T2 cr st <- runTransactionM cenv txst applyBuyGas
 
     let cache = _txCache st
+        warns = _txWarnings st
 
     pure $ T3 cr cache warns
   where
     stGasModel
       | chainweb217Pact' = gasModel
       | otherwise = _geGasModel freeGasEnv
-    txst = TransactionState mcache0 mempty 0 Nothing stGasModel
+    txst = TransactionState mcache0 mempty 0 Nothing stGasModel mempty
 
 
     executionConfigNoHistory = mkExecutionConfig
@@ -208,19 +209,18 @@ applyCmd v logger gasLogger pdbenv miner gasModel txCtx spv cmd initialGas mcach
       PactError EvalError _ _ doc -> "Unknown primitive" `T.isInfixOf` renderCompactText' doc
       _ -> False
 
-    redeemAllGas warns r = do
+    redeemAllGas r = do
       txGasUsed .= fromIntegral gasLimit
-      applyRedeem warns r
+      applyRedeem r
 
-    applyBuyGas = do
+    applyBuyGas =
       catchesPactError (buyGas isPactBackCompatV16 cmd miner) >>= \case
         Left e -> view txRequestKey >>= \rk ->
           throwM $ BuyGasFailure $ GasPurchaseFailure (requestKeyToTransactionHash rk) e
-        Right _ -> checkTooBigTx initialGas gasLimit applyPayload (redeemAllGas mempty)
+        Right _ -> checkTooBigTx initialGas gasLimit applyPayload redeemAllGas
 
     applyPayload = do
       txGasModel .= gasModel
-
       if chainweb217Pact' then txGasUsed += initialGas
       else txGasUsed .= initialGas
 
@@ -232,16 +232,16 @@ applyCmd v logger gasLogger pdbenv miner gasModel txCtx spv cmd initialGas mcach
                   ApplyLocal -> e
                   ApplySend -> toEmptyPactError e
             r <- jsonErrorResult e' "tx failure for request key when running cmd"
-            redeemAllGas mempty r
+            redeemAllGas r
           | chainweb213Pact' || not (isOldListErr e) -> do
               r <- jsonErrorResult e "tx failure for request key when running cmd"
-              redeemAllGas mempty r
+              redeemAllGas r
           | otherwise -> do
               r <- jsonErrorResult (toOldListErr e) "tx failure for request key when running cmd"
-              redeemAllGas mempty r
-        Right (r, ws) -> applyRedeem ws r
+              redeemAllGas r
+        Right r -> applyRedeem r
 
-    applyRedeem warns cr = do
+    applyRedeem cr = do
       txGasModel .= (_geGasModel freeGasEnv)
 
       r <- catchesPactError $! redeemGas cmd
@@ -251,8 +251,7 @@ applyCmd v logger gasLogger pdbenv miner gasModel txCtx spv cmd initialGas mcach
           fatal $ "tx failure for request key while redeeming gas: " <> sshow e
         Right es -> do
           logs <- use txLogs
-          let loggedCr = set crLogs (Just logs) $ over crEvents (es ++) cr
-          pure (loggedCr, warns)
+          return $! set crLogs (Just logs) $ over crEvents (es ++) cr
 
 listErrMsg :: Doc
 listErrMsg =
@@ -268,10 +267,8 @@ applyGenesisCmd
     -> Command (Payload PublicMeta ParsedCode)
       -- ^ command with payload to execute
     -> IO (T2 (CommandResult [TxLog Value]) ModuleCache)
-applyGenesisCmd logger dbEnv spv cmd = do
-    T2 r st <- runTransactionM tenv txst go
-    let mc = _txCache st
-    pure $ T2 r mc
+applyGenesisCmd logger dbEnv spv cmd =
+    second _txCache <$!> runTransactionM tenv txst go
   where
     nid = networkIdOf cmd
     rk = cmdToRequestKey cmd
@@ -301,6 +298,7 @@ applyGenesisCmd logger dbEnv spv cmd = do
         , _txGasUsed = 0
         , _txGasId = Nothing
         , _txGasModel = _geGasModel freeGasEnv
+        , _txWarnings = mempty
         }
 
     interp = initStateInterpreter
@@ -361,7 +359,7 @@ applyCoinbase v logger dbEnv (Miner mid mks@(MinerKeys mk)) reward@(ParsedDecima
       enablePact45 txCtx
     tenv = TransactionEnv Transactional dbEnv logger Nothing (ctxToPublicData txCtx) noSPVSupport
            Nothing 0.0 rk 0 ec
-    txst = TransactionState mc mempty 0 Nothing (_geGasModel freeGasEnv)
+    txst = TransactionState mc mempty 0 Nothing (_geGasModel freeGasEnv) mempty
     initState = setModuleCache mc $ initCapabilities [magic_COINBASE]
     rk = RequestKey chash
     parent = _tcParentHeader txCtx
@@ -428,7 +426,7 @@ applyLocal
     -> ExecutionConfig
     -> IO (CommandResult [TxLog Value])
 applyLocal logger gasLogger dbEnv gasModel txCtx spv cmdIn mc execConfig =
-    fst <$> evalTransactionM tenv txst go
+    evalTransactionM tenv txst go
   where
     cmd = payloadObj <$> cmdIn
     rk = cmdToRequestKey cmd
@@ -439,7 +437,7 @@ applyLocal logger gasLogger dbEnv gasModel txCtx spv cmdIn mc execConfig =
     gasLimit = view cmdGasLimit cmd
     tenv = TransactionEnv Local dbEnv logger gasLogger (ctxToPublicData txCtx) spv nid gasPrice
            rk (fromIntegral gasLimit) execConfig
-    txst = TransactionState mc mempty 0 Nothing gasModel
+    txst = TransactionState mc mempty 0 Nothing gasModel mempty
     gas0 = initialGasOf (_cmdPayload cmdIn)
 
     applyPayload m = do
@@ -451,14 +449,10 @@ applyLocal logger gasLogger dbEnv gasModel txCtx spv cmdIn mc execConfig =
           applyContinuation gas0 interp cm signers chash managedNamespacePolicy
 
       case cr of
-        Left e -> do
-          r <- jsonErrorResult e "applyLocal"
-          pure (r, mempty)
-        Right (r, ws) -> do
-          let r' = r { _crMetaData = Just (toJSON $ ctxToPublicData' txCtx) }
-          pure (r', ws)
+        Left e -> jsonErrorResult e "applyLocal"
+        Right r -> return $! r { _crMetaData = Just (toJSON $ ctxToPublicData' txCtx) }
 
-    go = checkTooBigTx gas0 gasLimit (applyPayload $ _pPayload $ _cmdPayload cmd) (return . (,mempty))
+    go = checkTooBigTx gas0 gasLimit (applyPayload $ _pPayload $ _cmdPayload cmd) return
 
 
 readInitModules
@@ -489,7 +483,7 @@ readInitModules logger dbEnv txCtx
     chash = pactInitialHash
     tenv = TransactionEnv Local dbEnv logger Nothing (ctxToPublicData txCtx) noSPVSupport nid 0.0
            rk 0 def
-    txst = TransactionState mempty mempty 0 Nothing (_geGasModel freeGasEnv)
+    txst = TransactionState mempty mempty 0 Nothing (_geGasModel freeGasEnv) mempty
     interp = defaultInterpreter
     die msg = throwM $ PactInternalError $ "readInitModules: " <> msg
     mkCmd = buildExecParsedCode (Just (v, h)) Nothing
@@ -665,7 +659,7 @@ jsonErrorResult err msg = do
 runPayload
     :: Command (Payload PublicMeta ParsedCode)
     -> NamespacePolicy
-    -> TransactionM p (CommandResult [TxLog Value], S.Set PactWarning)
+    -> TransactionM p (CommandResult [TxLog Value])
 runPayload cmd nsp = do
     g0 <- use txGasUsed
     interp <- gasInterpreter g0
@@ -689,13 +683,11 @@ runGenesis
     -> NamespacePolicy
     -> Interpreter p
     -> TransactionM p (CommandResult [TxLog Value])
-runGenesis cmd nsp interp = do
-    (r, _) <- case payload of
-      Exec pm ->
-        applyExec 0 interp pm signers chash nsp
-      Continuation ym ->
-        applyContinuation 0 interp ym signers chash nsp
-    pure r
+runGenesis cmd nsp interp = case payload of
+    Exec pm ->
+      applyExec 0 interp pm signers chash nsp
+    Continuation ym ->
+      applyContinuation 0 interp ym signers chash nsp
   where
     signers = _pSigners $ _cmdPayload cmd
     chash = toUntypedHash $ _cmdHash cmd
@@ -710,21 +702,21 @@ applyExec
     -> [Signer]
     -> Hash
     -> NamespacePolicy
-    -> TransactionM p (CommandResult [TxLog Value], S.Set PactWarning)
+    -> TransactionM p (CommandResult [TxLog Value])
 applyExec initialGas interp em senderSigs hsh nsp = do
     EvalResult{..} <- applyExec' initialGas interp em senderSigs hsh nsp
     for_ _erLogGas $ \gl -> gasLog $ "gas logs: " <> sshow gl
     logs <- use txLogs
     rk <- view txRequestKey
 
+    -- set tx warnings to eval warnings
+    txWarnings .= _erWarnings
+
     -- applyExec enforces non-empty expression set so `last` ok
     -- forcing it here for lazy errors. TODO NFData the Pacts
     lastResult <- return $!! last _erOutput
-    let cr = CommandResult
-          rk _erTxId (PactResult (Right lastResult))
-          _erGas (Just logs) _erExec Nothing _erEvents
-
-    pure (cr, _erWarnings)
+    return $! CommandResult rk _erTxId (PactResult (Right lastResult))
+      _erGas (Just logs) _erExec Nothing _erEvents
 
 -- | Variation on 'applyExec' that returns 'EvalResult' as opposed to
 -- wrapping it up in a JSON result.
@@ -821,19 +813,20 @@ applyContinuation
     -> [Signer]
     -> Hash
     -> NamespacePolicy
-    -> TransactionM p (CommandResult [TxLog Value], S.Set PactWarning)
+    -> TransactionM p (CommandResult [TxLog Value])
 applyContinuation initialGas interp cm senderSigs hsh nsp = do
     EvalResult{..} <- applyContinuation' initialGas interp cm senderSigs hsh nsp
     for_ _erLogGas $ \gl -> gasLog $ "gas logs: " <> sshow gl
     logs <- use txLogs
     rk <- view txRequestKey
 
-    -- last safe here because cont msg is guaranteed one exp
-    let cr = CommandResult
-          rk _erTxId (PactResult (Right (last _erOutput)))
-          _erGas (Just logs) _erExec Nothing _erEvents
+    -- set tx warnings to eval warnings
+    txWarnings .= _erWarnings
 
-    pure (cr, _erWarnings)
+    -- last safe here because cont msg is guaranteed one exp
+    return $! (CommandResult rk _erTxId (PactResult (Right (last _erOutput)))
+      _erGas (Just logs) _erExec Nothing) _erEvents
+
 
 setEnvGas ::  Gas -> EvalEnv e -> TransactionM p ()
 setEnvGas initialGas = liftIO . views eeGas (`writeIORef` initialGas)
@@ -980,11 +973,10 @@ redeemGas cmd = do
 
     fee <- gasSupplyOf <$> use txGasUsed <*> view txGasPrice
 
-    (cr, _) <- applyContinuation 0 (initState mcache) (redeemGasCmd fee gid)
+    _crEvents <$> applyContinuation 0 (initState mcache) (redeemGasCmd fee gid)
       (_pSigners $ _cmdPayload cmd) (toUntypedHash $ _cmdHash cmd)
       managedNamespacePolicy
 
-    pure $ _crEvents cr
   where
     initState mc = initStateInterpreter
       $ setModuleCache mc
@@ -1014,9 +1006,9 @@ initStateInterpreter s = Interpreter (put s >>)
 checkTooBigTx
     :: Gas
     -> GasLimit
-    -> TransactionM p (CommandResult [TxLog Value], S.Set PactWarning)
-    -> (CommandResult [TxLog Value] -> TransactionM p (CommandResult [TxLog Value], S.Set PactWarning))
-    -> TransactionM p (CommandResult [TxLog Value], S.Set PactWarning)
+    -> TransactionM p (CommandResult [TxLog Value])
+    -> (CommandResult [TxLog Value] -> TransactionM p (CommandResult [TxLog Value]))
+    -> TransactionM p (CommandResult [TxLog Value])
 checkTooBigTx initialGas gasLimit next onFail
   | initialGas >= (fromIntegral gasLimit) = do
       txGasUsed .= (fromIntegral gasLimit) -- all gas is consumed

--- a/src/Chainweb/Pact/TransactionExec.hs
+++ b/src/Chainweb/Pact/TransactionExec.hs
@@ -709,8 +709,8 @@ applyExec initialGas interp em senderSigs hsh nsp = do
     logs <- use txLogs
     rk <- view txRequestKey
 
-    -- set tx warnings to eval warnings
-    txWarnings .= _erWarnings
+    -- concat tx warnings with eval warnings
+    txWarnings <>= _erWarnings
 
     -- applyExec enforces non-empty expression set so `last` ok
     -- forcing it here for lazy errors. TODO NFData the Pacts
@@ -821,7 +821,7 @@ applyContinuation initialGas interp cm senderSigs hsh nsp = do
     rk <- view txRequestKey
 
     -- set tx warnings to eval warnings
-    txWarnings .= _erWarnings
+    txWarnings <>= _erWarnings
 
     -- last safe here because cont msg is guaranteed one exp
     return $! (CommandResult rk _erTxId (PactResult (Right (last _erOutput)))

--- a/src/Chainweb/Pact/Types.hs
+++ b/src/Chainweb/Pact/Types.hs
@@ -44,7 +44,6 @@ module Chainweb.Pact.Types
   , txGasId
   , txLogs
   , txCache
-  , txWarnings
 
     -- * Transaction Env
   , TransactionEnv(..)
@@ -153,7 +152,6 @@ import Data.Aeson hiding (Error,(.=))
 import Data.Default (def)
 import Data.HashMap.Strict (HashMap)
 import qualified Data.HashMap.Strict as HM
-import Data.Set (Set)
 import qualified Data.Map.Strict as M
 import Data.Text (pack, unpack, Text)
 import Data.Vector (Vector)
@@ -174,7 +172,7 @@ import Pact.Types.Gas
 import qualified Pact.Types.Logger as P
 import Pact.Types.Names
 import Pact.Types.Persistence (ExecutionMode, TxLog)
-import Pact.Types.Runtime (ExecutionConfig(..), ModuleData(..), PactWarning)
+import Pact.Types.Runtime (ExecutionConfig(..), ModuleData(..))
 import Pact.Types.SPV
 import Pact.Types.Term
 
@@ -248,7 +246,6 @@ data TransactionState = TransactionState
     , _txGasUsed :: !Gas
     , _txGasId :: !(Maybe GasId)
     , _txGasModel :: !GasModel
-    , _txWarnings :: Set PactWarning
     }
 makeLenses ''TransactionState
 

--- a/src/Chainweb/Pact/Types.hs
+++ b/src/Chainweb/Pact/Types.hs
@@ -44,6 +44,7 @@ module Chainweb.Pact.Types
   , txGasId
   , txLogs
   , txCache
+  , txWarnings
 
     -- * Transaction Env
   , TransactionEnv(..)
@@ -152,6 +153,7 @@ import Data.Aeson hiding (Error,(.=))
 import Data.Default (def)
 import Data.HashMap.Strict (HashMap)
 import qualified Data.HashMap.Strict as HM
+import Data.Set (Set)
 import qualified Data.Map.Strict as M
 import Data.Text (pack, unpack, Text)
 import Data.Vector (Vector)
@@ -172,7 +174,7 @@ import Pact.Types.Gas
 import qualified Pact.Types.Logger as P
 import Pact.Types.Names
 import Pact.Types.Persistence (ExecutionMode, TxLog)
-import Pact.Types.Runtime (ExecutionConfig(..), ModuleData(..))
+import Pact.Types.Runtime (ExecutionConfig(..), ModuleData(..), PactWarning)
 import Pact.Types.SPV
 import Pact.Types.Term
 
@@ -246,6 +248,7 @@ data TransactionState = TransactionState
     , _txGasUsed :: !Gas
     , _txGasId :: !(Maybe GasId)
     , _txGasModel :: !GasModel
+    , _txWarnings :: Set PactWarning
     }
 makeLenses ''TransactionState
 

--- a/src/Chainweb/Pact/Validations.hs
+++ b/src/Chainweb/Pact/Validations.hs
@@ -35,6 +35,7 @@ import Control.Lens
 
 import Data.Decimal (decimalPlaces)
 import Data.Maybe (isJust)
+import Data.Text (Text)
 import Data.Word (Word8)
 
 -- internal modules
@@ -64,7 +65,7 @@ assertLocalMetadata
     :: P.Command (P.Payload P.PublicMeta c)
     -> TxContext
     -> Maybe LocalSignatureVerification
-    -> PactServiceM tbl (Either MetadataValidationFailure ())
+    -> PactServiceM tbl (Either Text ())
 assertLocalMetadata cmd@(P.Command pay sigs hsh) txCtx sigVerify = do
     v <- view psVersion
     cid <- view psChainId
@@ -97,7 +98,7 @@ assertLocalMetadata cmd@(P.Command pay sigs hsh) txCtx sigVerify = do
 
     eUnless t assertion
       | assertion = Right ()
-      | otherwise = Left $ MetadataValidationFailure t
+      | otherwise = Left t
 
 -- | Check whether a particular Pact chain id is parseable
 --

--- a/src/Chainweb/WebPactExecutionService.hs
+++ b/src/Chainweb/WebPactExecutionService.hs
@@ -38,7 +38,6 @@ import Chainweb.Payload
 import Chainweb.Transaction
 import Chainweb.Utils (T2)
 
-import Pact.Types.Command
 import Pact.Types.Hash
 import Pact.Types.Persistence (RowKey, TxLog)
 
@@ -66,7 +65,7 @@ data PactExecutionService = PactExecutionService
         Maybe LocalSignatureVerification ->
         Maybe BlockHeight ->
         ChainwebTransaction ->
-        IO (Either PactException (Either MetadataValidationFailure (CommandResult Hash))))
+        IO (Either PactException LocalResult))
       -- ^ Directly execute a single transaction in "local" mode (all DB interactions rolled back).
       -- Corresponds to `local` HTTP endpoint.
     , _pactLookup :: !(

--- a/test/Chainweb/Test/Pact/Checkpointer.hs
+++ b/test/Chainweb/Test/Pact/Checkpointer.hs
@@ -615,7 +615,7 @@ runExec cp (PactDbEnv' pactdbenv) eData eCode = do
     h' = H.toUntypedHash (H.hash "" :: H.PactHash)
     cmdenv = TransactionEnv Transactional pactdbenv (_cpeLogger cp) Nothing def
              noSPVSupport Nothing 0.0 (RequestKey h') 0 def
-    cmdst = TransactionState mempty mempty 0 Nothing (_geGasModel freeGasEnv) mempty
+    cmdst = TransactionState mempty mempty 0 Nothing (_geGasModel freeGasEnv)
 
 runCont :: CheckpointEnv -> PactDbEnv' -> PactId -> Int -> IO EvalResult
 runCont cp (PactDbEnv' pactdbenv) pactId step = do
@@ -627,7 +627,7 @@ runCont cp (PactDbEnv' pactdbenv) pactId step = do
     h' = H.toUntypedHash (H.hash "" :: H.PactHash)
     cmdenv = TransactionEnv Transactional pactdbenv (_cpeLogger cp) Nothing def
              noSPVSupport Nothing 0.0 (RequestKey h') 0 def
-    cmdst = TransactionState mempty mempty 0 Nothing (_geGasModel freeGasEnv) mempty
+    cmdst = TransactionState mempty mempty 0 Nothing (_geGasModel freeGasEnv)
 
 -- -------------------------------------------------------------------------- --
 -- Pact Utils

--- a/test/Chainweb/Test/Pact/Checkpointer.hs
+++ b/test/Chainweb/Test/Pact/Checkpointer.hs
@@ -615,7 +615,7 @@ runExec cp (PactDbEnv' pactdbenv) eData eCode = do
     h' = H.toUntypedHash (H.hash "" :: H.PactHash)
     cmdenv = TransactionEnv Transactional pactdbenv (_cpeLogger cp) Nothing def
              noSPVSupport Nothing 0.0 (RequestKey h') 0 def
-    cmdst = TransactionState mempty mempty 0 Nothing (_geGasModel freeGasEnv)
+    cmdst = TransactionState mempty mempty 0 Nothing (_geGasModel freeGasEnv) mempty
 
 runCont :: CheckpointEnv -> PactDbEnv' -> PactId -> Int -> IO EvalResult
 runCont cp (PactDbEnv' pactdbenv) pactId step = do
@@ -627,7 +627,7 @@ runCont cp (PactDbEnv' pactdbenv) pactId step = do
     h' = H.toUntypedHash (H.hash "" :: H.PactHash)
     cmdenv = TransactionEnv Transactional pactdbenv (_cpeLogger cp) Nothing def
              noSPVSupport Nothing 0.0 (RequestKey h') 0 def
-    cmdst = TransactionState mempty mempty 0 Nothing (_geGasModel freeGasEnv)
+    cmdst = TransactionState mempty mempty 0 Nothing (_geGasModel freeGasEnv) mempty
 
 -- -------------------------------------------------------------------------- --
 -- Pact Utils

--- a/test/Chainweb/Test/Pact/PactExec.hs
+++ b/test/Chainweb/Test/Pact/PactExec.hs
@@ -545,9 +545,10 @@ execLocalTest runPact name (trans',check) = testCaseSch name (go >>= check)
       results' <- tryAllSynchronous $ runPact $ \_ ->
         execLocal trans Nothing Nothing Nothing
       case results' of
-        Right (Left (MetadataValidationFailure e)) ->
+        Right (MetadataValidationFailure e) ->
           return $ Left $ show e
-        Right (Right cr) -> return $ Right cr
+        Right (LocalResultLegacy cr) -> return $ Right cr
+        Right (LocalResultWithWarns cr _) -> return $ Right cr
         Left e -> return $ Left $ show e
 
 getPactCode :: TestSource -> IO Text

--- a/test/Chainweb/Test/Pact/PactMultiChainTest.hs
+++ b/test/Chainweb/Test/Pact/PactMultiChainTest.hs
@@ -287,7 +287,7 @@ pact45UpgradeTest = do
   buildSimpleCmd code = buildBasicGas 3000
       $ mkExec' code
 
-runLocal :: ChainId -> CmdBuilder -> PactTestM (Either PactException (Either MetadataValidationFailure (CommandResult Hash)))
+runLocal :: ChainId -> CmdBuilder -> PactTestM (Either PactException LocalResult)
 runLocal cid' cmd = do
   HM.lookup cid' <$> view menvPacts >>= \case
     Just pact -> buildCwCmd cmd >>=
@@ -298,11 +298,11 @@ assertLocalFailure
     :: (HasCallStack, MonadIO m)
     => String
     -> Doc
-    -> Either PactException (Either MetadataValidationFailure (CommandResult Hash))
+    -> Either PactException LocalResult
     -> m ()
 assertLocalFailure s d lr =
   liftIO $ assertEqual s (Just d) $
-    lr ^? _Right . _Right . crResult . to _pactResult . _Left . to peDoc
+    lr ^? _Right . _LocalResultLegacy . crResult . to _pactResult . _Left . to peDoc
 
 pact43UpgradeTest :: PactTestM ()
 pact43UpgradeTest = do

--- a/test/Chainweb/Test/Pact/RemotePactTest.hs
+++ b/test/Chainweb/Test/Pact/RemotePactTest.hs
@@ -334,22 +334,9 @@ localPreflightSimTest iot nio = testCaseSteps "local preflight sim test" $ \step
     sigs1' <- testKeyPairs sender00 Nothing >>= \case
       [ks] -> pure $ replicate 101 ks
       _ -> assertFailure "/local test keypair construction failed"
+
     cmd6 <- mkRawTx mv pcid sigs1'
     runClientFailureAssertion sid cenv cmd6 "Signature list size too big"
-
-    step "Execute preflight /local tx - collect warnings"
-    cmd7 <- mkRawTx' mv pcid sigs0 "(+ 1 2.0)"
-    runLocalPreflightClient sid cenv cmd7 >>= \case
-      Left e -> assertFailure $ show e
-      Right LocalResultLegacy{} ->
-        assertFailure "Preflight /local call produced legacy result"
-      Right MetadataValidationFailure{} ->
-        assertFailure "Preflight produced an impossible result"
-      Right (LocalResultWithWarns _ ws) -> case ws of
-        [w] | "decimal/integer operator overload" `T.isInfixOf` w ->
-          pure ()
-        ws' -> assertFailure $ "Incorrect warns: " ++ show ws'
-
   where
     runLocalPreflightClient sid e cmd = flip runClientM e $
       pactLocalWithQueryApiClient v sid
@@ -369,15 +356,13 @@ localPreflightSimTest iot nio = testCaseSteps "local preflight sim test" $ \step
     -- would allow for us to modify the chain id to something
     -- unparsable. Hence we need to do this in the unparsable
     -- chain id case and nowhere else.
-    mkRawTx mv pcid kps = mkRawTx' mv pcid kps "(+ 1 2)"
-
-    mkRawTx' mv pcid kps code = modifyMVar mv $ \(nn :: Int) -> do
+    mkRawTx mv pcid kps = modifyMVar mv $ \(nn :: Int) -> do
       let nonce = "nonce" <> sshow nn
           ttl = 2 * 24 * 60 * 60
           pm = Pact.PublicMeta pcid "sender00" 1000 0.1 (fromInteger ttl)
 
       t <- toTxCreationTime <$> iot
-      c <- Pact.mkExec code A.Null (pm t) kps (Just "fastTimedCPM-peterson") (Just nonce)
+      c <- Pact.mkExec "(+ 1 2)" A.Null (pm t) kps (Just "fastTimedCPM-peterson") (Just nonce)
       pure (succ nn, c)
 
     mkCmdBuilder sigs nid pcid limit price = do

--- a/test/Chainweb/Test/Pact/RemotePactTest.hs
+++ b/test/Chainweb/Test/Pact/RemotePactTest.hs
@@ -290,7 +290,11 @@ localPreflightSimTest iot nio = testCaseSteps "local preflight sim test" $ \step
     cmd0 <- mkRawTx mv psid psigs
     runLocalPreflightClient sid cenv cmd0 >>= \case
       Left e -> assertFailure $ show e
-      Right{} -> pure ()
+      Right LocalResultLegacy{} ->
+        assertFailure "Preflight /local call produced legacy result"
+      Right MetadataValidationFailure{} ->
+        assertFailure "Preflight produced an impossible result"
+      Right LocalResultWithWarns{} -> pure ()
 
     step "Execute preflight /local tx - preflight+signoverify known /send success"
     cmd0' <- mkRawTx mv psid psigs

--- a/test/Chainweb/Test/Pact/RemotePactTest.hs
+++ b/test/Chainweb/Test/Pact/RemotePactTest.hs
@@ -334,9 +334,22 @@ localPreflightSimTest iot nio = testCaseSteps "local preflight sim test" $ \step
     sigs1' <- testKeyPairs sender00 Nothing >>= \case
       [ks] -> pure $ replicate 101 ks
       _ -> assertFailure "/local test keypair construction failed"
-
     cmd6 <- mkRawTx mv pcid sigs1'
     runClientFailureAssertion sid cenv cmd6 "Signature list size too big"
+
+    step "Execute preflight /local tx - collect warnings"
+    cmd7 <- mkRawTx' mv pcid sigs0 "(+ 1 2.0)"
+    runLocalPreflightClient sid cenv cmd7 >>= \case
+      Left e -> assertFailure $ show e
+      Right LocalResultLegacy{} ->
+        assertFailure "Preflight /local call produced legacy result"
+      Right MetadataValidationFailure{} ->
+        assertFailure "Preflight produced an impossible result"
+      Right (LocalResultWithWarns _ ws) -> case ws of
+        [w] | "decimal/integer operator overload" `T.isInfixOf` w ->
+          pure ()
+        ws' -> assertFailure $ "Incorrect warns: " ++ show ws'
+
   where
     runLocalPreflightClient sid e cmd = flip runClientM e $
       pactLocalWithQueryApiClient v sid
@@ -356,13 +369,15 @@ localPreflightSimTest iot nio = testCaseSteps "local preflight sim test" $ \step
     -- would allow for us to modify the chain id to something
     -- unparsable. Hence we need to do this in the unparsable
     -- chain id case and nowhere else.
-    mkRawTx mv pcid kps = modifyMVar mv $ \(nn :: Int) -> do
+    mkRawTx mv pcid kps = mkRawTx' mv pcid kps "(+ 1 2)"
+
+    mkRawTx' mv pcid kps code = modifyMVar mv $ \(nn :: Int) -> do
       let nonce = "nonce" <> sshow nn
           ttl = 2 * 24 * 60 * 60
           pm = Pact.PublicMeta pcid "sender00" 1000 0.1 (fromInteger ttl)
 
       t <- toTxCreationTime <$> iot
-      c <- Pact.mkExec "(+ 1 2)" A.Null (pm t) kps (Just "fastTimedCPM-peterson") (Just nonce)
+      c <- Pact.mkExec code A.Null (pm t) kps (Just "fastTimedCPM-peterson") (Just nonce)
       pure (succ nn, c)
 
     mkCmdBuilder sigs nid pcid limit price = do

--- a/test/Chainweb/Test/Pact/TransactionTests.hs
+++ b/test/Chainweb/Test/Pact/TransactionTests.hs
@@ -255,7 +255,7 @@ testCoinbase797DateFix = testCaseSteps "testCoinbase791Fix" $ \step -> do
       let h = H.toUntypedHash (H.hash "" :: H.PactHash)
           tenv = TransactionEnv Transactional pdb logger Nothing def
             noSPVSupport Nothing 0.0 (RequestKey h) 0 def
-          txst = TransactionState mempty mempty 0 Nothing (_geGasModel freeGasEnv)
+          txst = TransactionState mempty mempty 0 Nothing (_geGasModel freeGasEnv) mempty
 
       CommandResult _ _ (PactResult pr) _ _ _ _ _ <- evalTransactionM tenv txst $!
         applyExec 0 defaultInterpreter localCmd [] h permissiveNamespacePolicy

--- a/test/Chainweb/Test/Pact/TransactionTests.hs
+++ b/test/Chainweb/Test/Pact/TransactionTests.hs
@@ -255,9 +255,9 @@ testCoinbase797DateFix = testCaseSteps "testCoinbase791Fix" $ \step -> do
       let h = H.toUntypedHash (H.hash "" :: H.PactHash)
           tenv = TransactionEnv Transactional pdb logger Nothing def
             noSPVSupport Nothing 0.0 (RequestKey h) 0 def
-          txst = TransactionState mempty mempty 0 Nothing (_geGasModel freeGasEnv)
+          txst = TransactionState mempty mempty 0 Nothing (_geGasModel freeGasEnv) mempty
 
-      (CommandResult _ _ (PactResult pr) _ _ _ _ _, _warns) <- evalTransactionM tenv txst $!
+      CommandResult _ _ (PactResult pr) _ _ _ _ _ <- evalTransactionM tenv txst $!
         applyExec 0 defaultInterpreter localCmd [] h permissiveNamespacePolicy
 
       testResult pr

--- a/test/Chainweb/Test/Pact/TransactionTests.hs
+++ b/test/Chainweb/Test/Pact/TransactionTests.hs
@@ -255,9 +255,9 @@ testCoinbase797DateFix = testCaseSteps "testCoinbase791Fix" $ \step -> do
       let h = H.toUntypedHash (H.hash "" :: H.PactHash)
           tenv = TransactionEnv Transactional pdb logger Nothing def
             noSPVSupport Nothing 0.0 (RequestKey h) 0 def
-          txst = TransactionState mempty mempty 0 Nothing (_geGasModel freeGasEnv) mempty
+          txst = TransactionState mempty mempty 0 Nothing (_geGasModel freeGasEnv)
 
-      CommandResult _ _ (PactResult pr) _ _ _ _ _ <- evalTransactionM tenv txst $!
+      (CommandResult _ _ (PactResult pr) _ _ _ _ _, _warns) <- evalTransactionM tenv txst $!
         applyExec 0 defaultInterpreter localCmd [] h permissiveNamespacePolicy
 
       testResult pr

--- a/test/Chainweb/Test/RestAPI/Utils.hs
+++ b/test/Chainweb/Test/RestAPI/Utils.hs
@@ -130,7 +130,7 @@ localWithQueryParams
     -> Maybe LocalSignatureVerification
     -> Maybe BlockHeight
     -> Command Text
-    -> IO (CommandResult Hash)
+    -> IO LocalResult
 localWithQueryParams sid cenv pf sv rd cmd =
     recovering testRetryPolicy [h] $ \s -> do
       debug
@@ -155,8 +155,10 @@ local
     -> ClientEnv
     -> Command Text
     -> IO (CommandResult Hash)
-local sid cenv =
-    localWithQueryParams sid cenv Nothing Nothing Nothing
+local sid cenv cmd = do
+    LocalResultLegacy cr <-
+      localWithQueryParams sid cenv Nothing Nothing Nothing cmd
+    pure cr
 
 localTestToRetry
     :: ChainId

--- a/tools/cwtool/TxSimulator.hs
+++ b/tools/cwtool/TxSimulator.hs
@@ -100,7 +100,7 @@ simulate sc@(SimConfig dbDir txIdx' _ _ cid ver) = do
               PactDbEnv' pde <-
                 _cpRestore cp $ Just (succ (_blockHeight parent), _blockHash parent)
               mc <- readInitModules logger pde txc
-              (T2 !cr _mc) <-
+              T3 !cr _mc _ <-
                 trace (logFunction cwLogger) "applyCmd" () 1 $
                   applyCmd ver logger gasLogger pde miner (getGasModel txc)
                   txc noSPVSupport cmd (initGas cmdPwt) mc ApplySend


### PR DESCRIPTION
TODO: 

- [x] Hookup warning system
- [x] Decide on final datatypes for /local output
  - Should we have enriched local output that is `CommandResult` when legacy is called, with warnings defined when preflight?
- [ ] ~~Fold pact 4.6 prep into this pr?~~