### PR TITLE
Fix encoding wibbles in /local, return a list of validation failures

### DIFF
--- a/src/Chainweb/Pact/RestAPI/Server.hs
+++ b/src/Chainweb/Pact/RestAPI/Server.hs
@@ -357,7 +357,7 @@ localHandler logger pact preflight sigVerify rewindDepth cmd = do
         { errBody = "Execution failed: " <> BSL8.pack (show err) }
       Right (MetadataValidationFailure e) -> do
         throwError $ err400
-          { errBody = "Metadata validation failed: " <> BSL8.pack (show e) }
+          { errBody = "Metadata validation failed: " <> Aeson.encode e }
       Right lr -> pure lr
   where
     logg = logFunctionJson (setComponent "local-handler" logger)

--- a/src/Chainweb/Pact/Service/Types.hs
+++ b/src/Chainweb/Pact/Service/Types.hs
@@ -29,6 +29,7 @@ import Control.Applicative
 
 import Data.Aeson
 import Data.Map (Map)
+import Data.List.NonEmpty (NonEmpty)
 import Data.Text (Text, pack, unpack)
 import Data.Vector (Vector)
 
@@ -107,7 +108,7 @@ data LocalPreflightSimulation
 -- | The type of local results (used in /local endpoint)
 --
 data LocalResult
-    = MetadataValidationFailure ![Text]
+    = MetadataValidationFailure !(NonEmpty Text)
     | LocalResultWithWarns !(CommandResult Hash) ![Text]
     | LocalResultLegacy !(CommandResult Hash)
     deriving (Show, Generic)

--- a/src/Chainweb/Pact/Service/Types.hs
+++ b/src/Chainweb/Pact/Service/Types.hs
@@ -107,7 +107,7 @@ data LocalPreflightSimulation
 -- | The type of local results (used in /local endpoint)
 --
 data LocalResult
-    = MetadataValidationFailure !Text
+    = MetadataValidationFailure ![Text]
     | LocalResultWithWarns !(CommandResult Hash) ![Text]
     | LocalResultLegacy !(CommandResult Hash)
     deriving (Show, Generic)
@@ -121,7 +121,7 @@ instance NFData LocalResult where
 
 instance ToJSON LocalResult where
   toJSON (MetadataValidationFailure e) = object
-    [ "preflightValidationFailure" .= toJSON e ]
+    [ "preflightValidationFailures" .= e ]
   toJSON (LocalResultLegacy cr) = toJSON cr
   toJSON (LocalResultWithWarns cr ws) = object
     [ "preflightResult" .= cr

--- a/src/Chainweb/Pact/Validations.hs
+++ b/src/Chainweb/Pact/Validations.hs
@@ -34,7 +34,7 @@ module Chainweb.Pact.Validations
 import Control.Lens
 
 import Data.Decimal (decimalPlaces)
-import Data.Maybe (isJust)
+import Data.Maybe (isJust, catMaybes)
 import Data.Text (Text)
 import Data.Word (Word8)
 
@@ -65,7 +65,7 @@ assertLocalMetadata
     :: P.Command (P.Payload P.PublicMeta c)
     -> TxContext
     -> Maybe LocalSignatureVerification
-    -> PactServiceM tbl (Either Text ())
+    -> PactServiceM tbl (Either [Text] ())
 assertLocalMetadata cmd@(P.Command pay sigs hsh) txCtx sigVerify = do
     v <- view psVersion
     cid <- view psChainId
@@ -75,16 +75,20 @@ assertLocalMetadata cmd@(P.Command pay sigs hsh) txCtx sigVerify = do
         nid = P._pNetworkId pay
         signers = P._pSigners pay
 
-    pure $ sequence_
-      [ eUnless "Unparseable transaction chain id" $ assertParseChainId pcid
-      , eUnless "Chain id mismatch" $ assertChainId cid pcid
-      , eUnless "Transaction Gas limit exceeds block gas limit" $ assertBlockGasLimit bgl gl
-      , eUnless "Gas price decimal precision too high" $ assertGasPrice gp
-      , eUnless "Network id mismatch" $ assertNetworkId v nid
-      , eUnless "Signature list size too big" $ assertSigSize sigs
-      , eUnless "Invalid transaction signatures" $ sigValidate signers
-      , eUnless "Tx time outside of valid range" $ assertTxTimeRelativeToParent pct cmd
-      ]
+    let vs = catMaybes
+          [ eUnless "Unparseable transaction chain id" $ assertParseChainId pcid
+          , eUnless "Chain id mismatch" $ assertChainId cid pcid
+          , eUnless "Transaction Gas limit exceeds block gas limit" $ assertBlockGasLimit bgl gl
+          , eUnless "Gas price decimal precision too high" $ assertGasPrice gp
+          , eUnless "Network id mismatch" $ assertNetworkId v nid
+          , eUnless "Signature list size too big" $ assertSigSize sigs
+          , eUnless "Invalid transaction signatures" $ sigValidate signers
+          , eUnless "Tx time outside of valid range" $ assertTxTimeRelativeToParent pct cmd
+          ]
+
+    pure $ case vs of
+      [] -> Right ()
+      xs -> Left xs
   where
     sigValidate signers
       | Just NoVerify <- sigVerify = True
@@ -97,8 +101,8 @@ assertLocalMetadata cmd@(P.Command pay sigs hsh) txCtx sigVerify = do
       $ txCtx
 
     eUnless t assertion
-      | assertion = Right ()
-      | otherwise = Left t
+      | assertion = Nothing
+      | otherwise = Just t
 
 -- | Check whether a particular Pact chain id is parseable
 --


### PR DESCRIPTION
Optional QOL improvements for `/local`.