### PR TITLE
Optimize JSON+base64 encoding

### DIFF
--- a/src/Chainweb/BlockHash.hs
+++ b/src/Chainweb/BlockHash.hs
@@ -128,7 +128,7 @@ decodeBlockHash = BlockHash <$!> decodeMerkleLogHash
 
 instance ToJSON (BlockHash_ a) where
     toJSON = toJSON . encodeB64UrlNoPaddingText . runPutS . encodeBlockHash
-    toEncoding = toEncoding . encodeB64UrlNoPaddingText . runPutS . encodeBlockHash
+    toEncoding = b64UrlNoPaddingTextEncoding . runPutS . encodeBlockHash
     {-# INLINE toJSON #-}
     {-# INLINE toEncoding #-}
 

--- a/src/Chainweb/BlockHeader.hs
+++ b/src/Chainweb/BlockHeader.hs
@@ -779,8 +779,8 @@ decodeBlockHeader = BlockHeader
     <*> decodeBlockHash
 
 instance ToJSON BlockHeader where
-    toJSON = toJSON .  encodeB64UrlNoPaddingText . runPutS . encodeBlockHeader
-    toEncoding = toEncoding .  encodeB64UrlNoPaddingText . runPutS . encodeBlockHeader
+    toJSON = toJSON . encodeB64UrlNoPaddingText . runPutS . encodeBlockHeader
+    toEncoding = b64UrlNoPaddingTextEncoding . runPutS . encodeBlockHeader
     {-# INLINE toJSON #-}
     {-# INLINE toEncoding #-}
 

--- a/src/Chainweb/Difficulty.hs
+++ b/src/Chainweb/Difficulty.hs
@@ -145,7 +145,7 @@ decodePowHashNatBe = PowHashNat <$!> decodeWordBe
 
 instance ToJSON PowHashNat where
     toJSON = toJSON . encodeB64UrlNoPaddingText . runPutS . encodePowHashNat
-    toEncoding = toEncoding . encodeB64UrlNoPaddingText . runPutS . encodePowHashNat
+    toEncoding = b64UrlNoPaddingTextEncoding . runPutS . encodePowHashNat
     {-# INLINE toJSON #-}
     {-# INLINE toEncoding #-}
 

--- a/src/Chainweb/Payload.hs
+++ b/src/Chainweb/Payload.hs
@@ -238,7 +238,7 @@ instance Show Transaction where
 
 instance ToJSON Transaction where
     toJSON = toJSON . encodeB64UrlNoPaddingText . _transactionBytes
-    toEncoding = toEncoding . encodeB64UrlNoPaddingText . _transactionBytes
+    toEncoding = b64UrlNoPaddingTextEncoding . _transactionBytes
     {-# INLINE toJSON #-}
     {-# INLINE toEncoding #-}
 
@@ -282,7 +282,7 @@ newtype TransactionOutput = TransactionOutput
 
 instance ToJSON TransactionOutput where
     toJSON = toJSON . encodeB64UrlNoPaddingText . _transactionOutputBytes
-    toEncoding = toEncoding . encodeB64UrlNoPaddingText . _transactionOutputBytes
+    toEncoding = b64UrlNoPaddingTextEncoding . _transactionOutputBytes
     {-# INLINE toJSON #-}
     {-# INLINE toEncoding #-}
 
@@ -406,7 +406,7 @@ instance Show MinerData where
 
 instance ToJSON MinerData where
     toJSON = toJSON . encodeB64UrlNoPaddingText . _minerData
-    toEncoding = toEncoding . encodeB64UrlNoPaddingText . _minerData
+    toEncoding = b64UrlNoPaddingTextEncoding . _minerData
     {-# INLINE toJSON #-}
 
 instance FromJSON MinerData where
@@ -528,7 +528,7 @@ instance Show CoinbaseOutput where
 
 instance ToJSON CoinbaseOutput where
     toJSON = toJSON . encodeB64UrlNoPaddingText . _coinbaseOutput
-    toEncoding = toEncoding . encodeB64UrlNoPaddingText . _coinbaseOutput
+    toEncoding = b64UrlNoPaddingTextEncoding . _coinbaseOutput
     {-# INLINE toJSON #-}
     {-# INLINE toEncoding #-}
 

--- a/src/Chainweb/PowHash.hs
+++ b/src/Chainweb/PowHash.hs
@@ -115,7 +115,7 @@ instance Hashable PowHash where
 
 instance ToJSON PowHash where
     toJSON = toJSON . encodeB64UrlNoPaddingText . runPutS . encodePowHash
-    toEncoding = toEncoding . encodeB64UrlNoPaddingText . runPutS . encodePowHash
+    toEncoding = b64UrlNoPaddingTextEncoding . runPutS . encodePowHash
     {-# INLINE toJSON #-}
     {-# INLINE toEncoding #-}
 

--- a/src/Chainweb/Utils.hs
+++ b/src/Chainweb/Utils.hs
@@ -103,6 +103,7 @@ module Chainweb.Utils
 , encodeB64UrlText
 , decodeB64UrlText
 , encodeB64UrlNoPaddingText
+, b64UrlNoPaddingTextEncoding
 , decodeB64UrlNoPaddingText
 
 -- ** JSON
@@ -239,8 +240,10 @@ import Data.Bifunctor
 import Data.Bool (bool)
 import Data.ByteString (ByteString)
 import qualified Data.ByteString as B
+import qualified Data.ByteString.Char8 as B8
 import qualified Data.ByteString.Base64 as B64
 import qualified Data.ByteString.Base64.URL as B64U
+import qualified Data.ByteString.Builder as BB
 import qualified Data.ByteString.Lazy as BL
 import qualified Data.Csv as CSV
 import Data.Decimal
@@ -649,6 +652,12 @@ decodeB64UrlNoPaddingText = fromEitherM
 encodeB64UrlNoPaddingText :: B.ByteString -> T.Text
 encodeB64UrlNoPaddingText = T.dropWhileEnd (== '=') . T.decodeUtf8 . B64U.encode
 {-# INLINE encodeB64UrlNoPaddingText #-}
+
+-- | Encode a binary value to a base64-url (without padding) JSON encoding.
+--
+b64UrlNoPaddingTextEncoding :: B.ByteString -> Encoding
+b64UrlNoPaddingTextEncoding t =
+    Aeson.unsafeToEncoding $ BB.char8 '\"' <> BB.byteString (B8.dropWhileEnd (== '=') $ B64U.encode t) <> BB.char8 '\"'
 
 -- -------------------------------------------------------------------------- --
 -- ** JSON


### PR DESCRIPTION
base64 text is already both a) valid UTF8 and b) escaped with respect to JSON. So why spend time encoding to UTF8, or escaping for JSON? This PR stops us doing that.