### PR TITLE
relax bounds of wai-middleware-validation dependencies

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -112,6 +112,14 @@ allow-newer: token-bucket:*
 allow-newer: ixset-typed:*
 allow-newer: hashable:*
 
+-- wai-middleware-validation dependencies
+
+allow-newer: wai-middleware-validation:*
+allow-newer: validation:*
+allow-newer: these:*
+allow-newer: regex-base:*
+allow-newer: regex-tdfa:*
+
 -- -------------------------------------------------------------------------- --
 -- Upper Bounds
 

--- a/chainweb.cabal
+++ b/chainweb.cabal
@@ -484,6 +484,7 @@ test-suite chainweb-tests
         Chainweb.Test.TreeDB
         Chainweb.Test.TreeDB.RemoteDB
         Chainweb.Test.Utils
+        Chainweb.Test.Utils.APIValidation
         Chainweb.Test.Version
         Chainweb.Test.Utils.BlockHeader
         Chainweb.Test.Utils.TestHeader

--- a/test/Chainweb/Test/Utils.hs
+++ b/test/Chainweb/Test/Utils.hs
@@ -137,7 +137,9 @@ module Chainweb.Test.Utils
 
 import Control.Concurrent
 import Control.Concurrent.Async
+#if !MIN_VERSION_base(4,15,0)
 import Control.Exception (evaluate)
+#endif
 import Control.Lens
 import Control.Monad
 import Control.Monad.Catch (MonadThrow, finally, bracket)

--- a/test/Chainweb/Test/Utils.hs
+++ b/test/Chainweb/Test/Utils.hs
@@ -19,8 +19,6 @@
 -- Maintainer: Lars Kuhtz <lars@kadena.io>
 -- Stability: experimental
 --
--- TODO
---
 module Chainweb.Test.Utils
 (
 -- * Misc
@@ -139,7 +137,6 @@ module Chainweb.Test.Utils
 
 import Control.Concurrent
 import Control.Concurrent.Async
-import Control.Exception (Exception, evaluate)
 import Control.Lens
 import Control.Monad
 import Control.Monad.Catch (MonadThrow, finally, bracket)
@@ -148,33 +145,24 @@ import Control.Monad.IO.Class
 import Data.Aeson (FromJSON, ToJSON)
 import Data.Bifunctor hiding (second)
 import qualified Data.ByteString as B
-import qualified Data.ByteString.Char8 as B8
 import qualified Data.ByteString.Lazy as BL
 import Data.Coerce (coerce)
 import Data.Foldable
-import Data.IORef
 import qualified Data.HashMap.Strict as HashMap
-import qualified Data.HashSet as HashSet
-import qualified Data.Map as Map
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as T
 import Data.Tree
 import qualified Data.Tree.Lens as LT
-import Data.Typeable
 import qualified Data.Vector as V
 import Data.Word (Word64)
-import qualified Data.Yaml as Yaml
 
 import qualified Network.Connection as HTTP
 import qualified Network.HTTP.Client as HTTP
 import qualified Network.HTTP.Client.TLS as HTTP
-import Network.HTTP.Types
 import Network.Socket (close)
 import qualified Network.Wai as W
 import qualified Network.Wai.Handler.Warp as W
 import Network.Wai.Handler.WarpTLS as W (runTLSSocket)
-import Network.Wai.Middleware.OpenApi(OpenApi)
-import qualified Network.Wai.Middleware.Validation as WV
 
 import Numeric.Natural
 
@@ -183,7 +171,6 @@ import Servant.Client (BaseUrl(..), ClientEnv, Scheme(..), mkClientEnv)
 import System.Environment (withArgs)
 import System.IO
 import System.IO.Temp
-import System.IO.Unsafe(unsafePerformIO)
 import System.LogLevel
 import System.Random (randomIO)
 
@@ -197,7 +184,6 @@ import Test.Tasty.HUnit
 import Test.Tasty.QuickCheck (testProperty, property, discard, (.&&.))
 
 import Text.Printf (printf)
-import Text.Show.Pretty
 
 import Data.List (sortOn,isInfixOf)
 

--- a/test/Chainweb/Test/Utils.hs
+++ b/test/Chainweb/Test/Utils.hs
@@ -137,6 +137,7 @@ module Chainweb.Test.Utils
 
 import Control.Concurrent
 import Control.Concurrent.Async
+import Control.Exception (evaluate)
 import Control.Lens
 import Control.Monad
 import Control.Monad.Catch (MonadThrow, finally, bracket)

--- a/test/Chainweb/Test/Utils/APIValidation.hs
+++ b/test/Chainweb/Test/Utils/APIValidation.hs
@@ -1,0 +1,101 @@
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE NumericUnderscores #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TupleSections #-}
+
+-- |
+-- Module: Chainweb.Test.Utils.APIValidation
+-- Copyright: Copyright © 2023 Kadena LLC.
+-- License: MIT
+--
+module Chainweb.Test.Utils.APIValidation
+( ValidationException(..)
+, mkApiValidationMiddleware
+) where
+
+import Control.Exception (Exception, evaluate)
+import Control.Monad
+
+import qualified Data.ByteString.Char8 as B8
+import qualified Data.ByteString.Lazy as BL
+import Data.Foldable
+import Data.IORef
+import qualified Data.HashSet as HashSet
+import qualified Data.Map as Map
+import qualified Data.Text.Encoding as T
+import Data.Typeable
+import qualified Data.Yaml as Yaml
+
+import qualified Network.HTTP.Client as HTTP
+import Network.HTTP.Types
+import qualified Network.Wai as W
+import Network.Wai.Middleware.OpenApi(OpenApi)
+import qualified Network.Wai.Middleware.Validation as WV
+
+
+import System.IO.Unsafe(unsafePerformIO)
+
+import Text.Show.Pretty
+
+-- internal modules
+
+import Chainweb.ChainId
+import Chainweb.Utils
+import Chainweb.Version
+
+-- -------------------------------------------------------------------------- --
+-- Validation Exception
+
+data ValidationException = ValidationException
+    { vReq :: W.Request
+    , vResp :: (ResponseHeaders, Status, BL.ByteString)
+    , vErr :: WV.TopLevelError
+    }
+    deriving (Show, Typeable)
+
+instance Exception ValidationException
+
+-- -------------------------------------------------------------------------- --
+-- Load OpenAPI Specs
+
+{-# NOINLINE chainwebOpenApiSpec #-}
+chainwebOpenApiSpec :: OpenApi
+chainwebOpenApiSpec = unsafePerformIO $ do
+    mgr <- manager 10_000_000
+    let specUri = "https://raw.githubusercontent.com/kadena-io/chainweb-openapi/main/chainweb.openapi.yaml"
+    Yaml.decodeThrow . BL.toStrict . HTTP.responseBody =<< HTTP.httpLbs (HTTP.parseRequest_ specUri) mgr
+
+{-# NOINLINE pactOpenApiSpec #-}
+pactOpenApiSpec :: OpenApi
+pactOpenApiSpec = unsafePerformIO $ do
+    mgr <- manager 10_000_000
+    let specUri = "https://raw.githubusercontent.com/kadena-io/chainweb-openapi/main/pact.openapi.yaml"
+    Yaml.decodeThrow . BL.toStrict . HTTP.responseBody =<< HTTP.httpLbs (HTTP.parseRequest_ specUri) mgr
+
+-- -------------------------------------------------------------------------- --
+-- API Validation Middleware
+
+mkApiValidationMiddleware :: ChainwebVersion -> IO W.Middleware
+mkApiValidationMiddleware v = do
+    coverageRef <- newIORef $ WV.CoverageMap Map.empty
+    _ <- evaluate chainwebOpenApiSpec
+    _ <- evaluate pactOpenApiSpec
+    return $ WV.mkValidator coverageRef (WV.Log lg (const (return ()))) findPath
+  where
+    lg (_, req) (respBody, resp) err = do
+        let ex = ValidationException req (W.responseHeaders resp, W.responseStatus resp, respBody) err
+        print $ ppShow ex
+        error "validation error"
+    findPath path = asum
+        [ case B8.split '/' path of
+            ("" : "chainweb" : "0.0" : rawVersion : "chain" : rawChainId : "pact" : "api" : "v1" : rest) -> do
+                reqVersion <- chainwebVersionFromText (T.decodeUtf8 rawVersion)
+                guard (reqVersion == v)
+                reqChainId <- chainIdFromText (T.decodeUtf8 rawChainId)
+                guard (HashSet.member reqChainId (chainIds v))
+                return (B8.intercalate "/" ("":rest), pactOpenApiSpec)
+            _ -> Nothing
+        , (,chainwebOpenApiSpec) <$> B8.stripPrefix (T.encodeUtf8 $ "/chainweb/0.0/" <> chainwebVersionToText v) path
+        , Just (path,chainwebOpenApiSpec)
+        ]


### PR DESCRIPTION
Main purpose of the PR is to relax upper bounds that are introduced by dependencies of wai-middleware-validation.

The PR includes a few small changes along the way that, I think, improve readability and maintainability a bit.