### PR TITLE
Test return value typechecking and read-* in try

### DIFF
--- a/test/Chainweb/Test/Pact/PactMultiChainTest.hs
+++ b/test/Chainweb/Test/Pact/PactMultiChainTest.hs
@@ -861,7 +861,19 @@ chainweb219UpgradeTest = do
         assertTxSuccess
         "User function return value types should not be checked before the fork"
         (pDecimal 1.0)
-      , PactTxTest readMsg $
+      , PactTxTest tryReadString $
+        assertTxFailure
+        "read-* errors are not recoverable before the fork"
+        ""
+      , PactTxTest tryReadInteger $
+        assertTxFailure
+        "read-* errors are not recoverable before the fork"
+        ""
+      , PactTxTest tryReadKeyset $
+        assertTxFailure
+        "read-* errors are not recoverable before the fork"
+        ""
+      , PactTxTest tryReadMsg $
         assertTxFailure
         "read-* errors are not recoverable before the fork"
         ""
@@ -893,7 +905,19 @@ chainweb219UpgradeTest = do
         assertTxFailure
         "User function type annotation must match body type after the fork"
         "Type error: expected string, found integer"
-      , PactTxTest readMsg $
+      , PactTxTest tryReadString $
+        assertTxSuccess
+        "read-* errors are recoverable after the fork"
+        (pDecimal 1.0)
+      , PactTxTest tryReadInteger $
+        assertTxSuccess
+        "read-* errors are recoverable after the fork"
+        (pDecimal 1.0)
+      , PactTxTest tryReadKeyset $
+        assertTxSuccess
+        "read-* errors are recoverable after the fork"
+        (pDecimal 1.0)
+      , PactTxTest tryReadMsg $
         assertTxSuccess
         "read-* errors are recoverable after the fork"
         (pDecimal 1.0)
@@ -926,7 +950,28 @@ chainweb219UpgradeTest = do
                   , "  (defun foo:string () 1))"
                   , "(m.foo)"
                   ])
-    readMsg = buildBasicGas 10000
+    tryReadInteger = buildBasicGas 1000
+        $ mkExec' (mconcat
+                  [ "(try 1 (read-integer \"somekey\"))"
+                  , "(try 1 (read-string \"somekey\"))"
+                  , "(try 1 (read-keyset \"somekey\"))"
+                  , "(try 1 (read-msg \"somekey\"))"
+                  ])
+    tryReadString = buildBasicGas 1000
+        $ mkExec' (mconcat
+                  [ "(try 1 (read-integer \"somekey\"))"
+                  , "(try 1 (read-string \"somekey\"))"
+                  , "(try 1 (read-keyset \"somekey\"))"
+                  , "(try 1 (read-msg \"somekey\"))"
+                  ])
+    tryReadKeyset = buildBasicGas 1000
+        $ mkExec' (mconcat
+                  [ "(try 1 (read-integer \"somekey\"))"
+                  , "(try 1 (read-string \"somekey\"))"
+                  , "(try 1 (read-keyset \"somekey\"))"
+                  , "(try 1 (read-msg \"somekey\"))"
+                  ])
+    tryReadMsg = buildBasicGas 1000
         $ mkExec' (mconcat
                   [ "(try 1 (read-integer \"somekey\"))"
                   , "(try 1 (read-string \"somekey\"))"

--- a/test/Chainweb/Test/Pact/PactMultiChainTest.hs
+++ b/test/Chainweb/Test/Pact/PactMultiChainTest.hs
@@ -126,6 +126,7 @@ tests = ScheduledTest testName go
          , test generousConfig getGasModel "chainweb216Test" chainweb216Test
          , test generousConfig getGasModel "pact45UpgradeTest" pact45UpgradeTest
          , test generousConfig getGasModel "pact46UpgradeTest" pact46UpgradeTest
+         , test generousConfig getGasModel "pact47UpgradeTest" pact47UpgradeTest
          , test generousConfig getGasModel "chainweb219UpgradeTest" chainweb219UpgradeTest
          ]
       where
@@ -824,6 +825,34 @@ pact46UpgradeTest = do
         $ mkExec' (mconcat
         [ "(pairing-check [{'x: 1, 'y: 2}] [{'x:[0, 0], 'y:[0, 0]}])"
         ])
+
+pact47UpgradeTest :: PactTestM ()
+pact46UpgradeTest = do
+
+  -- run past genesis, upgrades
+  runToHeight 70
+
+  runBlockTest
+      [ PactTxTest runIllTypedFunction $
+        assertTxSuccess
+        "User function return value types should not be checked before the fork" _ ]
+
+  runBlockTest
+      [ PactTxtest runIllTypedFunction $
+        assertTxFailure
+        "User function type annotation must match body type after the fork"
+        ""
+      ]
+
+  where
+    runIllTypedFunction = buildBasicGas 10000
+        $ mkExec' (mconcat
+                  [ "(namespace 'free)"
+                  , "(module m g (defgap g () true)"
+                  , "  (defun foo:string () 1))"
+                  , "  (m.foo)"
+                  ])
+
 
 chainweb219UpgradeTest :: PactTestM ()
 chainweb219UpgradeTest = do

--- a/test/Chainweb/Test/Pact/PactMultiChainTest.hs
+++ b/test/Chainweb/Test/Pact/PactMultiChainTest.hs
@@ -951,33 +951,14 @@ chainweb219UpgradeTest = do
                   , "(m.foo)"
                   ])
     tryReadInteger = buildBasicGas 1000
-        $ mkExec' (mconcat
-                  [ "(try 1 (read-integer \"somekey\"))"
-                  , "(try 1 (read-string \"somekey\"))"
-                  , "(try 1 (read-keyset \"somekey\"))"
-                  , "(try 1 (read-msg \"somekey\"))"
-                  ])
+        $ mkExec' "(try 1 (read-integer \"somekey\"))"
     tryReadString = buildBasicGas 1000
-        $ mkExec' (mconcat
-                  [ "(try 1 (read-integer \"somekey\"))"
-                  , "(try 1 (read-string \"somekey\"))"
-                  , "(try 1 (read-keyset \"somekey\"))"
-                  , "(try 1 (read-msg \"somekey\"))"
-                  ])
+        $ mkExec' "(try 1 (read-string \"somekey\"))"
     tryReadKeyset = buildBasicGas 1000
-        $ mkExec' (mconcat
-                  [ "(try 1 (read-integer \"somekey\"))"
-                  , "(try 1 (read-string \"somekey\"))"
-                  , "(try 1 (read-keyset \"somekey\"))"
-                  , "(try 1 (read-msg \"somekey\"))"
-                  ])
+        $ mkExec' "(try 1 (read-keyset \"somekey\"))"
     tryReadMsg = buildBasicGas 1000
-        $ mkExec' (mconcat
-                  [ "(try 1 (read-integer \"somekey\"))"
-                  , "(try 1 (read-string \"somekey\"))"
-                  , "(try 1 (read-keyset \"somekey\"))"
-                  , "(try 1 (read-msg \"somekey\"))"
-                  ])
+        $ mkExec' "(try 1 (read-msg \"somekey\"))"
+
 
 pact4coin3UpgradeTest :: PactTestM ()
 pact4coin3UpgradeTest = do

--- a/test/Chainweb/Test/Pact/PactMultiChainTest.hs
+++ b/test/Chainweb/Test/Pact/PactMultiChainTest.hs
@@ -838,6 +838,10 @@ pact47UpgradeTest = do
         assertTxSuccess
         "User function return value types should not be checked before the fork"
         (pDecimal 1.0)
+       , PactTxTest readMsg $
+         assertTxFailure
+         "read-* errors are not recoverable before the fork"
+         ""
       ]
 
   runBlockTest
@@ -845,6 +849,10 @@ pact47UpgradeTest = do
         assertTxFailure
         "User function type annotation must match body type after the fork"
         "Type error: expected string, found integer"
+      , PactTxTest readMsg $
+        assertTxSuccess
+        "read-* errors are recoverable after the fork"
+        (pDecimal 1.0)
       ]
 
   where
@@ -856,6 +864,13 @@ pact47UpgradeTest = do
                   , "(m.foo)"
                   ])
 
+    readMsg = buildBasicGas 10000
+        $ mkExec' (mconcat
+                  [ "(try 1 (read-integer \"somekey\"))"
+                  , "(try 1 (read-string \"somekey\"))"
+                  , "(try 1 (read-keyset \"somekey\"))"
+                  , "(try 1 (read-msg \"somekey\"))"
+                  ])
 
 chainweb219UpgradeTest :: PactTestM ()
 chainweb219UpgradeTest = do

--- a/test/Chainweb/Test/Pact/PactMultiChainTest.hs
+++ b/test/Chainweb/Test/Pact/PactMultiChainTest.hs
@@ -831,13 +831,13 @@ pact47UpgradeTest :: PactTestM ()
 pact47UpgradeTest = do
 
   -- run past genesis, upgrades
-  runToHeight 70
+  runToHeight 69
 
   runBlockTest
       [ PactTxTest runIllTypedFunction $
         assertTxSuccess
         "User function return value types should not be checked before the fork"
-        (pInteger 1)
+        (pDecimal 1.0)
       ]
 
   runBlockTest

--- a/test/Chainweb/Test/Pact/PactMultiChainTest.hs
+++ b/test/Chainweb/Test/Pact/PactMultiChainTest.hs
@@ -826,8 +826,9 @@ pact46UpgradeTest = do
         [ "(pairing-check [{'x: 1, 'y: 2}] [{'x:[0, 0], 'y:[0, 0]}])"
         ])
 
+
 pact47UpgradeTest :: PactTestM ()
-pact46UpgradeTest = do
+pact47UpgradeTest = do
 
   -- run past genesis, upgrades
   runToHeight 70
@@ -835,22 +836,24 @@ pact46UpgradeTest = do
   runBlockTest
       [ PactTxTest runIllTypedFunction $
         assertTxSuccess
-        "User function return value types should not be checked before the fork" _ ]
+        "User function return value types should not be checked before the fork"
+        (pInteger 1)
+      ]
 
   runBlockTest
-      [ PactTxtest runIllTypedFunction $
+      [ PactTxTest runIllTypedFunction $
         assertTxFailure
         "User function type annotation must match body type after the fork"
-        ""
+        "Type error: expected string, found integer"
       ]
 
   where
-    runIllTypedFunction = buildBasicGas 10000
+    runIllTypedFunction = buildBasicGas 70000
         $ mkExec' (mconcat
                   [ "(namespace 'free)"
-                  , "(module m g (defgap g () true)"
+                  , "(module m g (defcap g () true)"
                   , "  (defun foo:string () 1))"
-                  , "  (m.foo)"
+                  , "(m.foo)"
                   ])
 
 


### PR DESCRIPTION
Add tests for the upgrade to pact-4.7.

 - [x] Return value type checking
 - [x] `read-msg` recoverability with `try`