### PR TITLE
Add rewind depth support for execLocal

### DIFF
--- a/src/Chainweb/Chainweb.hs
+++ b/src/Chainweb/Chainweb.hs
@@ -409,6 +409,7 @@ withChainwebInternal conf logger peer serviceSock rocksDb pactDbDir backupDir re
   where
     pactConfig maxGasLimit = PactServiceConfig
       { _pactReorgLimit = _configReorgLimit conf
+      , _pactLocalRewindDepthLimit = _configLocalRewindDepthLimit conf
       , _pactRevalidate = _configValidateHashesOnReplay conf
       , _pactQueueSize = _configPactQueueSize conf
       , _pactResetDb = resetDb

--- a/src/Chainweb/Chainweb/Configuration.hs
+++ b/src/Chainweb/Chainweb/Configuration.hs
@@ -104,7 +104,7 @@ import Chainweb.HostAddress
 import qualified Chainweb.Mempool.Mempool as Mempool
 import Chainweb.Mempool.P2pConfig
 import Chainweb.Miner.Config
-import Chainweb.Pact.Types (defaultReorgLimit, defaultModuleCacheLimit)
+import Chainweb.Pact.Types (defaultReorgLimit, defaultModuleCacheLimit, defaultLocalRewindDepthLimit)
 import Chainweb.Payload.RestAPI (PayloadBatchLimit(..), defaultServicePayloadBatchLimit)
 import Chainweb.Utils
 import Chainweb.Version
@@ -379,6 +379,7 @@ data ChainwebConfiguration = ChainwebConfiguration
     , _configMinGasPrice :: !Mempool.GasPrice
     , _configPactQueueSize :: !Natural
     , _configReorgLimit :: !Natural
+    , _configLocalRewindDepthLimit :: !Natural
     , _configValidateHashesOnReplay :: !Bool
         -- ^ Re-validate payload hashes during replay.
     , _configAllowReadsInLocal :: !Bool
@@ -432,6 +433,7 @@ defaultChainwebConfiguration v = ChainwebConfiguration
     , _configMinGasPrice = 1e-8
     , _configPactQueueSize = 2000
     , _configReorgLimit = int defaultReorgLimit
+    , _configLocalRewindDepthLimit = int defaultLocalRewindDepthLimit
     , _configValidateHashesOnReplay = False
     , _configAllowReadsInLocal = False
     , _configRosetta = False
@@ -457,6 +459,7 @@ instance ToJSON ChainwebConfiguration where
         , "minGasPrice" .= _configMinGasPrice o
         , "pactQueueSize" .= _configPactQueueSize o
         , "reorgLimit" .= _configReorgLimit o
+        , "localRewindDepthLimit" .= _configLocalRewindDepthLimit o
         , "validateHashesOnReplay" .= _configValidateHashesOnReplay o
         , "allowReadsInLocal" .= _configAllowReadsInLocal o
         , "rosetta" .= _configRosetta o
@@ -487,6 +490,7 @@ instance FromJSON (ChainwebConfiguration -> ChainwebConfiguration) where
         <*< configMinGasPrice ..: "minGasPrice" % o
         <*< configPactQueueSize ..: "pactQueueSize" % o
         <*< configReorgLimit ..: "reorgLimit" % o
+        <*< configLocalRewindDepthLimit ..: "localRewindDepthLimit" % o
         <*< configValidateHashesOnReplay ..: "validateHashesOnReplay" % o
         <*< configAllowReadsInLocal ..: "allowReadsInLocal" % o
         <*< configRosetta ..: "rosetta" % o
@@ -528,6 +532,9 @@ pChainwebConfiguration = id
         <> help "Max allowed reorg depth.\
                 \ Consult https://github.com/kadena-io/chainweb-node/blob/master/docs/RecoveringFromDeepForks.md for\
                 \ more information. "
+    <*< configLocalRewindDepthLimit .:: jsonOption
+        % long "local-rewind-depth-limit"
+        <> help "Max allowed rewind depth for the local command."
     <*< configValidateHashesOnReplay .:: boolOption_
         % long "validateHashesOnReplay"
         <> help "Re-validate payload hashes during transaction replay."

--- a/src/Chainweb/Pact/PactService.hs
+++ b/src/Chainweb/Pact/PactService.hs
@@ -668,10 +668,10 @@ execLocal cwtx preflight sigVerify rdepth = withDiscardedBatch $ do
     let ancestorRank = fromIntegral $ _height $ _blockHeight parentBlockHeader - fromMaybe 0 rdepth
     ancestor <- liftIO $ seekAncestor _psBlockHeaderDb parentBlockHeader ancestorRank
 
-    let rewindHeader
-          | Just a <- ancestor = Just $ ParentHeader a
-          -- when there is no ancestor, use the current parent
-          | otherwise = Just $ _tcParentHeader ctx
+    rewindHeader <- case ancestor of
+        Just a -> pure $ Just $ ParentHeader a
+        Nothing -> throwM $ BlockHeaderLookupFailure $
+            "failed seekAncestor of parent header with ancestorRank " <> sshow ancestorRank
 
     let execConfig = P.mkExecutionConfig $
             [ P.FlagAllowReadInLocal | _psAllowReadsInLocal ] ++

--- a/src/Chainweb/Pact/PactService.hs
+++ b/src/Chainweb/Pact/PactService.hs
@@ -638,6 +638,8 @@ execLocal
       -- ^ rewind depth (note: this is a *depth*, not an absolute height)
     -> PactServiceM tbl LocalResult
 execLocal cwtx preflight sigVerify rdepth = withDiscardedBatch $ do
+    parent <- syncParentHeader "execLocal"
+
     PactServiceEnv{..} <- ask
 
     let !cmd = payloadObj <$> cwtx
@@ -657,7 +659,7 @@ execLocal cwtx preflight sigVerify rdepth = withDiscardedBatch $ do
     when ((_height rewindHeight) > _psLocalRewindDepthLimit) $ do
         throwM $ LocalRewindLimitExceeded (fromIntegral _psLocalRewindDepthLimit) rewindHeight
 
-    let parentBlockHeader = _parentHeader $ _tcParentHeader ctx
+    let parentBlockHeader = _parentHeader parent
     let ancestorRank = fromIntegral $ _height $ _blockHeight parentBlockHeader - fromMaybe 0 rdepth
     ancestor <- liftIO $ seekAncestor _psBlockHeaderDb parentBlockHeader ancestorRank
 

--- a/src/Chainweb/Pact/PactService.hs
+++ b/src/Chainweb/Pact/PactService.hs
@@ -660,6 +660,11 @@ execLocal cwtx preflight sigVerify rdepth = withDiscardedBatch $ do
         throwM $ LocalRewindLimitExceeded (fromIntegral _psLocalRewindDepthLimit) rewindHeight
 
     let parentBlockHeader = _parentHeader parent
+
+    -- we fail if the requested depth is bigger than the current parent block height
+    -- because we can't go after the genesis block
+    when (fromMaybe 0 rdepth > _blockHeight parentBlockHeader) $ throwM LocalRewindGenesisExceeded
+
     let ancestorRank = fromIntegral $ _height $ _blockHeight parentBlockHeader - fromMaybe 0 rdepth
     ancestor <- liftIO $ seekAncestor _psBlockHeaderDb parentBlockHeader ancestorRank
 

--- a/src/Chainweb/Pact/PactService/Checkpointer.hs
+++ b/src/Chainweb/Pact/PactService/Checkpointer.hs
@@ -327,7 +327,7 @@ withDiscardedBatch act = do
 -- should consider merging it with 'restoreCheckpointer' and always rewind.
 --
 -- Rewinds the pact state to the given parent in a single database transactions.
--- Rewinds to the genesis block if he parent is 'Nothing'.
+-- Rewinds to the genesis block if the parent is 'Nothing'.
 --
 -- If the rewind is deeper than the optionally provided rewind limit, an
 -- exception is raised.

--- a/src/Chainweb/Pact/Service/Types.hs
+++ b/src/Chainweb/Pact/Service/Types.hs
@@ -64,6 +64,8 @@ data PactServiceConfig = PactServiceConfig
   { _pactReorgLimit :: !Natural
     -- ^ Maximum allowed reorg depth, implemented as a rewind limit in validate. New block
     -- hardcodes this to 8 currently.
+  , _pactLocalRewindDepthLimit :: !Natural
+    -- ^ Maximum allowed rewind depth in the local command.
   , _pactRevalidate :: !Bool
     -- ^ Re-validate payload hashes during transaction replay
   , _pactAllowReadsInLocal :: !Bool
@@ -168,6 +170,9 @@ data PactException
   | BuyGasFailure !GasPurchaseFailure
   | MempoolFillFailure !Text
   | BlockGasLimitExceeded !Gas
+  | LocalRewindLimitExceeded
+    { _localRewindExceededLimit :: !Natural
+    , _localRewindRequestedDepth :: !BlockHeight }
   deriving (Eq,Generic)
 
 instance Show PactException where

--- a/src/Chainweb/Pact/Service/Types.hs
+++ b/src/Chainweb/Pact/Service/Types.hs
@@ -173,6 +173,7 @@ data PactException
   | LocalRewindLimitExceeded
     { _localRewindExceededLimit :: !Natural
     , _localRewindRequestedDepth :: !BlockHeight }
+  | LocalRewindGenesisExceeded
   deriving (Eq,Generic)
 
 instance Show PactException where

--- a/src/Chainweb/Pact/Types.hs
+++ b/src/Chainweb/Pact/Types.hs
@@ -75,6 +75,7 @@ module Chainweb.Pact.Types
   , psGasModel
   , psMinerRewards
   , psReorgLimit
+  , psLocalRewindDepthLimit
   , psOnFatalError
   , psVersion
   , psValidateHashesOnReplay
@@ -137,6 +138,7 @@ module Chainweb.Pact.Types
   -- * miscellaneous
   , defaultOnFatalError
   , defaultReorgLimit
+  , defaultLocalRewindDepthLimit
   , defaultPactServiceConfig
   , defaultBlockGasLimit
   , defaultModuleCacheLimit
@@ -354,7 +356,6 @@ data PactServiceEnv tbl = PactServiceEnv
     , _psBlockHeaderDb :: !BlockHeaderDb
     , _psGasModel :: TxContext -> GasModel
     , _psMinerRewards :: !MinerRewards
-    , _psReorgLimit :: {-# UNPACK #-} !Word64
     , _psOnFatalError :: forall a. PactException -> Text -> IO a
     , _psVersion :: ChainwebVersion
     , _psValidateHashesOnReplay :: !Bool
@@ -365,6 +366,12 @@ data PactServiceEnv tbl = PactServiceEnv
         -- ^ logger factory. A new logger can be created via
         --
         -- P.newLogger loggers (P.LogName "myLogger")
+
+    -- Configuration limits for rewinds
+    , _psLocalRewindDepthLimit :: {-# UNPACK #-} !Word64
+    -- ^ The limit of rewind's depth in the `execLocal` command.
+    , _psReorgLimit :: {-# UNPACK #-} !Word64
+    -- ^ The limit of checkpointer's rewind in the `execValidationBlock` command.
 
     -- The following two fields are used to enforce invariants for using the
     -- checkpointer. These would better be enforced on the type level. But that
@@ -392,6 +399,9 @@ instance HasChainId (PactServiceEnv c) where
 defaultReorgLimit :: Word64
 defaultReorgLimit = 480
 
+defaultLocalRewindDepthLimit :: Word64
+defaultLocalRewindDepthLimit = 100
+
 -- | Default limit for the per chain size of the decoded module cache.
 --
 -- default limit: 60 MiB per chain
@@ -403,6 +413,7 @@ defaultModuleCacheLimit = DbCacheLimitBytes (60 * mebi)
 defaultPactServiceConfig :: PactServiceConfig
 defaultPactServiceConfig = PactServiceConfig
       { _pactReorgLimit = fromIntegral defaultReorgLimit
+      , _pactLocalRewindDepthLimit = fromIntegral defaultLocalRewindDepthLimit
       , _pactRevalidate = True
       , _pactQueueSize = 1000
       , _pactResetDb = True

--- a/src/Chainweb/Pact/Types.hs
+++ b/src/Chainweb/Pact/Types.hs
@@ -356,6 +356,10 @@ data PactServiceEnv tbl = PactServiceEnv
     , _psBlockHeaderDb :: !BlockHeaderDb
     , _psGasModel :: TxContext -> GasModel
     , _psMinerRewards :: !MinerRewards
+    , _psLocalRewindDepthLimit :: {-# UNPACK #-} !Word64
+    -- ^ The limit of rewind's depth in the `execLocal` command.
+    , _psReorgLimit :: {-# UNPACK #-} !Word64
+    -- ^ The limit of checkpointer's rewind in the `execValidationBlock` command.
     , _psOnFatalError :: forall a. PactException -> Text -> IO a
     , _psVersion :: ChainwebVersion
     , _psValidateHashesOnReplay :: !Bool
@@ -366,12 +370,6 @@ data PactServiceEnv tbl = PactServiceEnv
         -- ^ logger factory. A new logger can be created via
         --
         -- P.newLogger loggers (P.LogName "myLogger")
-
-    -- Configuration limits for rewinds
-    , _psLocalRewindDepthLimit :: {-# UNPACK #-} !Word64
-    -- ^ The limit of rewind's depth in the `execLocal` command.
-    , _psReorgLimit :: {-# UNPACK #-} !Word64
-    -- ^ The limit of checkpointer's rewind in the `execValidationBlock` command.
 
     -- The following two fields are used to enforce invariants for using the
     -- checkpointer. These would better be enforced on the type level. But that

--- a/src/Chainweb/Pact/Types.hs
+++ b/src/Chainweb/Pact/Types.hs
@@ -356,9 +356,9 @@ data PactServiceEnv tbl = PactServiceEnv
     , _psBlockHeaderDb :: !BlockHeaderDb
     , _psGasModel :: TxContext -> GasModel
     , _psMinerRewards :: !MinerRewards
-    , _psLocalRewindDepthLimit :: {-# UNPACK #-} !Word64
+    , _psLocalRewindDepthLimit :: !Word64
     -- ^ The limit of rewind's depth in the `execLocal` command.
-    , _psReorgLimit :: {-# UNPACK #-} !Word64
+    , _psReorgLimit :: !Word64
     -- ^ The limit of checkpointer's rewind in the `execValidationBlock` command.
     , _psOnFatalError :: forall a. PactException -> Text -> IO a
     , _psVersion :: ChainwebVersion

--- a/src/Chainweb/Pact/Types.hs
+++ b/src/Chainweb/Pact/Types.hs
@@ -398,7 +398,7 @@ defaultReorgLimit :: Word64
 defaultReorgLimit = 480
 
 defaultLocalRewindDepthLimit :: Word64
-defaultLocalRewindDepthLimit = 100
+defaultLocalRewindDepthLimit = 1000
 
 -- | Default limit for the per chain size of the decoded module cache.
 --

--- a/test/Chainweb/Test/Pact/PactMultiChainTest.hs
+++ b/test/Chainweb/Test/Pact/PactMultiChainTest.hs
@@ -261,7 +261,10 @@ pactLocalDepthTest = do
 
   -- the negative depth turns into 18446744073709551611 and we expect the `LocalRewindLimitExceeded` exception
   -- since `BlockHeight` is a wrapper around `Word64`
-  handle (\(LocalRewindLimitExceeded _ _) -> return ()) $ do
+  handle (\case
+      { (LocalRewindLimitExceeded _ _) -> return ()
+      ; err -> liftIO $ assertFailure $ "Expected LocalRewindLimitExceeded, but got " ++ show err}
+      ) $ do
     runLocalWithDepth (Just $ BlockHeight (-5)) cid getSender00Balance >>= \_ ->
       liftIO $ assertFailure "block succeeded"
 

--- a/test/Chainweb/Test/Pact/PactMultiChainTest.hs
+++ b/test/Chainweb/Test/Pact/PactMultiChainTest.hs
@@ -266,11 +266,20 @@ pactLocalDepthTest = do
       ; err -> liftIO $ assertFailure $ "Expected LocalRewindLimitExceeded, but got " ++ show err}
       ) $ do
     runLocalWithDepth (Just $ BlockHeight (-5)) cid getSender00Balance >>= \_ ->
-      liftIO $ assertFailure "block succeeded"
+      liftIO $ assertFailure "Expected LocalRewindLimitExceeded, but block succeeded"
 
-  -- depth that reaches the genesis
-  runLocalWithDepth (Just $ BlockHeight 99) cid getSender00Balance >>= \r ->
+  -- the genesis depth
+  runLocalWithDepth (Just $ BlockHeight 55) cid getSender00Balance >>= \r ->
     checkLocalResult r $ assertTxSuccess "Should get the balance at the genesis block" (pDecimal 100000000)
+
+  -- depth that goes after the genesis block should trigger the `LocalRewindLimitExceeded` exception
+  handle (\case
+      { LocalRewindGenesisExceeded -> return ()
+      ; err -> liftIO $ assertFailure $ "Expected LocalRewindGenesisExceeded, but got " ++ show err}
+      ) $ do
+    runLocalWithDepth (Just $ BlockHeight 56) cid getSender00Balance >>= \r -> do
+      liftIO $ print r
+      liftIO $ assertFailure "Expected LocalRewindGenesisExceeded, but block succeeded"
 
   where
   checkLocalResult r checkResult = case r of

--- a/test/Chainweb/Test/Pact/Utils.hs
+++ b/test/Chainweb/Test/Pact/Utils.hs
@@ -625,6 +625,7 @@ testPactCtxSQLite logBackend v cid bhdb pdb sqlenv conf gasmodel = do
         , _psGasModel = gasmodel
         , _psMinerRewards = rs
         , _psReorgLimit = fromIntegral $ _pactReorgLimit conf
+        , _psLocalRewindDepthLimit = fromIntegral $ _pactLocalRewindDepthLimit conf
         , _psOnFatalError = defaultOnFatalError mempty
         , _psVersion = v
         , _psValidateHashesOnReplay = _pactRevalidate conf

--- a/tools/cwtool/TxSimulator.hs
+++ b/tools/cwtool/TxSimulator.hs
@@ -154,7 +154,7 @@ simulate sc@(SimConfig dbDir txIdx' _ _ cid ver gasLog doTypecheck) = do
           paydb <- newPayloadDb
           withRocksDb "txsim-rocksdb" modernDefaultOptions $ \rdb ->
             withBlockHeaderDb rdb ver cid $ \bdb -> do
-              let pse = PactServiceEnv Nothing cpe paydb bdb getGasModel readRewards 0 ferr
+              let pse = PactServiceEnv Nothing cpe paydb bdb getGasModel readRewards 100 0 ferr
                         ver True False logger gasLogger (pactLoggers cwLogger) False 1 defaultBlockGasLimit cid
                   pss = PactServiceState Nothing mempty (ParentHeader parent) noSPVSupport
               evalPactServiceM pss pse $ doBlock True parent (zip hdrs pwos)


### PR DESCRIPTION
This PR fixes the behaviour of `execLocal` functionality with a provided rewind depth parameter — it executes the transaction in the context of the block with the provided depth.