### PR TITLE
Add typechecking option to tx-sim

### DIFF
--- a/tools/cwtool/TxSimulator.hs
+++ b/tools/cwtool/TxSimulator.hs
@@ -16,6 +16,7 @@ import Control.Monad.IO.Class
 import Crypto.Hash.Algorithms
 import Data.Aeson (decodeStrict')
 import Data.Default
+import qualified Data.Map.Strict as M
 import Data.Maybe
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as T
@@ -57,11 +58,24 @@ import Servant.Client
 
 import Chainweb.Storage.Table.RocksDB
 
+import Pact.Gas
+import Pact.Interpreter
+import Pact.Native
+import Pact.Runtime.Utils
+import Pact.Typechecker
 import Pact.Types.Command
 import Pact.Types.Hash
+import Pact.Types.Info
 import Pact.Types.Logger
+import Pact.Types.Namespace
+import Pact.Types.Persistence
+import Pact.Types.Pretty
 import Pact.Types.RPC
+import Pact.Types.Runtime (runEval,keys,RefStore(..))
 import Pact.Types.SPV
+import Pact.Types.Term
+import Pact.Types.Typecheck
+
 
 import Utils.Logging.Trace
 
@@ -75,10 +89,11 @@ data SimConfig = SimConfig
     , scChain :: ChainId
     , scVersion :: ChainwebVersion
     , scGasLog :: Bool
+    , scTypecheck :: Bool
     }
 
 simulate :: SimConfig -> IO ()
-simulate sc@(SimConfig dbDir txIdx' _ _ cid ver gasLog) = do
+simulate sc@(SimConfig dbDir txIdx' _ _ cid ver gasLog doTypecheck) = do
   cenv <- setupClient sc
   (parent:hdrs) <- fetchHeaders sc cenv
   pwos <- fetchOutputs sc cenv hdrs
@@ -87,8 +102,8 @@ simulate sc@(SimConfig dbDir txIdx' _ _ cid ver gasLog) = do
       initRelationalCheckpointer (initBlockState defaultModuleCacheLimit 0) sqlenv logger ver cid
     bracket_
       (_cpBeginCheckpointerBatch cp)
-      (_cpDiscardCheckpointerBatch cp) $ case txIdx' of
-        Just txIdx -> do -- single-tx simulation
+      (_cpDiscardCheckpointerBatch cp) $ case (txIdx',doTypecheck) of
+        (Just txIdx,_) -> do -- single-tx simulation
           let PayloadWithOutputs txs md _ _ _ _ :: PayloadWithOutputs = head pwos
           miner <- decodeStrictOrThrow $ _minerData md
           let Transaction tx = fst $ txs V.! txIdx
@@ -106,7 +121,36 @@ simulate sc@(SimConfig dbDir txIdx' _ _ cid ver gasLog) = do
                   applyCmd ver logger gasLogger pde miner (getGasModel txc)
                   txc noSPVSupport cmd (initGas cmdPwt) mc ApplySend
               T.putStrLn (encodeToText cr)
-        Nothing -> do -- blocks simulation
+        (_,True) -> do
+          PactDbEnv' pde <-
+              _cpRestore cp $ Just (succ (_blockHeight parent), _blockHash parent)
+          let refStore = RefStore nativeDefs
+              pd = ctxToPublicData $ TxContext (ParentHeader parent) def
+              loadMod = fmap inlineModuleData . getModule (def :: Info)
+          ee <- setupEvalEnv pde Nothing Local (initMsgData pactInitialHash) refStore freeGasEnv
+              permissiveNamespacePolicy noSPVSupport pd def
+          void $ runEval def ee $ do
+            mods <- keys def Modules
+            coin <- loadMod "coin"
+            let dynEnv = M.singleton "fungible-v2" coin
+            forM mods $ \mn -> do
+              md <- loadMod mn
+              case _mdModule md of
+                MDInterface _ -> return ()
+                MDModule _ -> do
+                  tcr :: Either CheckerException ([TopLevel Node],[Failure]) <-
+                    try $ liftIO $ typecheckModule False dynEnv md
+                  case tcr of
+                    Left (CheckerException ei e) ->
+                      liftIO $ putStrLn $ "TC_FAILURE: " ++ showPretty mn ++ ": "
+                        ++ renderInfo ei ++ ": " ++ showPretty e
+                    Right (_,[]) -> liftIO $ putStrLn $ "TC_SUCCESS: " ++ showPretty mn
+                    Right (_,fails) ->
+                      liftIO $ putStrLn $ "TC_FAILURE: " ++ showPretty mn ++ ": "
+                      ++ "Unable to resolve all types: " ++ show (length fails) ++ " failures"
+
+
+        (Nothing,False) -> do -- blocks simulation
           paydb <- newPayloadDb
           withRocksDb "txsim-rocksdb" modernDefaultOptions $ \rdb ->
             withBlockHeaderDb rdb ver cid $ \bdb -> do
@@ -207,16 +251,16 @@ fetchOutputs sc cenv bhs = do
 
 simulateMain :: IO ()
 simulateMain = do
-  execParser opts >>= \(d,s,e,i,h,c,v,g) -> do
+  execParser opts >>= \(d,s,e,i,h,c,v,g,r) -> do
     vv <- chainwebVersionFromText (T.pack v)
     cc <- chainIdFromText (T.pack c)
     u <- parseBaseUrl h
     let rng = (fromIntegral @Integer s,fromIntegral @Integer (fromMaybe s e))
-    simulate $ SimConfig d i u rng cc vv g
+    simulate $ SimConfig d i u rng cc vv g r
   where
     opts = info (parser <**> helper)
         (fullDesc <> progDesc "Single Transaction simulator")
-    parser = (,,,,,,,)
+    parser = (,,,,,,,,)
         <$> strOption
              (short 'd'
               <> metavar "DBDIR"
@@ -249,3 +293,6 @@ simulateMain = do
         <*> switch
              (short 'g'
               <> help "Enable gas logging")
+        <*> switch
+             (short 't'
+              <> help "Typecheck modules")


### PR DESCRIPTION
Adds a `-t` flag to `cwtool tx-sim` to run static tc on every module on chain.

```
Stuarts-MBP-2:chainweb stuart$ cabal run cwtool -- tx-sim -d pactdbs -s 3299990 -c 2 -t | sort
TC_FAILURE: free.anedak-gas-station: Unable to resolve all types: 7 failures
TC_FAILURE: free.babena: Unable to resolve all types: 7 failures
TC_FAILURE: free.backalley-token: Unable to resolve all types: 3 failures
TC_FAILURE: free.backalley: Unable to resolve all types: 3 failures
TC_FAILURE: free.corona-inu: Unable to resolve all types: 8 failures
TC_FAILURE: free.dbc-token: Unable to resolve all types: 8 failures
TC_FAILURE: free.fin-us: Unable to resolve all types: 21 failures
TC_FAILURE: free.kDOGE: Unable to resolve all types: 1 failures
TC_FAILURE: free.kadena-mining-club: Unable to resolve all types: 45 failures
TC_FAILURE: free.kadena-wall: : Def in value position
TC_FAILURE: free.kayc-sale-manager: Unable to resolve all types: 3 failures
TC_FAILURE: free.kdoge: Unable to resolve all types: 8 failures
TC_FAILURE: free.kmc-gas-station: Unable to resolve all types: 7 failures
TC_FAILURE: free.kmc-gas: Unable to resolve all types: 7 failures
TC_FAILURE: free.memory-wall-gas-station: Unable to resolve all types: 7 failures
TC_FAILURE: free.real-kdoge: Unable to resolve all types: 8 failures
TC_FAILURE: free.rsa: : lam in value position
TC_FAILURE: free.util-lists: : lam in value position
TC_FAILURE: free.util-math: : lam in value position
TC_FAILURE: free.util-random: : lam in value position
TC_FAILURE: free.util-strings: : lam in value position
TC_FAILURE: free.util-time: Unable to resolve all types: 1 failures
TC_FAILURE: free.wall: : Def in value position
TC_FAILURE: free.wiza: Unable to resolve all types: 2 failures
TC_FAILURE: guards1: Unable to resolve all types: 2 failures
TC_FAILURE: hello: Unable to resolve all types: 1 failures
TC_FAILURE: hypercent.prod-hypercent-gas-station: Unable to resolve all types: 7 failures
TC_FAILURE: kaddex.aggregator: Unable to resolve all types: 6 failures
TC_FAILURE: kaddex.alchemist: : lam in value position
TC_FAILURE: kaddex.dao: Unable to resolve all types: 5 failures
TC_FAILURE: kaddex.exchange: : lam in value position
TC_FAILURE: kaddex.gas-guards: Unable to resolve all types: 2 failures
TC_FAILURE: kaddex.gas-station: : lam in value position
TC_FAILURE: kaddex.kdx: : lam in value position
TC_FAILURE: kaddex.skdx: Unable to resolve all types: 1 failures
TC_FAILURE: kaddex.staking: : lam in value position
TC_FAILURE: kaddex.wrapper: : lam in value position
TC_FAILURE: kswap.abc: Unable to resolve all types: 1 failures
TC_FAILURE: kswap.exchange: Unable to resolve all types: 19 failures
TC_FAILURE: kswap.gas-station: Unable to resolve all types: 7 failures
TC_FAILURE: kswap.kpenny: Unable to resolve all types: 3 failures
TC_FAILURE: kswap.xyz: Unable to resolve all types: 1 failures
TC_FAILURE: relay.gas-station: Unable to resolve all types: 7 failures
TC_FAILURE: relay.pool: Unable to resolve all types: 1 failures
TC_FAILURE: relay.relay: Unable to resolve all types: 6 failures
TC_FAILURE: runonflux.flux-gas-station: Unable to resolve all types: 7 failures
TC_FAILURE: runonflux.flux: Unable to resolve all types: 1 failures
TC_FAILURE: runonflux.testflux: Unable to resolve all types: 1 failures
TC_FAILURE: user.a: : lam in value position
TC_FAILURE: user.ab: Unable to resolve all types: 34 failures
TC_FAILURE: user.utxo1: Unable to resolve all types: 48 failures
TC_FAILURE: util.guards1: Unable to resolve all types: 2 failures
TC_SUCCESS: arkade.token
TC_SUCCESS: coin
TC_SUCCESS: free.KAPY
TC_SUCCESS: free.KAPYCOIN
TC_SUCCESS: free.KAYC
TC_SUCCESS: free.KDOGE
TC_SUCCESS: free.Kapy
TC_SUCCESS: free.KapyCoin
TC_SUCCESS: free.Kapycoin
TC_SUCCESS: free.SHIB
TC_SUCCESS: free.anedak
TC_SUCCESS: free.anydak
TC_SUCCESS: free.babena-ledger
TC_SUCCESS: free.bana
TC_SUCCESS: free.bulk-increase-count-test1
TC_SUCCESS: free.catcool
TC_SUCCESS: free.corona-token
TC_SUCCESS: free.crankk01
TC_SUCCESS: free.docu
TC_SUCCESS: free.elon
TC_SUCCESS: free.force
TC_SUCCESS: free.hyperhub
TC_SUCCESS: free.inu-crew
TC_SUCCESS: free.jodie-inu
TC_SUCCESS: free.jodie-token
TC_SUCCESS: free.kadena-mining-club1
TC_SUCCESS: free.kadoge
TC_SUCCESS: free.kapy
TC_SUCCESS: free.kapybara-token
TC_SUCCESS: free.kapycoin
TC_SUCCESS: free.kimki
TC_SUCCESS: free.kishu-ken
TC_SUCCESS: free.kitty-kad-kitties
TC_SUCCESS: free.kmp
TC_SUCCESS: free.memory-wall
TC_SUCCESS: free.monster
TC_SUCCESS: free.phiga-inu
TC_SUCCESS: free.popejoy
TC_SUCCESS: free.reminderapp
TC_SUCCESS: free.scar
TC_SUCCESS: free.shatter
TC_SUCCESS: free.sway
TC_SUCCESS: free.timpi
TC_SUCCESS: free.tron
TC_SUCCESS: free.ttest-token
TC_SUCCESS: free.universal-ledger
TC_SUCCESS: free.yeettoken
TC_SUCCESS: free.zrb
TC_SUCCESS: guards
TC_SUCCESS: hypercent.prod-fungible-util
TC_SUCCESS: hypercent.prod-hype-coin
TC_SUCCESS: kaddex.fungible-util
TC_SUCCESS: kaddex.noop-callable
TC_SUCCESS: kaddex.tokens
TC_SUCCESS: kdlaunch.kdswap-token
TC_SUCCESS: kdlaunch.token
TC_SUCCESS: kip.token-manifest
TC_SUCCESS: kswap.fungible-util
TC_SUCCESS: kswap.noop-callable
TC_SUCCESS: kswap.tokens
TC_SUCCESS: lago.USD2
TC_SUCCESS: lago.kwBTC
TC_SUCCESS: lago.kwUSDC
TC_SUCCESS: mok.token
TC_SUCCESS: ns
TC_SUCCESS: runonflux.fungible-util
TC_SUCCESS: user.fungible-util
TC_SUCCESS: util.fungible-util
TC_SUCCESS: util.guards
```