### PR TITLE
Fix nix builds by ignoring freeze & bumping hackage

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -62,7 +62,7 @@ source-repository-package
     type: git
     location: https://github.com/kadena-io/pact.git
     tag: 456aa65ef45596458488ed59e7167621b40e6139
-    --sha256: 0l59xi2by6l6gi10r8c437m7ics29215zr0zl1syyr3039vgmv0x
+    --sha256: sha256-J2Rh2EXczT4QzOM/agOzxq1UPdU6aNPDo3fnfeoVRbA=
 
 source-repository-package
     type: git

--- a/default-flake.nix
+++ b/default-flake.nix
@@ -24,6 +24,7 @@ let haskellSrc = with nix-filter.lib; filter {
         "examples"
         (matchExt "nix")
         "flake.lock"
+        "cabal.project.freeze"
       ];
     };
     chainweb = pkgs.haskell-nix.project' {

--- a/flake.lock
+++ b/flake.lock
@@ -292,11 +292,11 @@
     "hackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1681345550,
-        "narHash": "sha256-HYW1b1KSgNfRR8Md/F2TbyuJnFkxSGr+xU4llbNutRE=",
+        "lastModified": 1685492843,
+        "narHash": "sha256-X8dNs5Gfc2ucfaWAgZ1VmkpBB4Cb44EQZu0b7tkvz2Y=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "15eef733e16531da9013c5437db0357e38535a03",
+        "rev": "e7407bab324eb2445bda58c5ffac393e80dda1e4",
         "type": "github"
       },
       "original": {
@@ -315,7 +315,9 @@
         "flake-compat": "flake-compat",
         "flake-utils": "flake-utils_2",
         "ghc-8.6.5-iohk": "ghc-8.6.5-iohk",
-        "hackage": "hackage",
+        "hackage": [
+          "hackage"
+        ],
         "hls-1.10": "hls-1.10",
         "hpc-coveralls": "hpc-coveralls",
         "hydra": "hydra",
@@ -840,6 +842,7 @@
     "root": {
       "inputs": {
         "flake-utils": "flake-utils",
+        "hackage": "hackage",
         "haskellNix": "haskellNix",
         "nix-filter": "nix-filter",
         "nixpkgs": "nixpkgs_5"

--- a/flake.nix
+++ b/flake.nix
@@ -3,12 +3,15 @@
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs?rev=4d2b37a84fad1091b9de401eb450aae66f1a741e";
+    hackage.url = "github:input-output-hk/hackage.nix";
+    hackage.flake = false;
     haskellNix.url = "github:input-output-hk/haskell.nix";
+    haskellNix.inputs.hackage.follows = "hackage";
     flake-utils.url = "github:numtide/flake-utils";
     nix-filter.url = "github:numtide/nix-filter";
   };
 
-  outputs = { self, nixpkgs, flake-utils, haskellNix, nix-filter }:
+  outputs = { self, nixpkgs, flake-utils, haskellNix, nix-filter, ... }:
     flake-utils.lib.eachSystem
       [ "x86_64-linux" "x86_64-darwin"
         "aarch64-linux" "aarch64-darwin" ] (system:


### PR DESCRIPTION
This PR is an alternative to #1664. The main difference is that we bump the `hackage` snapshot by defining it as a direct input of our flake and telling `haskellNix` to `follow` it. The we can just `nix flake lock --update-input hackage` to bump the snapshot without actually bumping `haskell.nix`. I think this has 2 main advantages:
* Bumping `haskell.nix` may introduce unrelated changes to the build infrastructure. Changes one might not be willing to deal with just to bump the hackage snapshot.
* Bumping `haskell.nix` triggers a deeper transitive dependency rebuild session compared to just bumping `hackage`, which only requires a rebuild of the project's Haskell package dependencies. This can mean a 10-hour rebuild vs. a 2-hour rebuild.