### PR TITLE
Avoid importing haskellNix directly in default.nix

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -6,7 +6,10 @@ let flakeDefaultNix = (import (
        src =  ./.;
      }).defaultNix;
     inputs = flakeDefaultNix.inputs;
-    pkgsDef = import inputs.nixpkgs (import inputs.haskellNix {}).nixpkgsArgs;
+    pkgsDef = import inputs.nixpkgs {
+      config = inputs.haskellNix.config;
+      overlays = [ inputs.haskellNix.overlay] ;
+    };
 in
 { pkgs ? pkgsDef
 , compiler ? "ghc8107"


### PR DESCRIPTION
@chessai Pointed out that the current `master` branch fails to build with `nix build -f . default`, even though our nix build setup is supposed to compute the same derivation for `nix build` and `nix build -f . default` (which is the same as `nix-build`). This PR removes a discrepancy in the way `haskellNix` is used in the non-flake call path, which used to cause `haskellNix` to pick up `hackage.nix` from its own `flake.lock`, which ended up ignoring our explicit `hackage.nix` input.