### PR TITLE
Fix chainweb219Pact heights

### DIFF
--- a/src/Chainweb/Version/Development.hs
+++ b/src/Chainweb/Version/Development.hs
@@ -64,7 +64,7 @@ devnet = ChainwebVersion
             Chainweb216Pact -> AllChains $ BlockHeight 215
             Chainweb217Pact -> AllChains $ BlockHeight 470
             Chainweb218Pact -> AllChains $ BlockHeight 500
-            Chainweb219Pact -> AllChains $ BlockHeight 550 -- TODO
+            Chainweb219Pact -> AllChains $ BlockHeight 550
 
     , _versionUpgrades = foldr (chainZip HM.union) (AllChains mempty)
         [ forkUpgrades devnet

--- a/src/Chainweb/Version/Mainnet.hs
+++ b/src/Chainweb/Version/Mainnet.hs
@@ -138,7 +138,7 @@ mainnet = ChainwebVersion
         Chainweb216Pact -> AllChains (BlockHeight 2_988_324) -- 2022-09-02T00:00:00+00:00
         Chainweb217Pact -> AllChains (BlockHeight 3_250_348) -- 2022-12-02T00:00:00+00:00
         Chainweb218Pact -> AllChains (BlockHeight 3_512_363) -- 2023-03-03 00:00:00+00:00
-        Chainweb219Pact -> AllChains (BlockHeight 4_000_000) -- TODO
+        Chainweb219Pact -> AllChains (BlockHeight 3_774_423) -- 2023-06-02 00:00:00+00:00
 
     , _versionGraphs =
         (to20ChainsMainnet, twentyChainGraph) `Above`

--- a/src/Chainweb/Version/Testnet.hs
+++ b/src/Chainweb/Version/Testnet.hs
@@ -118,7 +118,7 @@ testnet = ChainwebVersion
         Chainweb216Pact -> AllChains 2_516_739  -- 2022-09-01 12:00:00+00:00
         Chainweb217Pact -> AllChains 2_777_367  -- 2022-12-01 12:00:00+00:00
         Chainweb218Pact -> AllChains 3_038_343  -- 2023-03-02 12:00:00+00:00
-        Chainweb219Pact -> AllChains (BlockHeight 4_000_000) -- TODO
+        Chainweb219Pact -> AllChains 3_299_753 -- 2023-06-01 12:00:00+00:00
 
     , _versionGraphs =
         (to20ChainsTestnet, twentyChainGraph) `Above`

--- a/test/Chainweb/Test/TestVersions.hs
+++ b/test/Chainweb/Test/TestVersions.hs
@@ -135,7 +135,7 @@ fastForks = tabulateHashMap $ \case
     Chainweb216Pact -> AllChains (BlockHeight 11)
     Chainweb217Pact -> AllChains (BlockHeight 20)
     Chainweb218Pact -> AllChains (BlockHeight 20)
-    Chainweb219Pact -> AllChains (BlockHeight 26)
+    Chainweb219Pact -> AllChains (BlockHeight 27)
 
 -- | A test version without Pact or PoW, with only one chain graph.
 barebonesTestVersion :: ChainGraph -> ChainwebVersion


### PR DESCRIPTION
A bad merge (or really bad merge order) made the `chainweb219Pact` block height revert to a placeholder. This works in partial replays of recent block history and on a mainnet node.