### PR TITLE
gha: verbose nix builds and --show-trace in case an error occurs

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -31,4 +31,4 @@ jobs:
       timeout-minutes: 740
       run: |
         echo Building the project and its devShell
-        nix build .#check
+        nix build -L --show-trace .#check

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -31,4 +31,4 @@ jobs:
       timeout-minutes: 740
       run: |
         echo Building the project and its devShell
-        nix build -L --show-trace .#check
+        nix build .#check --log-lines 500 --show-trace


### PR DESCRIPTION
This is so error messages don't get truncated, and we can get callstack/trace error messages