### PR TITLE
update pact pin to lastest master

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -59,8 +59,8 @@ package yet-another-logger
 source-repository-package
     type: git
     location: https://github.com/kadena-io/pact.git
-    tag: 7e8125af1313dcf944de4015f83db5a29d441a52
-    --sha256: 1qkzmwqzhhg33x62qpfgr44wan9vzkc7phs61dh0crjbw99czgxh
+    tag: 0d799a839eca103edecfaca96b82d455e03a2978
+    --sha256: 0mjp2fx3bdf3iad87k4sphs8dwfy7qfa10k4lw4sfmah4mc6c3pr
 
 source-repository-package
     type: git


### PR DESCRIPTION
After merging #1709 the pact pin was pointing at pact PR https://github.com/kadena-io/pact/pull/1263. This PR is now merged to master and the PR updates the pact pin accordingly.