### PR TITLE
Tiny fixes

### DIFF
--- a/chainweb.cabal
+++ b/chainweb.cabal
@@ -593,7 +593,7 @@ executable chainweb-node
     default-language: Haskell2010
     ghc-options:
         -threaded
-        "-with-rtsopts=-N -H1G -A64M"
+        "-with-rtsopts=-N -H1G -A64M --disable-delayed-os-memory-return"
         -rtsopts
     hs-source-dirs: node
     main-is: ChainwebNode.hs

--- a/node/ChainwebNode.hs
+++ b/node/ChainwebNode.hs
@@ -75,6 +75,7 @@ import System.FilePath
 import System.IO
 import qualified System.Logger as L
 import System.LogLevel
+import System.Mem
 
 -- internal modules
 
@@ -557,5 +558,9 @@ main = do
                     logFunctionJson logger Error (ProcessDied $ show e) >> throwIO e
                 ] $ do
                 kt <- mapM iso8601ParseM serviceDate
-                withServiceDate (logFunctionText logger) kt $
-                    node conf logger
+                withServiceDate (logFunctionText logger) kt $ void $ 
+                    race (node conf logger) (gcRunner (logFunctionText logger))
+    where
+    gcRunner lf = runForever lf "GarbageCollect" $ do
+        performMajorGC
+        threadDelay (30 * 1_000_000)

--- a/src/Chainweb/RestAPI/Utils.hs
+++ b/src/Chainweb/RestAPI/Utils.hs
@@ -518,7 +518,7 @@ bindPortTcp p interface = do
         socket <- bindPortGen N.Stream (int p) interface
         port <- N.socketPort socket
         return (int port, socket)
-    N.listen sock (max 2048 N.maxListenQueue)
+    N.listen sock (min 2048 N.maxListenQueue)
     return (port, sock)
 
 allocateSocket :: Port -> HostPreference -> IO (Port, N.Socket)

--- a/src/Chainweb/RestAPI/Utils.hs
+++ b/src/Chainweb/RestAPI/Utils.hs
@@ -518,7 +518,7 @@ bindPortTcp p interface = do
         socket <- bindPortGen N.Stream (int p) interface
         port <- N.socketPort socket
         return (int port, socket)
-    N.listen sock (min 2048 N.maxListenQueue)
+    N.listen sock N.maxListenQueue
     return (port, sock)
 
 allocateSocket :: Port -> HostPreference -> IO (Port, N.Socket)


### PR DESCRIPTION
See https://well-typed.com/blog/2021/03/memory-return/, makes the OS' value for the RSS for chainweb-node more accurately reflect the actual used memory. Also adds our version of "idle GC" every 30 seconds, which gives the runtime more chances to return memory to the OS. Also make the socket listen queue size slightly smaller, as was probably originally intended.