### PR TITLE
Update service date again

### DIFF
--- a/node/ChainwebNode.hs
+++ b/node/ChainwebNode.hs
@@ -529,7 +529,7 @@ pkgInfoScopes =
 -- SERVICE DATE for version 2.19
 --
 serviceDate :: Maybe String
-serviceDate = Just "2023-11-05T00:00:00Z"
+serviceDate = Just "2023-10-05T00:00:00Z"
 
 mainInfo :: ProgramInfo ChainwebNodeConfiguration
 mainInfo = programInfoValidate

--- a/node/ChainwebNode.hs
+++ b/node/ChainwebNode.hs
@@ -529,7 +529,7 @@ pkgInfoScopes =
 -- SERVICE DATE for version 2.19
 --
 serviceDate :: Maybe String
-serviceDate = Just "2023-11-07T00:00:00Z"
+serviceDate = Just "2023-11-05T00:00:00Z"
 
 mainInfo :: ProgramInfo ChainwebNodeConfiguration
 mainInfo = programInfoValidate


### PR DESCRIPTION
After acknowledging the issue with the service date and fixing the release calculator the service date still wasn't updated.