### PR TITLE
execNewBlock: remove the parent header as parameter and sync from the db instead

### DIFF
--- a/bench/Chainweb/Pact/Backend/ForkingBench.hs
+++ b/bench/Chainweb/Pact/Backend/ForkingBench.hs
@@ -214,7 +214,7 @@ playLine pdb bhdb trunkLength startingBlock pactQueue counter =
   where
     mineLine :: BlockHeader -> Word64 -> IORef Word64 -> IO [T3 ParentHeader BlockHeader PayloadWithOutputs]
     mineLine start l ncounter =
-        evalStateT (runReaderT (mapM (const go) [startHeight :: Word64 .. startHeight + l - 1]) pactQueue) start
+        evalStateT (runReaderT (mapM (const go) [startHeight :: Word64 .. startHeight + l]) pactQueue) start
       where
         startHeight :: Num a => a
         startHeight = fromIntegral $ _blockHeight start

--- a/src/Chainweb/Pact/Service/BlockValidation.hs
+++ b/src/Chainweb/Pact/Service/BlockValidation.hs
@@ -45,13 +45,12 @@ import Chainweb.Transaction
 import Chainweb.Utils (T2)
 
 
-newBlock :: Miner -> ParentHeader -> PactQueue ->
+newBlock :: Miner -> PactQueue ->
             IO (MVar (Either PactException PayloadWithOutputs))
-newBlock mi bHeader reqQ = do
+newBlock mi reqQ = do
     !resultVar <- newEmptyMVar :: IO (MVar (Either PactException PayloadWithOutputs))
     let !msg = NewBlockMsg NewBlockReq
-          { _newBlockHeader = bHeader
-          , _newMiner = mi
+          { _newMiner = mi
           , _newResultVar = resultVar }
     addRequest reqQ msg
     return resultVar

--- a/src/Chainweb/Pact/Service/Types.hs
+++ b/src/Chainweb/Pact/Service/Types.hs
@@ -303,11 +303,10 @@ data RequestMsg = NewBlockMsg !NewBlockReq
 type PactExMVar t = MVar (Either PactException t)
 
 data NewBlockReq = NewBlockReq
-    { _newBlockHeader :: !ParentHeader
-    , _newMiner :: !Miner
+    { _newMiner :: !Miner
     , _newResultVar :: !(PactExMVar PayloadWithOutputs)
     }
-instance Show NewBlockReq where show NewBlockReq{..} = show (_newBlockHeader, _newMiner)
+instance Show NewBlockReq where show NewBlockReq{..} = show _newMiner
 
 data ValidateBlockReq = ValidateBlockReq
     { _valBlockHeader :: !BlockHeader

--- a/test/Chainweb/Test/CutDB.hs
+++ b/test/Chainweb/Test/CutDB.hs
@@ -403,7 +403,7 @@ tryMineForChain
     -> ChainId
     -> IO (Either MineFailure (Cut, ChainId, PayloadWithOutputs))
 tryMineForChain miner webPact cutDb c cid = do
-    outputs <- _webPactNewBlock webPact miner parent
+    outputs <- _webPactNewBlock webPact cid miner
     let payloadHash = _payloadWithOutputsPayloadHash outputs
     t <- getCurrentTimeIntegral
     x <- testMineWithPayloadHash wdb (Nonce 0) t payloadHash cid c
@@ -416,7 +416,6 @@ tryMineForChain miner webPact cutDb c cid = do
             return $ Right (c', cid, outputs)
         Left e -> return $ Left e
   where
-    parent = ParentHeader $ c ^?! ixg cid -- parent to mine on
     wdb = view cutDbWebBlockHeaderDb cutDb
 
 -- | picks a random block header from a web chain. The result header is

--- a/test/Chainweb/Test/Pact/PactSingleChainTest.hs
+++ b/test/Chainweb/Test/Pact/PactSingleChainTest.hs
@@ -99,16 +99,12 @@ testVersion = slowForkingCpmTestVersion petersonChainGraph
 cid :: ChainId
 cid = someChainId testVersion
 
-genesisHeader :: BlockHeader
-genesisHeader = genesisBlockHeader testVersion cid
-
 tests :: RocksDb -> TestTree
 tests rdb = testGroup testName
   [ test $ goldenNewBlock "new-block-0" goldenMemPool
   , test $ goldenNewBlock "empty-block-tests" mempty
   , test newBlockAndValidate
   , test newBlockAndValidationFailure
-  , test newBlockRewindValidate
   , test getHistory
   , test testHistLookup1
   , test testHistLookup2
@@ -173,7 +169,7 @@ runBlock q bdb timeOffset = do
   ph <- getParentTestBlockDb bdb cid
   let blockTime = add timeOffset $ _bct $ _blockCreationTime ph
   nb <- forSuccess "newBlock" $
-        newBlock noMiner (ParentHeader ph) q
+        newBlock noMiner q
   forM_ (chainIds testVersion) $ \c -> do
     let o | c == cid = nb
           | otherwise = emptyPayload
@@ -196,7 +192,7 @@ newBlockAndValidationFailure refIO reqIO = testCase "newBlockAndValidationFailur
   ph <- getParentTestBlockDb bdb cid
   let blockTime = add second $ _bct $ _blockCreationTime ph
   nb <- forSuccess ("newBlockAndValidate" <> ": newblock") $
-        newBlock noMiner (ParentHeader ph) q
+        newBlock noMiner q
   forM_ (chainIds testVersion) $ \c -> do
     let o | c == cid = nb
           | otherwise = emptyPayload
@@ -631,35 +627,6 @@ assertSender00Bal bal msg hist =
         ])))
     hist
 
-newBlockRewindValidate :: IO (IORef MemPoolAccess) -> IO (SQLiteEnv, PactQueue, TestBlockDb) -> TestTree
-newBlockRewindValidate mpRefIO reqIO = testCase "newBlockRewindValidate" $ do
-  (_, q, bdb) <- reqIO
-  setOneShotMempool mpRefIO chainDataMemPool
-  cut0 <- readMVar $ _bdbCut bdb -- genesis cut
-
-  -- cut 1a
-  void $ runBlock q bdb second
-  cut1a <- readMVar $ _bdbCut bdb
-
-  -- rewind, cut 1b
-  void $ swapMVar (_bdbCut bdb) cut0
-  void $ runBlock q bdb second
-
-  -- rewind to cut 1a to trigger replay with chain data bug
-  void $ swapMVar (_bdbCut bdb) cut1a
-  void $ runBlock q bdb (secondsToTimeSpan 2)
-
-  where
-
-    chainDataMemPool = mempty {
-      mpaGetBlock = \_ _ _ _ bh -> do
-          fmap V.singleton $ buildCwCmd testVersion
-              $ signSender00
-              $ setFromHeader bh
-              $ mkCmd (sshow bh)
-              $ mkExec' "(chain-data)"
-      }
-
 signSender00 :: CmdBuilder -> CmdBuilder
 signSender00 = set cbSigners [mkEd25519Signer' sender00 []]
 
@@ -904,7 +871,7 @@ badlistNewBlockTest mpRefIO reqIO = testCase "badlistNewBlockTest" $ do
     $ mkCmd "badListMPA"
     $ mkExec' "(+ 1 2)"
   setOneShotMempool mpRefIO (badlistMPA badTx badHashRef)
-  resp <- forSuccess "badlistNewBlockTest" $ newBlock noMiner (ParentHeader genesisHeader) reqQ
+  resp <- forSuccess "badlistNewBlockTest" $ newBlock noMiner reqQ
   assertEqual "bad tx filtered from block" mempty (_payloadWithOutputsTransactions resp)
   badHash <- readIORef badHashRef
   assertEqual "Badlist should have badtx hash" (hashToTxHashList $ _cmdHash badTx) badHash
@@ -920,7 +887,7 @@ goldenNewBlock name mp mpRefIO reqIO = golden name $ do
     (_, reqQ, _) <- reqIO
     setOneShotMempool mpRefIO mp
     resp <- forSuccess ("goldenNewBlock:" ++ name) $
-      newBlock noMiner (ParentHeader genesisHeader) reqQ
+      newBlock noMiner reqQ
     -- ensure all golden txs succeed
     forM_ (_payloadWithOutputsTransactions resp) $ \(txIn,TransactionOutput out) -> do
       cr :: CommandResult Hash <- decodeStrictOrThrow out

--- a/test/Chainweb/Test/Pact/TTL.hs
+++ b/test/Chainweb/Test/Pact/TTL.hs
@@ -220,7 +220,7 @@ doNewBlock ctxIO mempool parent nonce t = do
      ctx <- ctxIO
      unlessM (tryPutMVar (_ctxMempool ctx) mempool) $
         error "Test failure: mempool access is not empty. Some previous test step failed unexpectedly"
-     mv <- newBlock noMiner parent $ _ctxQueue ctx
+     mv <- newBlock noMiner $ _ctxQueue ctx
      payload <- assertNotLeft =<< takeMVar mv
 
      let bh = newBlockHeader


### PR DESCRIPTION


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205566925523372