### PR TITLE
Enable applications workflow on merge_group event

### DIFF
--- a/.github/workflows/applications.yml
+++ b/.github/workflows/applications.yml
@@ -22,6 +22,7 @@ on:
     paths:
     - '**'
       #    - '!.github/**'
+  merge_group:
 
 env:
   AWS_ACCESS_KEY_ID: ${{ secrets.kadena_cabal_cache_aws_access_key_id }}


### PR DESCRIPTION
I want to use a merge queue!

I'm not sure if we need this PR per se, but https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue#triggering-merge-group-checks-with-github-actions says so.