### PR TITLE
flake: explicitly configure public build cache by default in nixConfig

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -38,4 +38,4 @@ jobs:
     - name: Build and cache artifacts
       run: |
         echo Building the project and its devShell
-        nix build .#check --log-lines 500 --show-trace
+        nix build .#check --log-lines 500 --show-trace --accept-flake-config

--- a/flake.nix
+++ b/flake.nix
@@ -15,6 +15,11 @@
     nix-filter.url = "github:numtide/nix-filter";
   };
 
+  nixConfig = {
+    extra-substituters = "https://nixcache.chainweb.com https://cache.iog.io";
+    trusted-public-keys = "nixcache.chainweb.com:FVN503ABX9F8x8K0ptnc99XEz5SaA4Sks6kNcZn2pBY= iohk.cachix.org-1:DpRUyj7h7V830dp/i6Nti+NEO2/nhblbov/8MW7Rqoo= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=";
+  };
+
   outputs = { self, nixpkgs, flake-utils, haskellNix, nix-filter, ... }:
     flake-utils.lib.eachSystem
       [ "x86_64-linux" "x86_64-darwin"


### PR DESCRIPTION
Summary: Add configuration for using the public S3 build cache in `nixConfig`, so all users get it OOTB with no effort. This is a much better experience than accidentally compiling 1 billion things on accident for the first time.

At some point, we might want to look at optimizing the cache itself (e.g. you can do a lot better in perf/price than raw S3), but that can come later since it only needs a URL change in practice.

Change-Id: I999da7a83317ad1bd83c8a521c43cff4