### PR TITLE
update parameters for replay db

### DIFF
--- a/.github/workflows/applications.yml
+++ b/.github/workflows/applications.yml
@@ -53,7 +53,7 @@ jobs:
       debug: ${{ steps.compile-flags.outputs.debug }}
       eventlog: ${{ steps.compile-flags.outputs.eventlog }}
       tag-suffix: ${{ steps.compile-flags.outputs.tag-suffix }}
-      chainweb-network-version: "fast-development"
+      chainweb-network-version: ${{ steps.compile-flags.outputs.chainweb-network-version }}
     steps:
     - name: Checkout repository
       uses: actions/checkout@v3
@@ -67,6 +67,8 @@ jobs:
       id: compile-flags
       run: |
         TAG_SUFFIX=
+        
+        echo "chainweb-network-version=fast-development" >> $GITHUB_OUTPUT
 
         # Optimization
         OPT_LEVEL=${{ github.event.inputs.optimizationLevel }}

--- a/.github/workflows/applications.yml
+++ b/.github/workflows/applications.yml
@@ -53,6 +53,7 @@ jobs:
       debug: ${{ steps.compile-flags.outputs.debug }}
       eventlog: ${{ steps.compile-flags.outputs.eventlog }}
       tag-suffix: ${{ steps.compile-flags.outputs.tag-suffix }}
+      chainweb-network-version: "fast-development"
     steps:
     - name: Checkout repository
       uses: actions/checkout@v3
@@ -176,11 +177,12 @@ jobs:
 
   sync-chain-db:
     name: Download test chain database
+    needs: [config]
     runs-on: 'ubuntu-latest'
     strategy:
       fail-fast: false
       matrix:
-        chainwebVersion: ['fast-development']
+        chainwebVersion: ${{ needs.config.outputs.chainweb-network-version }}
     env:
       DB_SNAPSHOT_URI: 's3://chainweb-chain-db/${{ matrix.chainwebVersion }}/pipeline-db/rocksDb'
     steps:
@@ -463,10 +465,10 @@ jobs:
       ARTIFACTS_NAME: chainweb-applications.${{ matrix.use-freeze-file }}.${{ matrix.ghc }}.${{ matrix.os }}
     steps:
     - uses: actions/checkout@v3
-    - name: Download ${{ matrix.chainwebVersion }} chain database artifact
+    - name: Download ${{ needs.config.outputs.chainweb-network-version }} chain database artifact
       uses: actions/download-artifact@v3
       with:
-        name: chain-db-development
+        name: ${{ needs.config.outputs.chainweb-network-version }}
         path: db
     - name: Download build artifacts
       uses: actions/download-artifact@v3
@@ -485,7 +487,7 @@ jobs:
           databaseDirectory: "db"
           chainweb:
             onlySyncPact: true
-            chainwebVersion: fast-development
+            chainwebVersion: ${{ needs.config.outputs.chainweb-network-version }}
             validateHashesOnReplay: true
             p2p:
               peer:

--- a/.github/workflows/applications.yml
+++ b/.github/workflows/applications.yml
@@ -180,7 +180,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        chainwebVersion: ['development']
+        chainwebVersion: ['fast-development']
     env:
       DB_SNAPSHOT_URI: 's3://chainweb-chain-db/${{ matrix.chainwebVersion }}/pipeline-db/rocksDb'
     steps:
@@ -485,7 +485,7 @@ jobs:
           databaseDirectory: "db"
           chainweb:
             onlySyncPact: true
-            chainwebVersion: development
+            chainwebVersion: fast-development
             validateHashesOnReplay: true
             p2p:
               peer:

--- a/.github/workflows/applications.yml
+++ b/.github/workflows/applications.yml
@@ -183,17 +183,15 @@ jobs:
     runs-on: 'ubuntu-latest'
     strategy:
       fail-fast: false
-      matrix:
-        chainwebVersion: ${{ needs.config.outputs.chainweb-network-version }}
     env:
-      DB_SNAPSHOT_URI: 's3://chainweb-chain-db/${{ matrix.chainwebVersion }}/pipeline-db/rocksDb'
+      DB_SNAPSHOT_URI: 's3://chainweb-chain-db/${{ needs.config.outputs.chainweb-network-version }}/pipeline-db/rocksDb'
     steps:
     - name: Sync chain database from S3
       run: aws s3 sync "$DB_SNAPSHOT_URI" db/0/rocksDb --delete --exclude=LOCK
     - name: Store chain database as artifact
       uses: actions/upload-artifact@v3
       with:
-        name: chain-db-${{ matrix.chainwebVersion }}
+        name: chain-db-${{ needs.config.outputs.chainweb-network-version }}
         path: db
 
   # ########################################################################## #
@@ -470,7 +468,7 @@ jobs:
     - name: Download ${{ needs.config.outputs.chainweb-network-version }} chain database artifact
       uses: actions/download-artifact@v3
       with:
-        name: ${{ needs.config.outputs.chainweb-network-version }}
+        name: chain-db-${{ needs.config.outputs.chainweb-network-version }}
         path: db
     - name: Download build artifacts
       uses: actions/download-artifact@v3


### PR DESCRIPTION
As we've switched over to fast-development as the dev network for replays and integration tests, the existing replay steps aren't working.  This has updated parameters so that if we change the name again or add a new development network, we can change it in one place accurately.