### PR TITLE
Expose pact through Nix

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -16,7 +16,7 @@ in
 , flakePath ? flakeDefaultNix.outPath
 , nix-filter ? inputs.nix-filter
 , pact ? null
-, enablePactBuildtool ? true
+, enablePactBuildTool ? true
 , ...
 }:
 let haskellSrc = with nix-filter.lib; filter {
@@ -49,7 +49,7 @@ let haskellSrc = with nix-filter.lib; filter {
       ' $out
       echo 'packages: ${pact}' >> $out
     '';
-    overridePactBuildTool = pkgs.lib.optionalString enablePactBuildtool ''
+    overridePactBuildTool = pkgs.lib.optionalString enablePactBuildTool ''
       # Remove the -build-tool flag from the pact package section, this allows
       # us to build the pact executable through the chainweb project
       sed -i '/package pact/,/^[^\ ]/{/^[ \t]/!b; s/-build-tool//}' $out

--- a/default.nix
+++ b/default.nix
@@ -16,7 +16,7 @@ in
 , flakePath ? flakeDefaultNix.outPath
 , nix-filter ? inputs.nix-filter
 , pact ? null
-, enablePactBuildTool ? true
+, enablePactBuildTool ? false
 , ...
 }:
 let haskellSrc = with nix-filter.lib; filter {

--- a/default.nix
+++ b/default.nix
@@ -36,8 +36,13 @@ let haskellSrc = with nix-filter.lib; filter {
       # Remove the source-repository-package section for pact and inject the
       # override as a packages section
       ${pkgs.gawk}/bin/awk -i inplace '
-        BEGIN { delete_block=0; }
-        /^$/ { if (delete_block == 0) print buffer "\n"; buffer=""; delete_block=0; next; }
+        BEGINFILE { delete_block=0; buffer = ""; }
+        /^$/ {
+          if (delete_block == 0) print buffer "\n";
+          buffer="";
+          delete_block=0;
+          next;
+        }
         /location: https:\/\/github.com\/kadena-io\/pact.git/ { delete_block=1; }
         {
           if (delete_block == 0) {
@@ -45,7 +50,7 @@ let haskellSrc = with nix-filter.lib; filter {
             buffer = buffer $0;
           }
         }
-        END { if (delete_block == 0) print buffer; }
+        ENDFILE { if (delete_block == 0) print buffer "\n"; }
       ' $out
       echo 'packages: ${pact}' >> $out
     '';

--- a/default.nix
+++ b/default.nix
@@ -15,6 +15,8 @@ in
 , compiler ? "ghc963"
 , flakePath ? flakeDefaultNix.outPath
 , nix-filter ? inputs.nix-filter
+, pact ? null
+, enablePactBuildtool ? true
 , ...
 }:
 let haskellSrc = with nix-filter.lib; filter {
@@ -30,10 +32,36 @@ let haskellSrc = with nix-filter.lib; filter {
         "cabal.project.freeze"
       ];
     };
-    chainweb = pkgs.haskell-nix.project' {
+    overridePact = pkgs.lib.optionalString (pact != null) ''
+      # Remove the source-repository-package section for pact and inject the
+      # override as a packages section
+      ${pkgs.gawk}/bin/awk -i inplace '
+        BEGIN { delete_block=0; }
+        /^$/ { if (delete_block == 0) print buffer "\n"; buffer=""; delete_block=0; next; }
+        /location: https:\/\/github.com\/kadena-io\/pact.git/ { delete_block=1; }
+        {
+          if (delete_block == 0) {
+            if (buffer != "") buffer = buffer "\n";
+            buffer = buffer $0;
+          }
+        }
+        END { if (delete_block == 0) print buffer; }
+      ' $out
+      echo 'packages: ${pact}' >> $out
+    '';
+    overridePactBuildTool = pkgs.lib.optionalString enablePactBuildtool ''
+      # Remove the -build-tool flag from the pact package section, this allows
+      # us to build the pact executable through the chainweb project
+      sed -i '/package pact/,/^[^\ ]/{/^[ \t]/!b; s/-build-tool//}' $out
+    '';
+    chainweb = pkgs.haskell-nix.cabalProject' {
       src = haskellSrc;
       compiler-nix-name = compiler;
-      projectFileName = "cabal.project";
+      cabalProject = builtins.readFile (pkgs.runCommand "cabal.project" {} ''
+        cat ${./cabal.project} > $out
+        ${overridePact}
+        ${overridePactBuildTool}
+      '').outPath;
       shell.tools = {
         cabal = {};
       };

--- a/flake.lock
+++ b/flake.lock
@@ -83,6 +83,22 @@
         "type": "github"
       }
     },
+    "empty": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1683033565,
+        "narHash": "sha256-UZ2dz7/RzJKTw/8uqLu6biAbb3xNk23xUHb5/oAYWsw=",
+        "owner": "kadena-io",
+        "repo": "empty",
+        "rev": "c30c041f692678788a294069c95677774be2dff3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "kadena-io",
+        "repo": "empty",
+        "type": "github"
+      }
+    },
     "flake-compat": {
       "flake": false,
       "locked": {
@@ -592,11 +608,15 @@
     },
     "root": {
       "inputs": {
+        "empty": "empty",
         "flake-utils": "flake-utils",
         "hackage": "hackage",
         "haskellNix": "haskellNix",
         "nix-filter": "nix-filter",
-        "nixpkgs": "nixpkgs_2"
+        "nixpkgs": "nixpkgs_2",
+        "pact": [
+          "empty"
+        ]
       }
     },
     "stackage": {


### PR DESCRIPTION
This PR exposes the pact input of `chainweb` at the Nix layer:
* Allows the `pact` input to be overriden as a flake input
* Exposes the `pact` package (with the CLI) of the Haskell package set

This PR essentially does 2 things:
* If the `pact` input of the flake is overriden, it pre-processes `cabal.project` input of the `haskell.nix` project to remove the `source-repository-package` for `pact` and inject the given `pact` source as a `packages: ${pact}` entry. 
* As long as the `enablePactBuildTool` input of `default.nix` is `true` (`true` by default), it removes the `-build-tool` argument from the `flags` list of the `package pact` section, causing `pact` to emit its `executable pact` section.

Note that `haskell.nix`'s `cabalProject'` interface allows a certain degree of customization through the `modules` argument, but neither of these changes can be applied through that interface (one can actually try, but it doesn't work), because these changes affect the project's build plan generation, therefore they need to be applied very early on in the project's specification.

The purpose of this PR is to:
1) Allow the nixified devnet to to specify the pact version independently of the chainweb-node version by overriding the `pact` input
2) Allow the nixified devnet to use the same `pact` CLI version that's used in a given `chainweb-node` by accessing it through the `haskell.nix` project's `hsPkgs`. As a side benefit, this also means we don't have to wait for Nix to evaluate two separate `haskell.nix` projects.
