### PR TITLE
nix: small tweaks

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -28,6 +28,7 @@ let haskellSrc = with nix-filter.lib; filter {
         (matchExt "nix")
         "flake.lock"
         "cabal.project.freeze"
+        "dist-newstyle"
       ];
     };
     chainweb = pkgs.haskell-nix.project' {

--- a/default.nix
+++ b/default.nix
@@ -37,6 +37,7 @@ let haskellSrc = with nix-filter.lib; filter {
       projectFileName = "cabal.project";
       shell.tools = {
         cabal = {};
+        haskell-language-server = {};
       };
       shell.buildInputs = with pkgs; [
         zlib


### PR DESCRIPTION
Don't pick up `dist-newstyle`, and also include `haskell-language-server` in the default flake env.