### PR TITLE
service: return correct tx hash in txindex inner join

### DIFF
--- a/src/Chainweb/Pact/Backend/RelationalCheckpointer.hs
+++ b/src/Chainweb/Pact/Backend/RelationalCheckpointer.hs
@@ -339,19 +339,21 @@ doLookupSuccessful dbenv confDepth hashes = runBlockEnv dbenv $ do
           blockheightval = maybe [] (\bh -> [SInt bh]) blockheight
           qvals = [ SBlob (BS.fromShort hash) | (TypedHash hash) <- V.toList hashes ] ++ blockheightval
 
-        qry db qtext qvals [RInt, RBlob] >>= mapM go
-      return $ HashMap.fromList (zip (V.toList hashes) r)
+        qry db qtext qvals [RInt, RBlob, RBlob] >>= mapM go
+      return $ HashMap.fromList (map (\(T3 blockheight blockhash txhash) -> (txhash, T2 blockheight blockhash)) r)
   where
-    qtext = "SELECT blockheight, hash FROM \
+    qtext = "SELECT blockheight, hash, txhash FROM \
             \TransactionIndex INNER JOIN BlockHistory \
             \USING (blockheight) WHERE txhash IN (" <> hashesParams <> ")"
             <> maybe "" (const " AND blockheight <= ?") confDepth
             <> ";"
     hashesParams = Utf8 $ intercalate "," [ "?" | _ <- V.toList hashes]
 
-    go ((SInt h):(SBlob blob):_) = do
-        !hsh <- either fail return $ runGetEitherS decodeBlockHash blob
-        return $! T2 (fromIntegral h) hsh
+    go :: [SType] -> IO (T3 BlockHeight BlockHash PactHash)
+    go (SInt blockheight:SBlob blockhash:SBlob txhash:_) = do
+        !blockhash' <- either fail return $ runGetEitherS decodeBlockHash blockhash
+        let !txhash' = TypedHash $ BS.toShort txhash
+        return $! T3 (fromIntegral blockheight) blockhash' txhash'
     go _ = fail "impossible"
 
 doGetBlockHistory :: Db logger -> BlockHeader -> Domain RowKey RowData -> IO BlockTxHistory


### PR DESCRIPTION
Summary: The INNER JOIN used to return the result set when looking up a transaction hash was `zip`'d without taking into account the ordering of the result set. This in turn meant that tx ID's got mapped to the wrong block IDs, resulting in lookup failures.

This could be reproduced with the following minimal `/poll` query with only two request keys:

    {"requestKeys": [
      "1zirlzrAQi4Zlzew5t8LF1jTtkom6YZS9qT-K9IEzHI",
      "MdYI2HrYztPbpnAN5BXCT4IRw10XqcIU1qAPLC0l9Eo"
    ]}

which would return the empty JSON object.

Aside from all of that, the error handling for `internalPoll` is rather poor as it exists purely within `MaybeT`, giving no chance of reporting any meaningful errors. (I threw away a small cleanup for this since it was too debugging oriented, and needs to go through another round of review.)

Closes #1732.


Change-Id: I3e6f1a98a5d867125c54cac8d47d01ba