### PR TITLE
Migrate to hs-nix-infra for the Nix setup

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -20,7 +20,7 @@ jobs:
       uses: actions/checkout@v3
 
     - name: Set up Nix with caching
-      uses: kadena-io/setup-nix-with-cache/by-root@enis/customizable-nix-conf
+      uses: kadena-io/setup-nix-with-cache/by-root@v3
       with:
         cache_url: s3://nixcache.chainweb.com?region=us-east-1
         signing_private_key: ${{ secrets.NIX_CACHE_PRIVATE_KEY }}

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -20,7 +20,7 @@ jobs:
       uses: actions/checkout@v3
 
     - name: Set up Nix with caching
-      uses: kadena-io/setup-nix-with-cache/by-root@v3
+      uses: kadena-io/setup-nix-with-cache/by-root@v3.1
       with:
         cache_url: s3://nixcache.chainweb.com?region=us-east-1
         signing_private_key: ${{ secrets.NIX_CACHE_PRIVATE_KEY }}

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -20,10 +20,11 @@ jobs:
       uses: actions/checkout@v3
 
     - name: Set up Nix with caching
-      uses: kadena-io/setup-nix-with-cache/by-root@v3
+      uses: kadena-io/setup-nix-with-cache/by-root@enis/customizable-nix-conf
       with:
         cache_url: s3://nixcache.chainweb.com?region=us-east-1
         signing_private_key: ${{ secrets.NIX_CACHE_PRIVATE_KEY }}
+        additional_experimental_features: recursive-nix
 
     - name: Set up AWS credentials
       uses: aws-actions/configure-aws-credentials@v2
@@ -34,8 +35,9 @@ jobs:
 
     - name: Give root user AWS credentials
       uses: kadena-io/setup-nix-with-cache/copy-root-aws-credentials@v3
-      
+
     - name: Build and cache artifacts
       run: |
         echo Building the project and its devShell
         nix build .#check --log-lines 500 --show-trace --accept-flake-config
+        nix build .#recursive --log-lines 500 --show-trace --accept-flake-config

--- a/default.nix
+++ b/default.nix
@@ -6,9 +6,10 @@ let flakeDefaultNix = (import (
        src =  ./.;
      }).defaultNix;
     inputs = flakeDefaultNix.inputs;
-    pkgsDef = import inputs.nixpkgs {
-      config = inputs.haskellNix.config;
-      overlays = [ inputs.haskellNix.overlay] ;
+    hs-nix-infra = inputs.hs-nix-infra;
+    pkgsDef = import hs-nix-infra.nixpkgs {
+      config = hs-nix-infra.haskellNix.config;
+      overlays = [ hs-nix-infra.haskellNix.overlay] ;
     };
 in
 { pkgs ? pkgsDef

--- a/default.nix
+++ b/default.nix
@@ -51,7 +51,16 @@ let haskellSrc = with nix-filter.lib; filter {
       ];
     };
     flake = chainweb.flake {};
-    default = pkgs.runCommandCC "chainweb" {} ''
+    metadata = {
+      pact = {
+        version = chainweb.hsPkgs.pact.identifier.version;
+        src = chainweb.hsPkgs.pact.src;
+      };
+      chainweb = {
+        version = chainweb.hsPkgs.chainweb.identifier.version;
+      };
+    };
+    default = pkgs.runCommandCC "chainweb" { outputs = ["out" "metadata"]; } ''
       mkdir -pv $out/bin
       cp ${flake.packages."chainweb:exe:chainweb-node"}/bin/chainweb-node $out/bin/chainweb-node
       cp ${flake.packages."chainweb:exe:cwtool"}/bin/cwtool $out/bin/cwtool
@@ -61,6 +70,11 @@ let haskellSrc = with nix-filter.lib; filter {
       ${pkgs.lib.optionalString (pkgs.stdenv.isLinux) ''
         patchelf --shrink-rpath $out/bin/{cwtool,chainweb-node}
       ''}
+
+      # Emit metadata about the chainweb binaries as a separate derivation output
+      cat > $metadata <<'EOF'
+      ${builtins.toJSON metadata}
+      EOF
     '';
 in {
   # The Haskell project flake: Used by flake.nix

--- a/flake.lock
+++ b/flake.lock
@@ -17,6 +17,21 @@
       }
     },
     "flake-compat": {
+      "locked": {
+        "lastModified": 1699384378,
+        "narHash": "sha256-jI0nYllONVrNnyOYrvQMIEJQJuNeKnfJo5keRxWMcWs=",
+        "owner": "enobayram",
+        "repo": "flake-compat",
+        "rev": "6ef9397736efb0f6075188aa3488022d1b85c11d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "enobayram",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-compat_2": {
       "flake": false,
       "locked": {
         "lastModified": 1672831974,
@@ -89,7 +104,7 @@
           "hs-nix-infra",
           "empty"
         ],
-        "flake-compat": "flake-compat",
+        "flake-compat": "flake-compat_2",
         "ghc-8.6.5-iohk": [
           "hs-nix-infra",
           "empty"
@@ -204,11 +219,7 @@
     "hs-nix-infra": {
       "inputs": {
         "empty": "empty",
-        "flake-compat": [
-          "hs-nix-infra",
-          "haskellNix",
-          "flake-compat"
-        ],
+        "flake-compat": "flake-compat",
         "hackage": [
           "hackage"
         ],
@@ -216,15 +227,16 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1699380825,
-        "narHash": "sha256-+iDc/HROuQJGDi+aS5iQqZJBjoAysOJ2SBRdPqTBPGM=",
+        "lastModified": 1699384809,
+        "narHash": "sha256-2ZHgx/GThQUGtoRaDVe72+nwHjt+y0F9SU5ZE00eG+g=",
         "owner": "kadena-io",
         "repo": "hs-nix-infra",
-        "rev": "9e1a1ccbf976499bd8820e567f94ceafd68d1789",
+        "rev": "796748d8830d0b254905fb0474a176de79e702d7",
         "type": "github"
       },
       "original": {
         "owner": "kadena-io",
+        "ref": "enis/experiment-with-recursive-inputs",
         "repo": "hs-nix-infra",
         "type": "github"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -18,11 +18,11 @@
     },
     "flake-compat": {
       "locked": {
-        "lastModified": 1699384378,
-        "narHash": "sha256-jI0nYllONVrNnyOYrvQMIEJQJuNeKnfJo5keRxWMcWs=",
+        "lastModified": 1699390179,
+        "narHash": "sha256-tWx/Y8O0xq8T/YNZUichaKVO2jOZSOSoiFLQLZHi9BI=",
         "owner": "enobayram",
         "repo": "flake-compat",
-        "rev": "6ef9397736efb0f6075188aa3488022d1b85c11d",
+        "rev": "3a9e1d04df57bd541b561799531431b2a2ba67e3",
         "type": "github"
       },
       "original": {
@@ -227,11 +227,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1699384809,
-        "narHash": "sha256-2ZHgx/GThQUGtoRaDVe72+nwHjt+y0F9SU5ZE00eG+g=",
+        "lastModified": 1699390214,
+        "narHash": "sha256-x4zJqdldyoSNvVNbxWfJlaZaSn+AM/MR4hwReqLh7d8=",
         "owner": "kadena-io",
         "repo": "hs-nix-infra",
-        "rev": "796748d8830d0b254905fb0474a176de79e702d7",
+        "rev": "ae42552e94dde924622a563129cfb569a9e2ebb4",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -204,6 +204,11 @@
     "hs-nix-infra": {
       "inputs": {
         "empty": "empty",
+        "flake-compat": [
+          "hs-nix-infra",
+          "haskellNix",
+          "flake-compat"
+        ],
         "hackage": [
           "hackage"
         ],
@@ -211,11 +216,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1699283242,
-        "narHash": "sha256-weg0rDYjM93IxaRwcfNlnT6lVJ/f6dtfyF6ngF/6dlw=",
+        "lastModified": 1699355159,
+        "narHash": "sha256-tyoBGztZoqyx6eWTR7uMpLAQhH9ZHGknQljZQtu/SYI=",
         "owner": "kadena-io",
         "repo": "hs-nix-infra",
-        "rev": "1410c0de36aa60fee36d65da22fb944ac87dee21",
+        "rev": "33e68113d0736b269c9eb3ed6551ff35bad84dca",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -18,11 +18,11 @@
     },
     "flake-compat": {
       "locked": {
-        "lastModified": 1699390179,
-        "narHash": "sha256-tWx/Y8O0xq8T/YNZUichaKVO2jOZSOSoiFLQLZHi9BI=",
+        "lastModified": 1699390864,
+        "narHash": "sha256-MWSuUZWZRYI8CAKbU/NhjNy22FSOuUZ9SsdwSW5N07o=",
         "owner": "enobayram",
         "repo": "flake-compat",
-        "rev": "3a9e1d04df57bd541b561799531431b2a2ba67e3",
+        "rev": "0b84b577d4a337421ff7b014b99cbf464d211fb3",
         "type": "github"
       },
       "original": {
@@ -227,11 +227,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1699390214,
-        "narHash": "sha256-x4zJqdldyoSNvVNbxWfJlaZaSn+AM/MR4hwReqLh7d8=",
+        "lastModified": 1699390882,
+        "narHash": "sha256-X0Q0jkGQw7W8qeUVhwJ/Dsu8TyKKofDIX5ga+oBc6k4=",
         "owner": "kadena-io",
         "repo": "hs-nix-infra",
-        "rev": "ae42552e94dde924622a563129cfb569a9e2ebb4",
+        "rev": "a147cc7c0ba19033cc5ba4a555405443f411b2b1",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -216,11 +216,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1699373628,
-        "narHash": "sha256-ieeoaxDbmloJT1+vl6fUEOO8rrVgLc+ZPiEPjZuif/0=",
+        "lastModified": 1699380825,
+        "narHash": "sha256-+iDc/HROuQJGDi+aS5iQqZJBjoAysOJ2SBRdPqTBPGM=",
         "owner": "kadena-io",
         "repo": "hs-nix-infra",
-        "rev": "00fee2645e99f944992ae54a1fffb1a8cb4a99a7",
+        "rev": "9e1a1ccbf976499bd8820e567f94ceafd68d1789",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -1,85 +1,18 @@
 {
   "nodes": {
-    "HTTP": {
+    "empty": {
       "flake": false,
       "locked": {
-        "lastModified": 1451647621,
-        "narHash": "sha256-oHIyw3x0iKBexEo49YeUDV1k74ZtyYKGR2gNJXXRxts=",
-        "owner": "phadej",
-        "repo": "HTTP",
-        "rev": "9bc0996d412fef1787449d841277ef663ad9a915",
+        "lastModified": 1683033565,
+        "narHash": "sha256-UZ2dz7/RzJKTw/8uqLu6biAbb3xNk23xUHb5/oAYWsw=",
+        "owner": "kadena-io",
+        "repo": "empty",
+        "rev": "c30c041f692678788a294069c95677774be2dff3",
         "type": "github"
       },
       "original": {
-        "owner": "phadej",
-        "repo": "HTTP",
-        "type": "github"
-      }
-    },
-    "cabal-32": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1603716527,
-        "narHash": "sha256-X0TFfdD4KZpwl0Zr6x+PLxUt/VyKQfX7ylXHdmZIL+w=",
-        "owner": "haskell",
-        "repo": "cabal",
-        "rev": "48bf10787e27364730dd37a42b603cee8d6af7ee",
-        "type": "github"
-      },
-      "original": {
-        "owner": "haskell",
-        "ref": "3.2",
-        "repo": "cabal",
-        "type": "github"
-      }
-    },
-    "cabal-34": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1645834128,
-        "narHash": "sha256-wG3d+dOt14z8+ydz4SL7pwGfe7SiimxcD/LOuPCV6xM=",
-        "owner": "haskell",
-        "repo": "cabal",
-        "rev": "5ff598c67f53f7c4f48e31d722ba37172230c462",
-        "type": "github"
-      },
-      "original": {
-        "owner": "haskell",
-        "ref": "3.4",
-        "repo": "cabal",
-        "type": "github"
-      }
-    },
-    "cabal-36": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1669081697,
-        "narHash": "sha256-I5or+V7LZvMxfbYgZATU4awzkicBwwok4mVoje+sGmU=",
-        "owner": "haskell",
-        "repo": "cabal",
-        "rev": "8fd619e33d34924a94e691c5fea2c42f0fc7f144",
-        "type": "github"
-      },
-      "original": {
-        "owner": "haskell",
-        "ref": "3.6",
-        "repo": "cabal",
-        "type": "github"
-      }
-    },
-    "cardano-shell": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1608537748,
-        "narHash": "sha256-PulY1GfiMgKVnBci3ex4ptk2UNYMXqGjJOxcPy2KYT4=",
-        "owner": "input-output-hk",
-        "repo": "cardano-shell",
-        "rev": "9392c75087cb9a3d453998f4230930dea3a95725",
-        "type": "github"
-      },
-      "original": {
-        "owner": "input-output-hk",
-        "repo": "cardano-shell",
+        "owner": "kadena-io",
+        "repo": "empty",
         "type": "github"
       }
     },
@@ -115,23 +48,6 @@
       "original": {
         "owner": "numtide",
         "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "ghc-8.6.5-iohk": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1600920045,
-        "narHash": "sha256-DO6kxJz248djebZLpSzTGD6s8WRpNI9BTwUeOf5RwY8=",
-        "owner": "input-output-hk",
-        "repo": "ghc",
-        "rev": "95713a6ecce4551240da7c96b6176f980af75cae",
-        "type": "github"
-      },
-      "original": {
-        "owner": "input-output-hk",
-        "ref": "release/8.6.5-iohk",
-        "repo": "ghc",
         "type": "github"
       }
     },
@@ -190,38 +106,100 @@
     },
     "haskellNix": {
       "inputs": {
-        "HTTP": "HTTP",
-        "cabal-32": "cabal-32",
-        "cabal-34": "cabal-34",
-        "cabal-36": "cabal-36",
-        "cardano-shell": "cardano-shell",
+        "HTTP": [
+          "hs-nix-infra",
+          "empty"
+        ],
+        "cabal-32": [
+          "hs-nix-infra",
+          "empty"
+        ],
+        "cabal-34": [
+          "hs-nix-infra",
+          "empty"
+        ],
+        "cabal-36": [
+          "hs-nix-infra",
+          "empty"
+        ],
+        "cardano-shell": [
+          "hs-nix-infra",
+          "empty"
+        ],
         "flake-compat": "flake-compat",
-        "ghc-8.6.5-iohk": "ghc-8.6.5-iohk",
+        "ghc-8.6.5-iohk": [
+          "hs-nix-infra",
+          "empty"
+        ],
         "ghc980": "ghc980",
         "ghc99": "ghc99",
         "hackage": [
+          "hs-nix-infra",
           "hackage"
         ],
-        "hls-1.10": "hls-1.10",
-        "hls-2.0": "hls-2.0",
-        "hls-2.2": "hls-2.2",
+        "hls-1.10": [
+          "hs-nix-infra",
+          "empty"
+        ],
+        "hls-2.0": [
+          "hs-nix-infra",
+          "empty"
+        ],
+        "hls-2.2": [
+          "hs-nix-infra",
+          "empty"
+        ],
         "hls-2.3": "hls-2.3",
-        "hpc-coveralls": "hpc-coveralls",
-        "hydra": "hydra",
-        "iserv-proxy": "iserv-proxy",
+        "hpc-coveralls": [
+          "hs-nix-infra",
+          "empty"
+        ],
+        "hydra": [
+          "hs-nix-infra",
+          "empty"
+        ],
+        "iserv-proxy": [
+          "hs-nix-infra",
+          "empty"
+        ],
         "nixpkgs": [
+          "hs-nix-infra",
           "haskellNix",
           "nixpkgs-unstable"
         ],
-        "nixpkgs-2003": "nixpkgs-2003",
-        "nixpkgs-2105": "nixpkgs-2105",
-        "nixpkgs-2111": "nixpkgs-2111",
-        "nixpkgs-2205": "nixpkgs-2205",
-        "nixpkgs-2211": "nixpkgs-2211",
-        "nixpkgs-2305": "nixpkgs-2305",
+        "nixpkgs-2003": [
+          "hs-nix-infra",
+          "empty"
+        ],
+        "nixpkgs-2105": [
+          "hs-nix-infra",
+          "empty"
+        ],
+        "nixpkgs-2111": [
+          "hs-nix-infra",
+          "empty"
+        ],
+        "nixpkgs-2205": [
+          "hs-nix-infra",
+          "empty"
+        ],
+        "nixpkgs-2211": [
+          "hs-nix-infra",
+          "empty"
+        ],
+        "nixpkgs-2305": [
+          "hs-nix-infra",
+          "empty"
+        ],
         "nixpkgs-unstable": "nixpkgs-unstable",
-        "old-ghc-nix": "old-ghc-nix",
-        "stackage": "stackage"
+        "old-ghc-nix": [
+          "hs-nix-infra",
+          "empty"
+        ],
+        "stackage": [
+          "hs-nix-infra",
+          "empty"
+        ]
       },
       "locked": {
         "lastModified": 1697195891,
@@ -234,57 +212,6 @@
       "original": {
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "type": "github"
-      }
-    },
-    "hls-1.10": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1680000865,
-        "narHash": "sha256-rc7iiUAcrHxwRM/s0ErEsSPxOR3u8t7DvFeWlMycWgo=",
-        "owner": "haskell",
-        "repo": "haskell-language-server",
-        "rev": "b08691db779f7a35ff322b71e72a12f6e3376fd9",
-        "type": "github"
-      },
-      "original": {
-        "owner": "haskell",
-        "ref": "1.10.0.0",
-        "repo": "haskell-language-server",
-        "type": "github"
-      }
-    },
-    "hls-2.0": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1687698105,
-        "narHash": "sha256-OHXlgRzs/kuJH8q7Sxh507H+0Rb8b7VOiPAjcY9sM1k=",
-        "owner": "haskell",
-        "repo": "haskell-language-server",
-        "rev": "783905f211ac63edf982dd1889c671653327e441",
-        "type": "github"
-      },
-      "original": {
-        "owner": "haskell",
-        "ref": "2.0.0.1",
-        "repo": "haskell-language-server",
-        "type": "github"
-      }
-    },
-    "hls-2.2": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1693064058,
-        "narHash": "sha256-8DGIyz5GjuCFmohY6Fa79hHA/p1iIqubfJUTGQElbNk=",
-        "owner": "haskell",
-        "repo": "haskell-language-server",
-        "rev": "b30f4b6cf5822f3112c35d14a0cba51f3fe23b85",
-        "type": "github"
-      },
-      "original": {
-        "owner": "haskell",
-        "ref": "2.2.0.0",
-        "repo": "haskell-language-server",
         "type": "github"
       }
     },
@@ -305,96 +232,26 @@
         "type": "github"
       }
     },
-    "hpc-coveralls": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1607498076,
-        "narHash": "sha256-8uqsEtivphgZWYeUo5RDUhp6bO9j2vaaProQxHBltQk=",
-        "owner": "sevanspowell",
-        "repo": "hpc-coveralls",
-        "rev": "14df0f7d229f4cd2e79f8eabb1a740097fdfa430",
-        "type": "github"
-      },
-      "original": {
-        "owner": "sevanspowell",
-        "repo": "hpc-coveralls",
-        "type": "github"
-      }
-    },
-    "hydra": {
+    "hs-nix-infra": {
       "inputs": {
-        "nix": "nix",
-        "nixpkgs": [
-          "haskellNix",
-          "hydra",
-          "nix",
-          "nixpkgs"
-        ]
+        "empty": "empty",
+        "hackage": [
+          "hackage"
+        ],
+        "haskellNix": "haskellNix",
+        "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1671755331,
-        "narHash": "sha256-hXsgJj0Cy0ZiCiYdW2OdBz5WmFyOMKuw4zyxKpgUKm4=",
-        "owner": "NixOS",
-        "repo": "hydra",
-        "rev": "f48f00ee6d5727ae3e488cbf9ce157460853fea8",
+        "lastModified": 1699020807,
+        "narHash": "sha256-T/vXF8PXGGnZXNAspFx3yhGFWh4n3a8f1UHlfuHWH1A=",
+        "owner": "kadena-io",
+        "repo": "hs-nix-infra",
+        "rev": "4e2cc022e56412eef42527f3876bae8c0ad0fe5d",
         "type": "github"
       },
       "original": {
-        "id": "hydra",
-        "type": "indirect"
-      }
-    },
-    "iserv-proxy": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1691634696,
-        "narHash": "sha256-MZH2NznKC/gbgBu8NgIibtSUZeJ00HTLJ0PlWKCBHb0=",
-        "ref": "hkm/remote-iserv",
-        "rev": "43a979272d9addc29fbffc2e8542c5d96e993d73",
-        "revCount": 14,
-        "type": "git",
-        "url": "https://gitlab.haskell.org/hamishmack/iserv-proxy.git"
-      },
-      "original": {
-        "ref": "hkm/remote-iserv",
-        "type": "git",
-        "url": "https://gitlab.haskell.org/hamishmack/iserv-proxy.git"
-      }
-    },
-    "lowdown-src": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1633514407,
-        "narHash": "sha256-Dw32tiMjdK9t3ETl5fzGrutQTzh2rufgZV4A/BbxuD4=",
-        "owner": "kristapsdz",
-        "repo": "lowdown",
-        "rev": "d2c2b44ff6c27b936ec27358a2653caaef8f73b8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "kristapsdz",
-        "repo": "lowdown",
-        "type": "github"
-      }
-    },
-    "nix": {
-      "inputs": {
-        "lowdown-src": "lowdown-src",
-        "nixpkgs": "nixpkgs",
-        "nixpkgs-regression": "nixpkgs-regression"
-      },
-      "locked": {
-        "lastModified": 1661606874,
-        "narHash": "sha256-9+rpYzI+SmxJn+EbYxjGv68Ucp22bdFUSy/4LkHkkDQ=",
-        "owner": "NixOS",
-        "repo": "nix",
-        "rev": "11e45768b34fdafdcf019ddbd337afa16127ff0f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "2.11.0",
-        "repo": "nix",
+        "owner": "kadena-io",
+        "repo": "hs-nix-infra",
         "type": "github"
       }
     },
@@ -415,129 +272,17 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1657693803,
-        "narHash": "sha256-G++2CJ9u0E7NNTAi9n5G8TdDmGJXcIjkJ3NF8cetQB8=",
+        "lastModified": 1669833724,
+        "narHash": "sha256-/HEZNyGbnQecrgJnfE8d0WC5c1xuPSD2LUpB6YXlg4c=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "365e1b3a859281cf11b94f87231adeabbdd878a2",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-22.05-small",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs-2003": {
-      "locked": {
-        "lastModified": 1620055814,
-        "narHash": "sha256-8LEHoYSJiL901bTMVatq+rf8y7QtWuZhwwpKE2fyaRY=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "1db42b7fe3878f3f5f7a4f2dc210772fd080e205",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-20.03-darwin",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs-2105": {
-      "locked": {
-        "lastModified": 1659914493,
-        "narHash": "sha256-lkA5X3VNMKirvA+SUzvEhfA7XquWLci+CGi505YFAIs=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "022caabb5f2265ad4006c1fa5b1ebe69fb0c3faf",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-21.05-darwin",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs-2111": {
-      "locked": {
-        "lastModified": 1659446231,
-        "narHash": "sha256-hekabNdTdgR/iLsgce5TGWmfIDZ86qjPhxDg/8TlzhE=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "eabc38219184cc3e04a974fe31857d8e0eac098d",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-21.11-darwin",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs-2205": {
-      "locked": {
-        "lastModified": 1685573264,
-        "narHash": "sha256-Zffu01pONhs/pqH07cjlF10NnMDLok8ix5Uk4rhOnZQ=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "380be19fbd2d9079f677978361792cb25e8a3635",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-22.05-darwin",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs-2211": {
-      "locked": {
-        "lastModified": 1688392541,
-        "narHash": "sha256-lHrKvEkCPTUO+7tPfjIcb7Trk6k31rz18vkyqmkeJfY=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "ea4c80b39be4c09702b0cb3b42eab59e2ba4f24b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-22.11-darwin",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs-2305": {
-      "locked": {
-        "lastModified": 1695416179,
-        "narHash": "sha256-610o1+pwbSu+QuF3GE0NU5xQdTHM3t9wyYhB9l94Cd8=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "715d72e967ec1dd5ecc71290ee072bcaf5181ed6",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-23.05-darwin",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs-regression": {
-      "locked": {
-        "lastModified": 1643052045,
-        "narHash": "sha256-uGJ0VXIhWKGXxkeNnq4TvV3CIOkUJ3PAoLZ3HMzNVMw=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "215d4d0fd80ca5163643b03a33fde804a29cc1e2",
+        "rev": "4d2b37a84fad1091b9de401eb450aae66f1a741e",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "215d4d0fd80ca5163643b03a33fde804a29cc1e2",
+        "rev": "4d2b37a84fad1091b9de401eb450aae66f1a741e",
         "type": "github"
       }
     },
@@ -557,62 +302,12 @@
         "type": "github"
       }
     },
-    "nixpkgs_2": {
-      "locked": {
-        "lastModified": 1669833724,
-        "narHash": "sha256-/HEZNyGbnQecrgJnfE8d0WC5c1xuPSD2LUpB6YXlg4c=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "4d2b37a84fad1091b9de401eb450aae66f1a741e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "4d2b37a84fad1091b9de401eb450aae66f1a741e",
-        "type": "github"
-      }
-    },
-    "old-ghc-nix": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1631092763,
-        "narHash": "sha256-sIKgO+z7tj4lw3u6oBZxqIhDrzSkvpHtv0Kki+lh9Fg=",
-        "owner": "angerman",
-        "repo": "old-ghc-nix",
-        "rev": "af48a7a7353e418119b6dfe3cd1463a657f342b8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "angerman",
-        "ref": "master",
-        "repo": "old-ghc-nix",
-        "type": "github"
-      }
-    },
     "root": {
       "inputs": {
         "flake-utils": "flake-utils",
         "hackage": "hackage",
-        "haskellNix": "haskellNix",
-        "nix-filter": "nix-filter",
-        "nixpkgs": "nixpkgs_2"
-      }
-    },
-    "stackage": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1696982937,
-        "narHash": "sha256-KASiTJAbIDfiMhHcoi2qtCYeTvRhZpR5PKzWQCteih4=",
-        "owner": "input-output-hk",
-        "repo": "stackage.nix",
-        "rev": "5531e02e80e9eeec3c817d24660e8e58e2f05703",
-        "type": "github"
-      },
-      "original": {
-        "owner": "input-output-hk",
-        "repo": "stackage.nix",
-        "type": "github"
+        "hs-nix-infra": "hs-nix-infra",
+        "nix-filter": "nix-filter"
       }
     },
     "systems": {

--- a/flake.lock
+++ b/flake.lock
@@ -20,13 +20,13 @@
       "locked": {
         "lastModified": 1699384378,
         "narHash": "sha256-jI0nYllONVrNnyOYrvQMIEJQJuNeKnfJo5keRxWMcWs=",
-        "owner": "enobayram",
+        "owner": "kadena-io",
         "repo": "flake-compat",
         "rev": "6ef9397736efb0f6075188aa3488022d1b85c11d",
         "type": "github"
       },
       "original": {
-        "owner": "enobayram",
+        "owner": "kadena-io",
         "repo": "flake-compat",
         "type": "github"
       }
@@ -228,16 +228,15 @@
         "nixpkgs-rec": "nixpkgs-rec"
       },
       "locked": {
-        "lastModified": 1699445699,
-        "narHash": "sha256-0tBNXXTACYo6vQOoz0bhL87Wc3wCUdM/9NArwYZInR8=",
+        "lastModified": 1699538616,
+        "narHash": "sha256-RVMPCvCeaSVpfzSgcM6yj8tvX8SC9qb8fCb5HEg9qUg=",
         "owner": "kadena-io",
         "repo": "hs-nix-infra",
-        "rev": "305c694ad709c837391655230941950b1624a343",
+        "rev": "3e2e6de968740e42eeaed7224e0465f267e7206d",
         "type": "github"
       },
       "original": {
         "owner": "kadena-io",
-        "ref": "enis/experiment-with-recursive-inputs",
         "repo": "hs-nix-infra",
         "type": "github"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -18,11 +18,11 @@
     },
     "flake-compat": {
       "locked": {
-        "lastModified": 1699390864,
-        "narHash": "sha256-MWSuUZWZRYI8CAKbU/NhjNy22FSOuUZ9SsdwSW5N07o=",
+        "lastModified": 1699384378,
+        "narHash": "sha256-jI0nYllONVrNnyOYrvQMIEJQJuNeKnfJo5keRxWMcWs=",
         "owner": "enobayram",
         "repo": "flake-compat",
-        "rev": "0b84b577d4a337421ff7b014b99cbf464d211fb3",
+        "rev": "6ef9397736efb0f6075188aa3488022d1b85c11d",
         "type": "github"
       },
       "original": {
@@ -224,14 +224,15 @@
           "hackage"
         ],
         "haskellNix": "haskellNix",
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "nixpkgs-rec": "nixpkgs-rec"
       },
       "locked": {
-        "lastModified": 1699390882,
-        "narHash": "sha256-X0Q0jkGQw7W8qeUVhwJ/Dsu8TyKKofDIX5ga+oBc6k4=",
+        "lastModified": 1699445699,
+        "narHash": "sha256-0tBNXXTACYo6vQOoz0bhL87Wc3wCUdM/9NArwYZInR8=",
         "owner": "kadena-io",
         "repo": "hs-nix-infra",
-        "rev": "a147cc7c0ba19033cc5ba4a555405443f411b2b1",
+        "rev": "305c694ad709c837391655230941950b1624a343",
         "type": "github"
       },
       "original": {
@@ -257,6 +258,22 @@
       }
     },
     "nixpkgs": {
+      "locked": {
+        "lastModified": 1669833724,
+        "narHash": "sha256-/HEZNyGbnQecrgJnfE8d0WC5c1xuPSD2LUpB6YXlg4c=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "4d2b37a84fad1091b9de401eb450aae66f1a741e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "4d2b37a84fad1091b9de401eb450aae66f1a741e",
+        "type": "github"
+      }
+    },
+    "nixpkgs-rec": {
       "locked": {
         "lastModified": 1669833724,
         "narHash": "sha256-/HEZNyGbnQecrgJnfE8d0WC5c1xuPSD2LUpB6YXlg4c=",

--- a/flake.lock
+++ b/flake.lock
@@ -51,43 +51,6 @@
         "type": "github"
       }
     },
-    "ghc980": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1692910316,
-        "narHash": "sha256-Qv8I3GzzIIN32RTEKI38BW5nO1f7j6Xm+dDeDUyYZWo=",
-        "ref": "ghc-9.8",
-        "rev": "249aa8193e4c5c1ee46ce29b39d2fffa57de7904",
-        "revCount": 61566,
-        "submodules": true,
-        "type": "git",
-        "url": "https://gitlab.haskell.org/ghc/ghc"
-      },
-      "original": {
-        "ref": "ghc-9.8",
-        "submodules": true,
-        "type": "git",
-        "url": "https://gitlab.haskell.org/ghc/ghc"
-      }
-    },
-    "ghc99": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1695427505,
-        "narHash": "sha256-j0hXl6uEI+Uwf37z3WLuQZN4S0XqGtiepELv2Gl2aHU=",
-        "ref": "refs/heads/master",
-        "rev": "b8e4fe2318798185228fb5f8214ba2384ac95b4f",
-        "revCount": 61951,
-        "submodules": true,
-        "type": "git",
-        "url": "https://gitlab.haskell.org/ghc/ghc"
-      },
-      "original": {
-        "submodules": true,
-        "type": "git",
-        "url": "https://gitlab.haskell.org/ghc/ghc"
-      }
-    },
     "hackage": {
       "flake": false,
       "locked": {
@@ -131,8 +94,14 @@
           "hs-nix-infra",
           "empty"
         ],
-        "ghc980": "ghc980",
-        "ghc99": "ghc99",
+        "ghc980": [
+          "hs-nix-infra",
+          "empty"
+        ],
+        "ghc99": [
+          "hs-nix-infra",
+          "empty"
+        ],
         "hackage": [
           "hs-nix-infra",
           "hackage"
@@ -242,11 +211,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1699020807,
-        "narHash": "sha256-T/vXF8PXGGnZXNAspFx3yhGFWh4n3a8f1UHlfuHWH1A=",
+        "lastModified": 1699283242,
+        "narHash": "sha256-weg0rDYjM93IxaRwcfNlnT6lVJ/f6dtfyF6ngF/6dlw=",
         "owner": "kadena-io",
         "repo": "hs-nix-infra",
-        "rev": "4e2cc022e56412eef42527f3876bae8c0ad0fe5d",
+        "rev": "1410c0de36aa60fee36d65da22fb944ac87dee21",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -216,11 +216,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1699366200,
-        "narHash": "sha256-DqH1/aWqQSTPUvrvXFOOCwV5PCYb24gSRyRoq2np4cY=",
+        "lastModified": 1699373628,
+        "narHash": "sha256-ieeoaxDbmloJT1+vl6fUEOO8rrVgLc+ZPiEPjZuif/0=",
         "owner": "kadena-io",
         "repo": "hs-nix-infra",
-        "rev": "6e76dc7413d9bafb5d48afe88465fade18f223e8",
+        "rev": "00fee2645e99f944992ae54a1fffb1a8cb4a99a7",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -216,11 +216,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1699355159,
-        "narHash": "sha256-tyoBGztZoqyx6eWTR7uMpLAQhH9ZHGknQljZQtu/SYI=",
+        "lastModified": 1699366200,
+        "narHash": "sha256-DqH1/aWqQSTPUvrvXFOOCwV5PCYb24gSRyRoq2np4cY=",
         "owner": "kadena-io",
         "repo": "hs-nix-infra",
-        "rev": "33e68113d0736b269c9eb3ed6551ff35bad84dca",
+        "rev": "6e76dc7413d9bafb5d48afe88465fade18f223e8",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -53,8 +53,8 @@
             outputs = [ "out" "metadata" ];
           } ''
             mkdir -p $out
-            ln -s $(nix build ${self}#default --print-out-paths)/bin $out/bin
-            cp $(nix build ${self}#default.metadata --print-out-paths) $metadata
+            ln -s $(nix build ${./.}#default --print-out-paths)/bin $out/bin
+            cp $(nix build ${./.}#default.metadata --print-out-paths) $metadata
           '';
         check = pkgs.runCommand "check" {} ''
           echo ${mkCheck "chainweb" executables}

--- a/flake.nix
+++ b/flake.nix
@@ -44,17 +44,16 @@
         echo ${name}: ${package}
         echo works > $out
       '';
-      runRecursive = hs-nix-infra.lib.recursiveRawFlakeBuilder basePkgs self;
     in {
       packages = {
         default = executables;
-        recursive = runRecursive "chainweb"
+        recursive = hs-nix-infra.lib.runRecursiveBuild system "chainweb"
           {
             outputs = [ "out" "metadata" ];
           } ''
             mkdir -p $out
-            ln -s $(nix build ${./.}#default --print-out-paths)/bin $out/bin
-            cp $(nix build ${./.}#default.metadata --print-out-paths) $metadata
+            ln -s $(nix-build-flake ${self} packages.${system}.default)/bin $out/bin
+            cp $(nix-build-flake ${self} packages.${system}.default.metadata) $metadata
           '';
         check = pkgs.runCommand "check" {} ''
           echo ${mkCheck "chainweb" executables}

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
       flake = false;
     };
     hs-nix-infra = {
-      url = "github:kadena-io/hs-nix-infra/enis/experiment-with-recursive-inputs";
+      url = "github:kadena-io/hs-nix-infra";
       inputs.hackage.follows = "hackage";
     };
     flake-utils.url = "github:numtide/flake-utils";

--- a/flake.nix
+++ b/flake.nix
@@ -44,8 +44,8 @@
         echo works > $out
       '';
       runRecursive = hs-nix-infra.lib.recursiveRawFlakeBuilder pkgs self;
-    in flake // {
-      packages = flake.packages // {
+    in {
+      packages = {
         default = executables;
         recursive = runRecursive "chainweb"
           {

--- a/flake.nix
+++ b/flake.nix
@@ -2,13 +2,12 @@
   description = "Chainweb";
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs?rev=4d2b37a84fad1091b9de401eb450aae66f1a741e";
     hackage = {
       url = "github:input-output-hk/hackage.nix";
       flake = false;
     };
-    haskellNix = {
-      url = "github:input-output-hk/haskell.nix";
+    hs-nix-infra = {
+      url = "github:kadena-io/hs-nix-infra";
       inputs.hackage.follows = "hackage";
     };
     flake-utils.url = "github:numtide/flake-utils";
@@ -20,11 +19,12 @@
     trusted-public-keys = "nixcache.chainweb.com:FVN503ABX9F8x8K0ptnc99XEz5SaA4Sks6kNcZn2pBY= iohk.cachix.org-1:DpRUyj7h7V830dp/i6Nti+NEO2/nhblbov/8MW7Rqoo= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=";
   };
 
-  outputs = { self, nixpkgs, flake-utils, haskellNix, nix-filter, ... }:
+  outputs = { self, hs-nix-infra, flake-utils, nix-filter, ... }:
     flake-utils.lib.eachSystem
       [ "x86_64-linux" "x86_64-darwin"
         "aarch64-linux" "aarch64-darwin" ] (system:
     let
+      inherit (hs-nix-infra) nixpkgs haskellNix;
       pkgs = import nixpkgs {
         inherit system;
         inherit (haskellNix) config;

--- a/flake.nix
+++ b/flake.nix
@@ -43,8 +43,18 @@
         echo ${name}: ${package}
         echo works > $out
       '';
+      runRecursive = hs-nix-infra.lib.recursiveRawFlakeBuilder pkgs self;
     in nixpkgs.lib.recursiveUpdate flake {
       packages.default = executables;
+      packages.recursive = runRecursive "chainweb"
+        {
+          buildInputs = [pkgs.jq];
+          outputs = [ "out" "metadata" ];
+        } ''
+          mkdir -p $out
+          ln -s $(nix build ${self}#default --print-out-paths)/bin $out/bin
+          cp $(nix build ${self}#default.metadata --print-out-paths) $metadata
+        '';
       packages.check = pkgs.runCommand "check" {} ''
         echo ${mkCheck "chainweb" executables}
         echo ${mkCheck "devShell" flake.devShell}

--- a/flake.nix
+++ b/flake.nix
@@ -25,6 +25,7 @@
         "aarch64-linux" "aarch64-darwin" ] (system:
     let
       inherit (hs-nix-infra) nixpkgs haskellNix;
+      basePkgs = hs-nix-infra.nixpkgs.legacyPackages.${system};
       pkgs = import nixpkgs {
         inherit system;
         inherit (haskellNix) config;
@@ -43,13 +44,13 @@
         echo ${name}: ${package}
         echo works > $out
       '';
-      runRecursive = hs-nix-infra.lib.recursiveRawFlakeBuilder pkgs self;
+      runRecursive = hs-nix-infra.lib.recursiveRawFlakeBuilder basePkgs self;
     in {
       packages = {
         default = executables;
         recursive = runRecursive "chainweb"
           {
-            buildInputs = [pkgs.jq];
+            buildInputs = [basePkgs.jq];
             outputs = [ "out" "metadata" ];
           } ''
             mkdir -p $out

--- a/flake.nix
+++ b/flake.nix
@@ -47,14 +47,18 @@
     in {
       packages = {
         default = executables;
+
+        # This package is equivalent to the default package, but it offloads the
+        # evaluation of the haskellNix project to a recursive nix-build. If you expect to
+        # find this package in your nix store or a binary cache, using this package will
+        # significantly reduce your nix eval times and the amount of data you download.
         recursive = hs-nix-infra.lib.runRecursiveBuild system "chainweb"
-          {
-            outputs = [ "out" "metadata" ];
-          } ''
-            mkdir -p $out
-            ln -s $(nix-build-flake ${self} packages.${system}.default)/bin $out/bin
+          { outputs = [ "out" "metadata" ]; }
+          ''
+            ln -s $(nix-build-flake ${self} packages.${system}.default) $out
             cp $(nix-build-flake ${self} packages.${system}.default.metadata) $metadata
           '';
+
         check = pkgs.runCommand "check" {} ''
           echo ${mkCheck "chainweb" executables}
           echo ${mkCheck "devShell" flake.devShell}

--- a/flake.nix
+++ b/flake.nix
@@ -50,7 +50,6 @@
         default = executables;
         recursive = runRecursive "chainweb"
           {
-            buildInputs = [basePkgs.jq];
             outputs = [ "out" "metadata" ];
           } ''
             mkdir -p $out

--- a/flake.nix
+++ b/flake.nix
@@ -62,5 +62,9 @@
           echo works > $out
         '';
       };
+      tmp = {
+        someVal = 123;
+        someDeriv = basePkgs.hello;
+      };
     });
 }

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
       flake = false;
     };
     hs-nix-infra = {
-      url = "github:kadena-io/hs-nix-infra";
+      url = "github:kadena-io/hs-nix-infra/enis/experiment-with-recursive-inputs";
       inputs.hackage.follows = "hackage";
     };
     flake-utils.url = "github:numtide/flake-utils";


### PR DESCRIPTION
This PR does the following:

## Unify the GHC packages used across Kadena projects

Instead of depending on `nixpkgs` and `haskellNix` directly, it depends on our new `hs-nix-infra` flake and uses the `nixpkgs` and `haskellNix` revisions provided by it. The hash of the `nixpkgs` and `haskellNix` flakes used for defining the `haskell.nix` `project` determines the hash of the GHC package that gets used to compile the Haskell modules.  

When multiple projects depend on `nixpkgs` and `haskellNix` independently, it's very hard (and not really well supported by nix CLI) to make sure that they don't deviate from each others' `nixpkgs` and `haskellNix` pins arbitrarily. I.e. updating two projects' `flake.lock` files at slightly different times is likely to cause one of the pins to be on a different revision, even though the difference doesn't matter functionally.

These unnecessarily different GHC packages put a lot of pressure on our CI infrastructure, taking hours to build functionally equivalent GHC packages and bloating the cache (with binaries from all the architectures we build and cache for). That also bloats the `/nix/store` of any `chainweb` user that wants to `nix build` an uncached `chainweb` version.

### The new workflow for updating Haskell-Nix toolchain

After this PR, the new workflow for managing our Haskell dependencies used by Nix will involve the following steps:
* If we need to update our `hackage` pin so that we can build with newly released Haskell packages, we can just `nix flake lock --update-input hackage` similar to how we've been doing so far, because this PR keeps declaring `hackage` as an input to the `chainweb-node` flake. This means the `hackage` flake pin can deviate between multiple projects, but that's relative OK, since the `hackage` pin doesn't influence the GHC package. The only bloat caused by such deviation is the need to download the `hackage` repository, which is inconvenient, but worthwhile in exchange for the convenience of easily bumping the hackage pin.
* If we need to use a new GHC version provided by a newer `nixpkgs` version or if we need to bump our `haskellNix` pin for any reason, then unlike the status quo, we need to follow a two-step process:
    * If `hs-nix-infra` has a newer version, bump it in this repo and see if that fixes the build.
    * If that latest `hs-nix-infra` version isn't good enough, then open a PR to `hs-nix-infra` to bump `nixpkgs` and `haskellNix`. The PR would preferably bump both of them to the latest version.

Hopefully, this new workflow will reduce the number of `nixpkgs` + `haskellNix` versions we depend on across our Haskell projects.

## Add a `recursive` alternative to the `default` package

As part of the CI automation for this repo, we're building and caching the Nix binaries for `chainweb`, which makes it convenient for any user to `nix build` chainweb from any commit/branch since all the dependencies will come from our binary cache. However, even without building anything locally, *evaluating* the `default` package of this flake takes a significant amount of time and involves downloading ~2 GB of Nix dependencies. This is due to the complexity of what `haskellNix` does for us at Nix evaluation time.

This PR introduces a `recursive` package to this flake's output, which uses `recursive-nix` to push the Nix evaluation of the `default` package into the build of a derivation. This means, any user that tries to `nix build .#recursive` will fetch the chainweb binary from our cache without having to perform any complex Nix evaluation locally or downloading the Nix dependencies of any such evaluation as long as the `recursive` derivation they're building is already in our binary cache. If not, the `recursive-nix` derivation will be built locally (in which case make sure your local Nix setup has `recursive-nix` enabled), which is essentially as much work as building `default` itself. This might still be worthwhile however, since subsequent builds of the same `recursive` derivation will complete immediately, without having to evaluate the `default` derivation again.

## Expose `pact` via `metadata`

The `default` package and the `recursive` package now both have a `metadata` output (in addition to the primary `out` output). This allows downstream consumers of these packages to access the version and the source of the `pact` package embedded into the `chainweb` binary they're building.