### PR TITLE
cutdb: allow forcing a cut through the cut pipeline

### DIFF
--- a/src/Chainweb/CutDB/RestAPI.hs
+++ b/src/Chainweb/CutDB/RestAPI.hs
@@ -61,6 +61,7 @@ cutGetApi = Proxy
 
 type CutPutApi_
     = ReqBody '[JSON] CutHashes
+    :> QueryFlag "force"
     :> Verb 'PUT 204 '[JSON] NoContent
 
 type CutPutApi (v :: ChainwebVersionT)

--- a/src/Chainweb/CutDB/RestAPI/Client.hs
+++ b/src/Chainweb/CutDB/RestAPI/Client.hs
@@ -49,5 +49,6 @@ cutGetClientLimit (FromSingChainwebVersion (SChainwebVersion :: Sing v))
 cutPutClient
     :: ChainwebVersion
     -> CutHashes
+    -> Bool
     -> ClientM NoContent
 cutPutClient (FromSingChainwebVersion (SChainwebVersion :: Sing v)) = client $ cutPutApi @v

--- a/src/Chainweb/CutDB/Sync.hs
+++ b/src/Chainweb/CutDB/Sync.hs
@@ -60,8 +60,12 @@ runClientThrowM req = fromEitherM <=< runClientM req
 putCut
     :: CutClientEnv
     -> CutHashes
+    -> Bool
     -> IO ()
-putCut (CutClientEnv v env) = void . flip runClientThrowM env . cutPutClient v
+putCut (CutClientEnv v env) hashes force
+  = void
+  $ flip runClientThrowM env
+  $ cutPutClient v hashes force
 
 getCut
     :: CutClientEnv
@@ -105,7 +109,7 @@ syncSession v p db logg env pinf = do
     cenv = CutClientEnv v env
 
     send c = do
-        putCut cenv c
+        putCut cenv c False -- XXX (aseipp): ???
         logg @T.Text Debug $ "put cut " <> encodeToText c
 
     receive = do
@@ -124,4 +128,4 @@ syncSession v p db logg env pinf = do
 
         let c' = set cutOrigin (Just pinf) c
         logg @T.Text Debug $ "received cut " <> encodeToText c'
-        addCutHashes db c'
+        addCutHashes db (cutHashOrdinary c')

--- a/src/Chainweb/Miner/Coordinator.hs
+++ b/src/Chainweb/Miner/Coordinator.hs
@@ -252,7 +252,7 @@ publish lf cdb pwVar miner pd s = do
 
             -- reset the primed payload for this cut extension
             atomically $ modifyTVar pwVar $ resetPrimed miner (_chainId bh)
-            addCutHashes cdb ch
+            addCutHashes cdb (cutHashOrdinary ch)
 
             let bytes = sum . fmap (BS.length . _transactionBytes) $
                         _payloadDataTransactions pd

--- a/test/Chainweb/Test/CutDB.hs
+++ b/test/Chainweb/Test/CutDB.hs
@@ -409,7 +409,7 @@ tryMineForChain miner webPact cutDb c cid = do
     x <- testMineWithPayloadHash wdb (Nonce 0) t payloadHash cid c
     case x of
         Right (T2 h c') -> do
-            addCutHashes cutDb (cutToCutHashes Nothing c')
+            addCutHashes cutDb $ cutHashOrdinary (cutToCutHashes Nothing c')
                 { _cutHashesHeaders = HM.singleton (_blockHash h) h
                 , _cutHashesPayloads = HM.singleton (_blockPayloadHash h) (payloadWithOutputsToPayloadData outputs)
                 }
@@ -544,4 +544,3 @@ testCutGet rdb = testCase "cut get" $ do
       assertGe "cut height is large enough" (Actual curHeight) (Expected $ 2 * int ch)
       retCut <- cutGetHandler cutDb (Just $ MaxRank (Max $ int halfCh))
       assertLe "cut hashes are too high" (Actual (_cutHashesHeight retCut)) (Expected halfCh)
-

--- a/test/Chainweb/Test/RestAPI/Client_.hs
+++ b/test/Chainweb/Test/RestAPI/Client_.hs
@@ -98,6 +98,7 @@ cutGetClient' v = runIdentity $ do
 cutPutClient'
     :: ChainwebVersion
     -> CutHashes
+    -> Bool
     -> ClientM_ NoContent
 cutPutClient' v = runIdentity $ do
     (SomeSing (SChainwebVersion :: Sing v)) <- return $ toSing (_versionName v)


### PR DESCRIPTION
Summary: To introduce orphan blocks to the devnet, we need to circumvent the ordinary cut pipeline and insert into the underlying `TVar` directly.

This largely gets things in place by just changing the types to layer in the needed information.

Change-Id: Id7981a7308cd669a8d48c4443a6c88c0