### PR TITLE
fix HasTextRepresentation for Fork, add test

### DIFF
--- a/src/Chainweb/Version.hs
+++ b/src/Chainweb/Version.hs
@@ -253,6 +253,7 @@ instance HasTextRepresentation Fork where
     fromText "chainweb219Pact" = return Chainweb219Pact
     fromText "chainweb220Pact" = return Chainweb220Pact
     fromText "chainweb221Pact" = return Chainweb221Pact
+    fromText "chainweb222Pact" = return Chainweb222Pact
     fromText "chainweb223Pact" = return Chainweb223Pact
     fromText t = throwM . TextFormatException $ "Unknown Chainweb fork: " <> t
 

--- a/test/Chainweb/Test/Orphans/Internal.hs
+++ b/test/Chainweb/Test/Orphans/Internal.hs
@@ -774,6 +774,9 @@ instance Arbitrary NetworkId where
 instance Arbitrary ChainId where
     arbitrary = unsafeChainId <$> arbitrary
 
+instance Arbitrary Fork where
+    arbitrary = elements [minBound..maxBound]
+
 instance Arbitrary ChainDatabaseGcConfig where
     arbitrary = elements
         [ GcNone

--- a/test/Chainweb/Test/Roundtrips.hs
+++ b/test/Chainweb/Test/Roundtrips.hs
@@ -480,6 +480,7 @@ hasTextRepresentationTests = testGroup "HasTextRepresentation roundtrips"
     , testProperty "TransactionOutput" $ prop_iso' @_ @TransactionOutput fromText toText
     , testProperty "ChainDatabaseGcConfig" $ prop_iso' @_ @ChainDatabaseGcConfig fromText toText
     , testProperty "MerkleRootType" $ prop_iso' @_ @MerkleRootType fromText toText
+    , testProperty "Fork" $ prop_iso' @_ @Fork fromText toText
     ]
 
 -- -------------------------------------------------------------------------- --


### PR DESCRIPTION
```
❯ cabal run test:chainweb-tests -- --pattern "roundtrip tests.HasTextRepresentation roundtrips"
Chainweb Tests
  Chainweb Unit Tests
    roundtrip tests
      HasTextRepresentation roundtrips
        ChainwebVersionName:   OK
          +++ OK, passed 100 tests.
        ChainId:               OK
          +++ OK, passed 100 tests.
        BlockHash:             OK
          +++ OK, passed 100 tests.
        Seconds:               OK
          +++ OK, passed 100 tests.
        Micros:                OK
          +++ OK, passed 100 tests.
        Hostname:              OK
          +++ OK, passed 100 tests.
        Port:                  OK
          +++ OK, passed 100 tests.
        HostAddress:           OK
          +++ OK, passed 100 tests.
        T.Text:                OK
          +++ OK, passed 100 tests.
        [Char]:                OK
          +++ OK, passed 100 tests.
        PeerId:                OK
          +++ OK, passed 100 tests.
        Int:                   OK
          +++ OK, passed 100 tests.
        P2pNetworkId:          OK
          +++ OK, passed 100 tests.
        Transaction:           OK
          +++ OK, passed 100 tests.
        TransactionOutput:     OK
          +++ OK, passed 100 tests.
        ChainDatabaseGcConfig: OK
          +++ OK, passed 100 tests.
        MerkleRootType:        OK
          +++ OK, passed 100 tests.
        Fork:                  OK
          +++ OK, passed 100 tests.

All 18 tests passed (0.02s)
```

This was broken in b0bbf8cf481f57fff0d1d05b7dcd5acfa1c7772f