### PR TITLE
Shorter test logs for RemotePactTest

### DIFF
--- a/test/Chainweb/Test/Utils.hs
+++ b/test/Chainweb/Test/Utils.hs
@@ -985,8 +985,7 @@ awaitBlockHeight v step cenv i = do
         | otherwise = do
             step
                 $ "awaiting cut with all block heights >= " <> show i
-                <> ". Current cut height: " <> show (_cutHashesHeight c)
-                <> ". Current block heights: " <> show (_bhwhHeight <$> _cutHashes c)
+                <> ". Current min. block height: " <> show (minimum $ _bhwhHeight <$> _cutHashes c)
                 <> " [" <> show (view rsIterNumberL s) <> "]"
             return True
 


### PR DESCRIPTION
This message is printed around 30 times when I run RemotePactTest; this change makes the message fit neatly in my terminal.