### PR TITLE
cabal: stop giving superfluous warnings on missing shared libraries

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -29,6 +29,7 @@ if os(darwin)
 package chainweb
     tests: True
     benchmarks: True
+    ghc-options: -Wno-missed-extra-shared-lib
 
 if impl(ghc >= 9.8.1)
     package chainweb


### PR DESCRIPTION
Summary: When running Template Haskell, GHC sees that some code it loads has dependent modules that also have a dependency on the zlib shared object via an `extra-libraries` clause; GHC can't find or load this module, issuing a warning, but it doesn't matter because the Template Haskell code doesn't actually *use* zlib despite having a transitive dependency on it.

Silence this warning, as it's *extremely* annoying to see while working on any files that use Template Haskell for any purposes e.g. deriving lenses.

Change-Id: I0ac0fe06ff0ff7fc40beb6f81b314374