### PR TITLE
Raise block gas limit in ForkingBench

### DIFF
--- a/bench/Chainweb/Pact/Backend/ForkingBench.hs
+++ b/bench/Chainweb/Pact/Backend/ForkingBench.hs
@@ -321,7 +321,7 @@ withResources rdb trunkLength logLevel compact f = C.envWithCleanup create destr
     startPact version l bhdb pdb mempool sqlEnv = do
         reqQ <- newPactQueue pactQueueSize
         a <- async $ runPactService version cid l reqQ mempool bhdb pdb sqlEnv testPactServiceConfig
-            { _pactBlockGasLimit = 150000
+            { _pactBlockGasLimit = 180000
             }
 
         return (a, reqQ)


### PR DESCRIPTION
The idea is to prevent benchmarks from being so flaky in CI.