### PR TITLE
Optimize buy gas not to use a defpact

### DIFF
--- a/src/Chainweb/Pact/Templates.hs
+++ b/src/Chainweb/Pact/Templates.hs
@@ -15,7 +15,7 @@
 -- Prebuilt Term templates for automated operations (coinbase, gas buy)
 --
 module Chainweb.Pact.Templates
-( mkBuyGasTerm
+( mkFundTxTerm
 , mkCoinbaseTerm
 , mkCoinbaseCmd
 ) where
@@ -65,8 +65,8 @@ strArgSetter :: Int -> ASetter' (Term Name) Text
 strArgSetter idx = tApp . appArgs . ix idx . tLiteral . _LString
 {-# INLINE strArgSetter #-}
 
-buyGasTemplate :: (Term Name, ASetter' (Term Name) Text, ASetter' (Term Name) Text)
-buyGasTemplate =
+fundTxTemplate :: (Term Name, ASetter' (Term Name) Text, ASetter' (Term Name) Text)
+fundTxTemplate =
   ( app (qn "coin" "fund-tx")
       [ strLit "sender"
       , strLit "mid"
@@ -76,7 +76,7 @@ buyGasTemplate =
   , strArgSetter 0
   , strArgSetter 1
   )
-{-# NOINLINE buyGasTemplate #-}
+{-# NOINLINE fundTxTemplate #-}
 
 
 dummyParsedCode :: ParsedCode
@@ -84,21 +84,21 @@ dummyParsedCode = ParsedCode "1" [ELiteral $ LiteralExp (LInteger 1) def]
 {-# NOINLINE dummyParsedCode #-}
 
 
-mkBuyGasTerm
+mkFundTxTerm
   :: MinerId   -- ^ Id of the miner to fund
   -> MinerKeys -- ^ Miner keyset
   -> Text      -- ^ Address of the sender from the command
   -> GasSupply -- ^ The gas limit total * price
   -> (Term Name,ExecMsg ParsedCode)
-mkBuyGasTerm (MinerId mid) (MinerKeys ks) sender total = (populatedTerm, execMsg)
-  where (term, senderS, minerS) = buyGasTemplate
+mkFundTxTerm (MinerId mid) (MinerKeys ks) sender total = (populatedTerm, execMsg)
+  where (term, senderS, minerS) = fundTxTemplate
         populatedTerm = set senderS sender $ set minerS mid term
         execMsg = ExecMsg dummyParsedCode (toLegacyJsonViaEncode buyGasData)
         buyGasData = J.object
           [ "miner-keyset" J..= ks
           , "total" J..= total
           ]
-{-# INLINABLE mkBuyGasTerm #-}
+{-# INLINABLE mkFundTxTerm #-}
 
 
 coinbaseTemplate :: (Term Name,ASetter' (Term Name) Text)

--- a/src/Chainweb/Pact/Templates.hs
+++ b/src/Chainweb/Pact/Templates.hs
@@ -17,6 +17,7 @@
 module Chainweb.Pact.Templates
 ( mkFundTxTerm
 , mkBuyGasTerm
+, mkRedeemGasTerm
 , mkCoinbaseTerm
 , mkCoinbaseCmd
 ) where
@@ -88,6 +89,18 @@ buyGasTemplate =
   , strArgSetter 0
   )
 
+redeemGasTemplate :: (Term Name, ASetter' (Term Name) Text, ASetter' (Term Name) Text)
+redeemGasTemplate =
+  ( app (qn "coin" "redeem-gas")
+      [ strLit "mid"
+      , app (bn "read-keyset") [strLit "miner-keyset"]
+      , strLit "sender"
+      , app (bn "read-decimal") [strLit "total"]
+      ]
+  , strArgSetter 2
+  , strArgSetter 0
+  )
+
 dummyParsedCode :: ParsedCode
 dummyParsedCode = ParsedCode "1" [ELiteral $ LiteralExp (LInteger 1) def]
 {-# NOINLINE dummyParsedCode #-}
@@ -120,6 +133,24 @@ mkBuyGasTerm sender total = (populatedTerm, execMsg)
         buyGasData = J.object
           [ "total" J..= total ]
 {-# INLINABLE mkBuyGasTerm #-}
+
+mkRedeemGasTerm
+  :: MinerId   -- ^ Id of the miner to fund
+  -> MinerKeys -- ^ Miner keyset
+  -> Text      -- ^ Address of the sender from the command
+  -> GasSupply -- ^ The gas limit total * price
+  -> GasSupply -- ^ The gas limit total * price
+  -> (Term Name,ExecMsg ParsedCode)
+mkRedeemGasTerm (MinerId mid) (MinerKeys ks) sender total fee = (populatedTerm, execMsg)
+  where (term, senderS, minerS) = redeemGasTemplate
+        populatedTerm = set senderS sender $ set minerS mid term
+        execMsg = ExecMsg dummyParsedCode (toLegacyJsonViaEncode redeemGasData)
+        redeemGasData = J.object
+          [ "total" J..= total
+          , "fee" J..= J.toJsonViaEncode fee
+          , "miner-keyset" J..= ks
+          ]
+{-# INLINABLE mkRedeemGasTerm #-}
 
 coinbaseTemplate :: (Term Name,ASetter' (Term Name) Text)
 coinbaseTemplate =

--- a/src/Chainweb/Pact/TransactionExec.hs
+++ b/src/Chainweb/Pact/TransactionExec.hs
@@ -872,7 +872,7 @@ buyGas isPactBackCompatV16 cmd (Miner mid mks) = go
       supply <- gasSupplyOf <$> view txGasLimit <*> view txGasPrice
       logGas <- isJust <$> view txGasLogger
 
-      let (buyGasTerm, buyGasCmd) = mkBuyGasTerm mid mks sender supply
+      let (buyGasTerm, buyGasCmd) = mkFundTxTerm mid mks sender supply
           interp mc = Interpreter $ \_input ->
             put (initState mc logGas) >> run (pure <$> eval buyGasTerm)
 

--- a/test/Chainweb/Test/Pact/RemotePactTest.hs
+++ b/test/Chainweb/Test/Pact/RemotePactTest.hs
@@ -1057,7 +1057,7 @@ allocationTest t cenv step = do
       $ ObjectMap
       $ M.fromList
         [ (FieldKey "account", PLiteral $ LString "allocation00")
-        , (FieldKey "balance", PLiteral $ LDecimal 1_099_993.89) -- balance = (1k + 1mm) - gas
+        , (FieldKey "balance", PLiteral $ LDecimal 1_099_993.91) -- balance = (1k + 1mm) - gas
         , (FieldKey "guard", PGuard $ GKeySetRef (KeySetName "allocation00" Nothing))
         ]
 
@@ -1081,7 +1081,7 @@ allocationTest t cenv step = do
       $ ObjectMap
       $ M.fromList
         [ (FieldKey "account", PLiteral $ LString "allocation02")
-        , (FieldKey "balance", PLiteral $ LDecimal 1_099_991) -- 1k + 1mm - gas
+        , (FieldKey "balance", PLiteral $ LDecimal 1_099_991.04) -- 1k + 1mm - gas
         , (FieldKey "guard", PGuard $ GKeySetRef (KeySetName "allocation02" Nothing))
         ]
 

--- a/test/Chainweb/Test/Rosetta/RestAPI.hs
+++ b/test/Chainweb/Test/Rosetta/RestAPI.hs
@@ -103,7 +103,7 @@ defMiningReward :: Decimal
 defMiningReward = 2.304523
 
 transferGasCost :: Decimal
-transferGasCost = gasCost 700
+transferGasCost = gasCost 698
 
 type RosettaTest = IO (Time Micros) -> IO ClientEnv -> TestTree
 
@@ -153,7 +153,7 @@ accountBalanceTests tio envIo =
       step "check initial balance"
       cenv <- envIo
       resp0 <- accountBalance cenv req
-      let startBal = 99999997.8600
+      let startBal = 99999997.8604
       checkBalance resp0 startBal
 
       step "send 1.0 tokens to sender00 from sender01"


### PR DESCRIPTION
This PR is meant to be reviewed commit-by-commit.

Buying gas right now requires starting and resuming a defpact, called `fund-tx`, which has two steps: buying gas (the `buy-gas` function), before the start of a transaction, debits the gas payer's account; and redeeming gas (the `redeem-gas` function), after the end of a transaction, pays the gas payer for the remaining unused gas and pays the miner for the used gas. We've discussed the storage impact of this, though now that is mostly irrelevant thanks to #1744. To summarize, each started Pact occupies a row in the Pacts table with its state; each time a Pact is resumed, this row is written to, keeping the old row for reorgs. There is also a time performance aspect. We grow the pending writes map with `PactExec`s by starting and resuming these defpacts, and we also spend time serializing and deserializing the `PactExec`s as and from JSON when we do so.

This also makes buying gas itself cost slightly less gas.

This PR calls the `buy-gas` and `redeem-gas` functions directly instead of via the `fund-tx` defpact.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206729978146609