### PR TITLE
Make compaction of live nodes retry until the db is available

### DIFF
--- a/chainweb.cabal
+++ b/chainweb.cabal
@@ -682,6 +682,7 @@ executable cwtool
         Chainweb.Test.Orphans.Internal
         Chainweb.Test.Orphans.Pact
         Chainweb.Test.Orphans.Time
+        Chainweb.Test.Pact.Utils
         Chainweb.Test.P2P.Peer.BootstrapConfig
         Chainweb.Test.Utils
         Chainweb.Test.Utils.BlockHeader
@@ -723,6 +724,7 @@ executable cwtool
         , containers >= 0.5
         , crypton >= 0.31
         , data-default >=0.7
+        , Decimal >= 0.5.2
         , deepseq >= 1.4
         , digraph >= 0.2.3
         , direct-sqlite >= 2.3.27

--- a/src/Chainweb/Pact/Backend/Compaction.hs
+++ b/src/Chainweb/Pact/Backend/Compaction.hs
@@ -28,6 +28,7 @@
 
 module Chainweb.Pact.Backend.Compaction
   ( CompactFlag(..)
+  , CompactException(..)
   , TargetBlockHeight(..)
   , compact
   , main

--- a/test/Chainweb/Test/MultiNode.hs
+++ b/test/Chainweb/Test/MultiNode.hs
@@ -106,6 +106,7 @@ import Chainweb.Pact.Backend.PactState.GrandHash.Calc qualified as GrandHash.Cal
 import Chainweb.Pact.Backend.PactState.GrandHash.Import qualified as GrandHash.Import
 import Chainweb.Pact.Backend.PactState.GrandHash.Utils qualified as GrandHash.Utils
 import Chainweb.Test.P2P.Peer.BootstrapConfig
+import Chainweb.Test.Pact.Utils (compactUntilAvailable)
 import Chainweb.Test.Utils
 import Chainweb.Time (Seconds(..))
 import Chainweb.Utils
@@ -537,9 +538,8 @@ compactAndResumeTest logLevel v n rdb pactDbDir step = do
         C.withDefaultLogger Warn $ \cLogger -> do
           let cLogger' = over YAL.setLoggerScope (\scope -> ("nodeId",sshow nid) : ("chainId",sshow cid) : scope) cLogger
           let flags = [C.NoVacuum]
-          let db = _sConn sqlEnv
           let bh = BlockHeight 5
-          void $ C.compact (C.Target bh) cLogger' db flags
+          void $ compactUntilAvailable (C.Target bh) cLogger' sqlEnv flags
 
     logFun "phase 3... restarting nodes and ensuring progress"
     runNodesForSeconds logLevel logFun (multiConfig v n) n 60 rdb pactDbDir ct

--- a/test/Chainweb/Test/Pact/RemotePactTest.hs
+++ b/test/Chainweb/Test/Pact/RemotePactTest.hs
@@ -367,8 +367,8 @@ txlogsCompactionTest t cenv pactDbDir = do
       let flags = [C.NoVacuum]
       let resetDb = False
 
-      Backend.withSqliteDb cid logger pactDbDir resetDb $ \(SQLiteEnv db _) -> do
-        void $ C.compact C.Latest logger db flags
+      Backend.withSqliteDb cid logger pactDbDir resetDb $ \dbEnv ->
+        compactUntilAvailable C.Latest logger dbEnv flags
 
     txLogs <- crGetTxLogs =<< local cid cenv =<< createTxLogsTx =<< nextNonce
 

--- a/test/Chainweb/Test/Pact/Utils.hs
+++ b/test/Chainweb/Test/Pact/Utils.hs
@@ -109,6 +109,7 @@ module Chainweb.Test.Pact.Utils
 , zeroNoncer
 -- * Pact State
 , compact
+, compactUntilAvailable
 , PactRow(..)
 , getLatestPactState
 , getPactUserTables
@@ -139,6 +140,7 @@ import Data.Default (def)
 import Data.Foldable
 import qualified Data.HashMap.Strict as HM
 import Data.IORef
+import Data.LogMessage
 import Data.Map (Map)
 import qualified Data.Map.Strict as M
 import Data.Maybe
@@ -151,10 +153,12 @@ import qualified Data.Vector as V
 import Database.SQLite3.Direct (Database)
 
 import GHC.Generics
+import GHC.IO.Exception(IOException(..))
 
 import Streaming.Prelude qualified as S
 import System.Directory
 import System.IO.Temp (createTempDirectory)
+import qualified System.Logger as YAL
 import System.LogLevel
 
 import Test.Tasty
@@ -1037,3 +1041,18 @@ compact :: ()
 compact logLevel cFlags (SQLiteEnv db _) bh = do
   C.withDefaultLogger logLevel $ \logger -> do
     void $ C.compact bh logger db cFlags
+
+-- | Compaction function that retries until the database is available.
+compactUntilAvailable
+  :: C.TargetBlockHeight
+  -> YAL.Logger SomeLogMessage
+  -> SQLiteEnv
+  -> [C.CompactFlag]
+  -> IO ()
+compactUntilAvailable tbh logger dbEnv@(SQLiteEnv db _) flags = do
+    try (C.compact tbh logger db flags) >>= \case
+        Left (C.CompactExceptionDb (fromException ->
+            Just (ioe_description -> "Database error: (ErrorBusy,\"database is locked\")")))
+            -> compactUntilAvailable tbh logger dbEnv flags
+        Left e -> throwM e
+        Right _ -> return ()


### PR DESCRIPTION
`RemotePactTest.txlogsCompactionTest` is flaky without this and actually `compact-live-node` in `SlowTests` is sort of flaky as well.