### PR TITLE
Allow the node to communicate when it's ready to serve requests

### DIFF
--- a/chainweb.cabal
+++ b/chainweb.cabal
@@ -587,6 +587,7 @@ test-suite chainweb-tests
         , text >=2.0
         , time >= 1.12.2
         , transformers >= 0.5
+        , unliftio >= 0.2.25
         , unordered-containers >= 0.2.16
         , vector >= 0.12.2
         , wai >= 3.2
@@ -757,6 +758,7 @@ executable cwtool
         , safe-exceptions >= 0.1
         , servant-client >= 0.18.2
         , servant-client-core >= 0.18.2
+        , stm >= 2.4
         , streaming >= 0.2.2
         , streaming-commons >= 0.2
         , tasty >= 1.0
@@ -766,6 +768,7 @@ executable cwtool
         , temporary >= 1.3
         , time >= 1.9
         , text >= 2.0
+        , unliftio >= 0.2.25
         , unordered-containers >= 0.2.16
         , vector >= 0.12.2
         , wai >= 3.2

--- a/node/ChainwebNode.hs
+++ b/node/ChainwebNode.hs
@@ -353,7 +353,7 @@ node conf logger = do
             Replayed _ _ -> return ()
             StartedChainweb cw ->
                 concurrentlies_
-                    [ runChainweb cw
+                    [ runChainweb cw (\_ -> return ())
                     -- we should probably push 'onReady' deeper here but this should be ok
                     , runCutMonitor (_chainwebLogger cw) (_cutResCutDb $ _chainwebCutResources cw)
                     , runQueueMonitor (_chainwebLogger cw) (_cutResCutDb $ _chainwebCutResources cw)

--- a/src/Chainweb/Miner/Core.hs
+++ b/src/Chainweb/Miner/Core.hs
@@ -211,4 +211,3 @@ fastCheckTargetN n trgPtr powPtr = compare
     <$> peekElemOff trgPtr n
     <*> peekElemOff powPtr n
 {-# INLINE fastCheckTargetN #-}
-

--- a/test/Chainweb/Test/MultiNode.hs
+++ b/test/Chainweb/Test/MultiNode.hs
@@ -224,7 +224,7 @@ harvestConsensusState
 harvestConsensusState _ _ _ (Replayed _ _) =
     error "harvestConsensusState: doesn't work when replaying, replays don't do consensus"
 harvestConsensusState logger stateVar nid (StartedChainweb cw) = do
-    runChainweb cw `finally` do
+    runChainweb cw (\_ -> return ()) `finally` do
         logFunctionText logger Info "write sample data"
         modifyMVar_ stateVar $
             sampleConsensusState


### PR DESCRIPTION
This is another attempt at fixing the racy issue that's causing `RemotePactTest` to be flaky. I ran into a segfault while I was writing this, which was caused by closing the rocksdb while the node was still running, in turn caused by incorrect use of `async`.