### PR TITLE
Raise test block gas limit to avoid spurious TxTimeouts during tests

### DIFF
--- a/src/Chainweb/Pact/Types.hs
+++ b/src/Chainweb/Pact/Types.hs
@@ -486,7 +486,7 @@ testPactServiceConfig = PactServiceConfig
 -- is initialized from the @_configBlockGasLimit@ value of @ChainwebConfiguration@.
 --
 testBlockGasLimit :: GasLimit
-testBlockGasLimit = 20000
+testBlockGasLimit = 100000
 
 newtype ReorgLimitExceeded = ReorgLimitExceeded Text
 


### PR DESCRIPTION
The block gas limit is used to calculate the tx timeout, and tests can trigger it if there are noisy neighbors. This hopefully fixes that.