### PR TITLE
Update Pact

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -71,8 +71,8 @@ package yet-another-logger
 source-repository-package
     type: git
     location: https://github.com/kadena-io/pact.git
-    tag: f9f3143f21d8639000449514d892aea2a0a9a19f
-    --sha256: 1bg2hbbmx9za3yz8ry2b20219wp8cdqllzf2pd17sl54pfp67xcc
+    tag: 31b2b6acd5991f9b3744db618ff737362981f4b0
+    --sha256: sha256-OZ2gsp/6bx+VheOcDJgOQZkoBrgObQl+RcVp3r+gsM4=
 
 source-repository-package
     type: git

--- a/src/Chainweb/Pact/TransactionExec.hs
+++ b/src/Chainweb/Pact/TransactionExec.hs
@@ -384,7 +384,7 @@ flagsFor v cid bh = S.fromList $ concat
   , disableReturnRTC v cid bh
   , enablePact49 v cid bh
   , enablePact410 v cid bh
-  , enablePactVerifiers v cid bh
+  , enablePact411 v cid bh
   ]
 
 applyCoinbase
@@ -851,8 +851,8 @@ enablePact49 v cid bh = [FlagDisablePact49 | not (chainweb221Pact v cid bh)]
 enablePact410 :: ChainwebVersion -> V.ChainId -> BlockHeight -> [ExecutionFlag]
 enablePact410 v cid bh = [FlagDisablePact410 | not (chainweb222Pact v cid bh)]
 
-enablePactVerifiers :: ChainwebVersion -> V.ChainId -> BlockHeight -> [ExecutionFlag]
-enablePactVerifiers v cid bh = [FlagDisableVerifiers | not (chainweb223Pact v cid bh)]
+enablePact411 :: ChainwebVersion -> V.ChainId -> BlockHeight -> [ExecutionFlag]
+enablePact411 v cid bh = [FlagDisablePact411 | not (chainweb223Pact v cid bh)]
 
 -- | Even though this is not forking, abstracting for future shutoffs
 disableReturnRTC :: ChainwebVersion -> V.ChainId -> BlockHeight -> [ExecutionFlag]

--- a/test/Chainweb/Test/Pact/RemotePactTest.hs
+++ b/test/Chainweb/Test/Pact/RemotePactTest.hs
@@ -378,6 +378,10 @@ txlogsCompactionTest t cenv pactDbDir = do
       "txlogs match latest state"
       txLogs
       (map (\(rk, rd) -> (rk, J.toJsonViaEncode (_rdData rd))) (M.toList latestState))
+    -- FLAKE:
+    -- test/Chainweb/Test/Pact/RemotePactTest.hs:377:
+    -- expected: [("A",Object (fromList [("age",Object (fromList [("int",Number 42.0)])),("name",String "Lindsey Lohan")])),("B",Object (fromList [("age",Object (fromList [("int",Number 30.0)])),("name",String "Nico Robin")])),("C",Object (fromList [("age",Object (fromList [("int",Number 420.0)])),("name",String "chessai")])),("C",Object (fromList [("age",Object (fromList [("int",Number 69.0)])),("name",String "chessai")]))]
+    --  but got: [("A",Object (fromList [("age",Object (fromList [("int",Number 42.0)])),("name",String "Lindsey Lohan")])),("B",Object (fromList [("age",Object (fromList [("int",Number 30.0)])),("name",String "Nico Robin")])),("C",Object (fromList [("age",Object (fromList [("int",Number 69.0)])),("name",String "chessai")]))]
 
 localTest :: Pact.TxCreationTime -> ClientEnv -> IO ()
 localTest t cenv = do


### PR DESCRIPTION
Removes *Verifiers flags in favor of Pact411 and Chainweb223 flags. Notes one test as flaky.