### PR TITLE
Rewind TransactionIndex on compaction

### DIFF
--- a/src/Chainweb/Pact/Backend/Compaction.hs
+++ b/src/Chainweb/Pact/Backend/Compaction.hs
@@ -435,8 +435,6 @@ dropNewTables bh = do
 
 -- | Delete all rows from Checkpointer system tables that are not for the target blockheight.
 --
---   We currently do not compact TransactionIndex. This will change once we are
---   properly pruning RocksDB.
 compactSystemTables :: BlockHeight -> CompactM ()
 compactSystemTables bh = do
   let systemTables = ["BlockHistory", "VersionedTableMutation"]
@@ -456,7 +454,13 @@ compactSystemTables bh = do
       "VersionedTableCreation"
       "DELETE FROM VersionedTableCreation WHERE createBlockheight > ?1;"
       [bhToSType bh]
-
+  -- We currently do not compact TransactionIndex. This will change once we are
+  -- properly pruning RocksDB.
+  execM'
+    "compactSystemTables: TransactionIndex"
+    "TransactionIndex"
+    "DELETE FROM TransactionIndex WHERE blockheight > ?1;"
+    [bhToSType bh]
 
 dropCompactTables :: CompactM ()
 dropCompactTables = do

--- a/src/Chainweb/WebPactExecutionService.hs
+++ b/src/Chainweb/WebPactExecutionService.hs
@@ -5,6 +5,7 @@ module Chainweb.WebPactExecutionService
   ( WebPactExecutionService(..)
   , _webPactNewBlock
   , _webPactValidateBlock
+  , _webPactSyncToBlock
   , PactExecutionService(..)
   , mkWebPactExecutionService
   , mkPactExecutionService
@@ -129,6 +130,13 @@ _webPactValidateBlock
     -> IO PayloadWithOutputs
 _webPactValidateBlock = _pactValidateBlock . _webPactExecutionService
 {-# INLINE _webPactValidateBlock #-}
+
+_webPactSyncToBlock
+    :: WebPactExecutionService
+    -> BlockHeader
+    -> IO ()
+_webPactSyncToBlock = _pactSyncToBlock . _webPactExecutionService
+{-# INLINE _webPactSyncToBlock #-}
 
 mkWebPactExecutionService
     :: HasCallStack

--- a/test/Chainweb/Test/Pact/PactMultiChainTest.hs
+++ b/test/Chainweb/Test/Pact/PactMultiChainTest.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE ImportQualifiedPost #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE NumericUnderscores #-}
 {-# LANGUAGE OverloadedStrings #-}
@@ -25,6 +26,8 @@ import qualified Data.Text as T
 import qualified Data.Vector as V
 import Test.Tasty
 import Test.Tasty.HUnit
+import System.Logger qualified as YAL
+import System.LogLevel
 
 -- internal modules
 
@@ -51,6 +54,7 @@ import Chainweb.Cut
 import Chainweb.Mempool.Mempool
 import Chainweb.Miner.Pact
 import Chainweb.Pact.Backend.Types
+import Chainweb.Pact.Backend.Compaction qualified as C
 import Chainweb.Pact.PactService
 import Chainweb.Pact.Service.Types
 import Chainweb.Pact.TransactionExec (listErrMsg)
@@ -79,7 +83,7 @@ cid = unsafeChainId 9
 data MultiEnv = MultiEnv
     { _menvBdb :: !TestBlockDb
     , _menvPact :: !WebPactExecutionService
-    , _menvPacts :: !(HM.HashMap ChainId PactExecutionService)
+    , _menvPacts :: !(HM.HashMap ChainId (SQLiteEnv, PactExecutionService))
     , _menvMpa :: !(IO (IORef MemPoolAccess))
     , _menvMiner :: !Miner
     , _menvChainId :: !ChainId
@@ -136,6 +140,7 @@ tests = testGroup testName
   , test generousConfig getGasModel "pact410UpgradeTest" pact410UpgradeTest
   , test generousConfig getGasModel "verifierTest" verifierTest
   , test generousConfig getGasModel "chainweb223Test" chainweb223Test
+  , test generousConfig getGasModel "compactAndSyncTest" compactAndSyncTest
   ]
   where
     testName = "Chainweb.Test.Pact.PactMultiChainTest"
@@ -355,10 +360,16 @@ runLocalWithDepth nonce depth cid' cmd = do
   cwCmd <- buildCwCmd nonce testVersion cmd
   liftIO $ _pactLocal pact Nothing Nothing depth cwCmd
 
+getSqlite :: ChainId -> PactTestM SQLiteEnv
+getSqlite cid' = do
+  HM.lookup cid' <$> view menvPacts >>= \case
+    Just (dbEnv, _) -> return dbEnv
+    Nothing -> liftIO $ assertFailure $ "No SQLite found for chain id " ++ show cid'
+
 getPactService :: ChainId -> PactTestM PactExecutionService
 getPactService cid' = do
   HM.lookup cid' <$> view menvPacts >>= \case
-    Just pact -> return pact
+    Just (_, pact) -> return pact
     Nothing -> liftIO $ assertFailure $ "No pact service found at chain id " ++ show cid'
 
 assertLocalFailure
@@ -525,11 +536,11 @@ chainweb215Test = do
   currCut <- currentCut
 
     -- rewind to saved cut 43
-  rewindTo savedCut
+  syncTo savedCut
   runToHeight 43
 
   -- resume on original cut
-  rewindTo currCut
+  syncTo currCut
 
   -- run until post-fork xchain proof exists
   resetMempool
@@ -546,7 +557,7 @@ chainweb215Test = do
     ]
 
     -- rewind to saved cut 50
-  rewindTo savedCut1
+  syncTo savedCut1
   runToHeight 53
 
   where
@@ -1294,6 +1305,29 @@ chainweb223Test = do
       (assertTxFailure "should not allow rotating principals after fork" "It is unsafe for principal accounts to rotate their guard")
     ]
 
+compactAndSyncTest :: PactTestM ()
+compactAndSyncTest = do
+  -- start with all forks on.
+  let start = latestBehaviorAt testVersion
+  runToHeight start
+  -- we want to run a transaction but it doesn't matter what it does, as long
+  -- as it gets on-chain and thus affects the Pact state.
+  runBlockTest
+    [ PactTxTest (buildBasic $ mkExec' "1") (assertTxSuccess "should allow innocent transaction" (pDecimal 1))
+    ]
+  -- save the cut with the tx, we'll return to it after compaction
+  cutWithTx <- currentCut
+  currentCid <- view menvChainId
+  dbEnv <- getSqlite currentCid
+
+  liftIO $ C.withDefaultLogger Warn $ \cLogger -> do
+    let cLogger' = over YAL.setLoggerScope (\scope -> ("chainId",sshow currentCid) : scope) cLogger
+    let flags = [C.NoVacuum]
+    -- compact to before the tx happened
+    void $ compactUntilAvailable (C.Target start) cLogger' dbEnv flags
+  -- now sync to after the tx and expect no errors
+  syncTo cutWithTx
+
 pact4coin3UpgradeTest :: PactTestM ()
 pact4coin3UpgradeTest = do
 
@@ -1383,7 +1417,7 @@ pact4coin3UpgradeTest = do
   withChain chain0 $ runBlockTests block22_0
 
   -- rewind to savedCut (cut 18)
-  rewindTo savedCut
+  syncTo savedCut
   runToHeight 22
 
   where
@@ -1469,8 +1503,8 @@ resetMempool = view menvMpa >>= \r -> setMempool r mempty
 currentCut :: PactTestM Cut
 currentCut = view menvBdb >>= liftIO . readMVar . _bdbCut
 
-rewindTo :: Cut -> PactTestM ()
-rewindTo c = do
+syncTo :: Cut -> PactTestM ()
+syncTo c = do
   pact <- view menvPact
   bdb <- view menvBdb
 
@@ -1478,11 +1512,10 @@ rewindTo c = do
     let
       ph = case HM.lookup cid' (_cutMap c) of
           Just h -> h
-          Nothing -> error $ "rewindTo: can't find block header for " ++ show cid'
+          Nothing -> error $ "syncTo: can't find block header for " ++ show cid'
 
-    -- reset the parent header using validateBlock
-    pout <- liftIO $ getPWOByHeader ph bdb
-    void $ liftIO $ _webPactValidateBlock pact ph (payloadWithOutputsToPayloadData pout)
+    -- reset the parent header using SyncToBlock
+    void $ liftIO $ _webPactSyncToBlock pact ph
 
     void $ liftIO $ swapMVar (_bdbCut bdb) c
 


### PR DESCRIPTION
Without this, nodes fail on compacted dbs with something like this:
```
2024-02-15T22:42:02.653Z [Error] [chainwebVersion=mainnet01|peerId=hYiuKp|port=...|host=...|chain=7|component=pact|type=ChainwebApp] Received exception running pact service (syncToBlockBlock): {"tag":"PactInternalError","contents":"callDb (dbIndexTransactions): user error (error during batch insert: ErrorConstraint)"}
chainweb-node: {"tag":"PactInternalError","contents":"{\"tag\":\"PactInternalError\",\"contents\":\"callDb (dbIndexTransactions): user error (error during batch insert: ErrorConstraint)\"}"}
```

It would maybe be preferable if we just did an ordinary checkpointer rewind. #1794 is the cause.