### PR TITLE
Change the MessageERC20 plugin's workflow with the token message.

### DIFF
--- a/src/Chainweb/VerifierPlugin/Hyperlane/MessageERC20.hs
+++ b/src/Chainweb/VerifierPlugin/Hyperlane/MessageERC20.hs
@@ -18,7 +18,6 @@ import Control.Error
 import Control.Monad (unless)
 import Control.Monad.Except
 
-import qualified Data.Map.Strict as M
 import qualified Data.Text.Encoding as Text
 import qualified Data.Vector as V
 import qualified Data.Set as Set
@@ -34,7 +33,7 @@ import Chainweb.Utils.Serialization (putRawByteString, runPutS, runGetS, putWord
 import Chainweb.VerifierPlugin
 import Chainweb.VerifierPlugin.Hyperlane.Binary
 import Chainweb.VerifierPlugin.Hyperlane.Utils
-import Chainweb.Utils (decodeB64UrlNoPaddingText, sshow)
+import Chainweb.Utils (encodeB64UrlNoPaddingText, decodeB64UrlNoPaddingText, sshow)
 
 plugin :: VerifierPlugin
 plugin = VerifierPlugin $ \proof caps gasRef -> do
@@ -72,9 +71,7 @@ plugin = VerifierPlugin $ \proof caps gasRef -> do
       "Recipients don't match. Expected: " <> sshow hmRecipientPactValue <> " but got " <> sshow capRecipient
 
   let
-    TokenMessageERC20{..} = hmTokenMessage
-    hmTokenMessagePactValue = PObject $ ObjectMap $ M.fromList
-        [ ("recipient", PLiteral $ LString tmRecipient), ("amount", PLiteral $ LDecimal $ wordToDecimal tmAmount) ]
+    hmTokenMessagePactValue = PLiteral $ LString $ encodeB64UrlNoPaddingText $ runPutS $ putTokenMessageERC20 hmTokenMessage
 
   unless (hmTokenMessagePactValue == capTokenMessage) $
     throwError $ VerifierError $

--- a/src/Chainweb/VerifierPlugin/Hyperlane/Utils.hs
+++ b/src/Chainweb/VerifierPlugin/Hyperlane/Utils.hs
@@ -14,6 +14,7 @@ module Chainweb.VerifierPlugin.Hyperlane.Utils
 
   , encodeHex
   , decodeHex
+  , decodeHexUnsafe
 
   , ethereumHeader
   ) where
@@ -26,6 +27,7 @@ import qualified Data.ByteString.Base16 as B16
 import qualified Data.ByteString.Short as BS
 import qualified Data.ByteString.Builder as Builder
 import Data.Text (Text)
+import Data.Either (fromRight)
 import Data.DoubleWord
 import Data.Decimal
 import Data.Ratio
@@ -74,6 +76,9 @@ decodeHex :: Text -> Either String B.ByteString
 decodeHex s
   | Just h <- Text.stripPrefix "0x" s = B16.decode $ Text.encodeUtf8 h
   | otherwise = Left "decodeHex: does not start with 0x"
+
+decodeHexUnsafe :: Text -> B.ByteString
+decodeHexUnsafe = fromRight (error "decodeHexUnsafe: failed to decode hex") . decodeHex
 
 decimalToWord :: Decimal -> Word256
 decimalToWord d =


### PR DESCRIPTION
Changes:
- make capability's token message take base64 message instead of object
- add chainId to token message
- refactor tests to generate base64 manually