### PR TITLE
fix: getVersionedTables based on VersionedTableCreation not VersionedTableMutation

### DIFF
--- a/src/Chainweb/Pact/Backend/Compaction.hs
+++ b/src/Chainweb/Pact/Backend/Compaction.hs
@@ -374,8 +374,8 @@ getVersionedTables bh = do
   logg Info "getVersionedTables"
   rs <- qryNoTemplateM
         "getVersionedTables.0"
-        " SELECT DISTINCT tablename FROM VersionedTableMutation \
-        \ WHERE blockheight <= ? ORDER BY blockheight; "
+        " SELECT tablename FROM VersionedTableCreation \
+        \ WHERE createBlockheight <= ? ORDER BY createBlockheight; "
         [bhToSType bh]
         [RText]
   pure (V.fromList (sortedTableNames rs))

--- a/test/Chainweb/Test/Pact/PactSingleChainTest.hs
+++ b/test/Chainweb/Test/Pact/PactSingleChainTest.hs
@@ -180,6 +180,8 @@ runBlockE q bdb timeOffset = do
   nextH <- getParentTestBlockDb bdb cid
   validateBlock nextH (payloadWithOutputsToPayloadData nb) q
 
+-- edmundn: why does any of this return PayloadWithOutputs instead of a
+-- list of Pact CommandResult?
 runBlock :: (HasCallStack) => PactQueue -> TestBlockDb -> TimeSpan Micros -> IO PayloadWithOutputs
 runBlock q bdb timeOffset = do
   forSuccess "newBlockAndValidate: validate" $


### PR DESCRIPTION
The old code would not compact tables that were created in the past relative to the compaction height but never written to in the past.