### PR TITLE
service: implement timeout support for `/local` endpoints

### DIFF
--- a/src/Chainweb/Chainweb.hs
+++ b/src/Chainweb/Chainweb.hs
@@ -428,6 +428,7 @@ withChainwebInternal conf logger peer serviceSock rocksDb pactDbDir backupDir re
       , _pactLogGas = _configLogGas conf
       , _pactModuleCacheLimit = _configModuleCacheLimit conf
       , _pactFullHistoryRequired = _configRosetta conf -- this could be OR'd with other things that require full history
+      , _pactEnableLocalTimeout = _configEnableLocalTimeout conf
       }
 
     pruningLogger :: T.Text -> logger

--- a/src/Chainweb/Chainweb/Configuration.hs
+++ b/src/Chainweb/Chainweb/Configuration.hs
@@ -70,6 +70,7 @@ module Chainweb.Chainweb.Configuration
 , configServiceApi
 , configOnlySyncPact
 , configSyncPactChains
+, configEnableLocalTimeout
 , defaultChainwebConfiguration
 , pChainwebConfiguration
 , validateChainwebConfiguration
@@ -405,6 +406,7 @@ data ChainwebConfiguration = ChainwebConfiguration
         --   if unset, all chains will be synchronized.
     , _configModuleCacheLimit :: !DbCacheLimitBytes
         -- ^ module cache size limit in bytes
+    , _configEnableLocalTimeout :: !Bool
     } deriving (Show, Eq, Generic)
 
 makeLenses ''ChainwebConfiguration
@@ -463,6 +465,7 @@ defaultChainwebConfiguration v = ChainwebConfiguration
     , _configSyncPactChains = Nothing
     , _configBackup = defaultBackupConfig
     , _configModuleCacheLimit = defaultModuleCacheLimit
+    , _configEnableLocalTimeout = False
     }
 
 instance ToJSON ChainwebConfiguration where
@@ -489,6 +492,7 @@ instance ToJSON ChainwebConfiguration where
         , "syncPactChains" .= _configSyncPactChains o
         , "backup" .= _configBackup o
         , "moduleCacheLimit" .= _configModuleCacheLimit o
+        , "enableLocalTimeout" .= _configEnableLocalTimeout o
         ]
 
 instance FromJSON ChainwebConfiguration where
@@ -519,6 +523,7 @@ instance FromJSON (ChainwebConfiguration -> ChainwebConfiguration) where
         <*< configSyncPactChains ..: "syncPactChains" % o
         <*< configBackup %.: "backup" % o
         <*< configModuleCacheLimit ..: "moduleCacheLimit" % o
+        <*< configEnableLocalTimeout ..: "enableLocalTimeout" % o
 
 pChainwebConfiguration :: MParser ChainwebConfiguration
 pChainwebConfiguration = id
@@ -573,7 +578,9 @@ pChainwebConfiguration = id
         % long "module-cache-limit"
         <> help "Maximum size of the per-chain checkpointer module cache in bytes"
         <> metavar "INT"
-    where
+    <*< configEnableLocalTimeout .:: option auto
+        % long "enable-local-timeout"
+        <> help "Enable timeout support on /local endpoints"
 
 parseVersion :: MParser ChainwebVersion
 parseVersion = constructVersion

--- a/src/Chainweb/Pact/PactService.hs
+++ b/src/Chainweb/Pact/PactService.hs
@@ -164,6 +164,7 @@ withPactService ver cid chainwebLogger bhDb pdb sqlenv config act =
                     , _psLogger = pactServiceLogger
                     , _psGasLogger = gasLogger <$ guard (_pactLogGas config)
                     , _psBlockGasLimit = _pactBlockGasLimit config
+                    , _psEnableLocalTimeout = _pactEnableLocalTimeout config
                     }
             !pst = PactServiceState mempty
 
@@ -698,50 +699,62 @@ execLocal cwtx preflight sigVerify rdepth = pactLabel "execLocal" $ do
     -- (i.e. setting rewind to 0).
     let rewindDepth = maybe 0 _rewindDepth rdepth
 
-    readFromNthParent (fromIntegral rewindDepth) $ do
-        pc <- view psParentHeader
-        let spv = pactSPV bhdb (_parentHeader pc)
-        ctx <- getTxContext pm
-        let gasModel = getGasModel ctx
-        mc <- getInitCache
-        dbEnv <- view psBlockDbEnv
+    let timeoutLimit
+          | _psEnableLocalTimeout = Just (2 * 1_000_000)
+          | otherwise = Nothing
 
-        --
-        -- if the ?preflight query parameter is set to True, we run the `applyCmd` workflow
-        -- otherwise, we prefer the old (default) behavior. When no preflight flag is
-        -- specified, we run the old behavior. When it is set to true, we also do metadata
-        -- validations.
-        --
-        r <- case preflight of
-          Just PreflightSimulation -> do
-            liftPactServiceM (assertLocalMetadata cmd ctx sigVerify) >>= \case
-              Right{} -> do
-                let initialGas = initialGasOf $ P._cmdPayload cwtx
-                T3 cr _mc warns <- liftIO $ applyCmd
-                  _psVersion _psLogger _psGasLogger (_cpPactDbEnv dbEnv)
-                  noMiner gasModel ctx spv cmd
-                  initialGas mc ApplyLocal
+    let act = readFromNthParent (fromIntegral rewindDepth) $ do
+                pc <- view psParentHeader
+                let spv = pactSPV bhdb (_parentHeader pc)
+                ctx <- getTxContext pm
+                let gasModel = getGasModel ctx
+                mc <- getInitCache
+                dbEnv <- view psBlockDbEnv
+        
+                --
+                -- if the ?preflight query parameter is set to True, we run the `applyCmd` workflow
+                -- otherwise, we prefer the old (default) behavior. When no preflight flag is
+                -- specified, we run the old behavior. When it is set to true, we also do metadata
+                -- validations.
+                --
+                r <- case preflight of
+                  Just PreflightSimulation -> do
+                    liftPactServiceM (assertLocalMetadata cmd ctx sigVerify) >>= \case
+                      Right{} -> do
+                        let initialGas = initialGasOf $ P._cmdPayload cwtx
+                        T3 cr _mc warns <- liftIO $ applyCmd
+                          _psVersion _psLogger _psGasLogger (_cpPactDbEnv dbEnv)
+                          noMiner gasModel ctx spv cmd
+                          initialGas mc ApplyLocal
+        
+                        let cr' = toHashCommandResult cr
+                            warns' = P.renderCompactText <$> toList warns
+                        pure $ LocalResultWithWarns cr' warns'
+                      Left e -> pure $ MetadataValidationFailure e
+                  _ -> liftIO $ do
+                    let execConfig = P.mkExecutionConfig $
+                            [ P.FlagAllowReadInLocal | _psAllowReadsInLocal ] ++
+                            enablePactEvents' (_chainwebVersion ctx) (_chainId ctx) (ctxCurrentBlockHeight ctx) ++
+                            enforceKeysetFormats' (_chainwebVersion ctx) (_chainId ctx) (ctxCurrentBlockHeight ctx) ++
+                            disableReturnRTC (_chainwebVersion ctx) (_chainId ctx) (ctxCurrentBlockHeight ctx)
+        
+                    cr <- applyLocal
+                      _psLogger _psGasLogger (_cpPactDbEnv dbEnv)
+                      gasModel ctx spv
+                      cwtx mc execConfig
+        
+                    let cr' = toHashCommandResult cr
+                    pure $ LocalResultLegacy cr'
+        
+                return r
 
-                let cr' = toHashCommandResult cr
-                    warns' = P.renderCompactText <$> toList warns
-                pure $ LocalResultWithWarns cr' warns'
-              Left e -> pure $ MetadataValidationFailure e
-          _ -> liftIO $ do
-            let execConfig = P.mkExecutionConfig $
-                    [ P.FlagAllowReadInLocal | _psAllowReadsInLocal ] ++
-                    enablePactEvents' (_chainwebVersion ctx) (_chainId ctx) (ctxCurrentBlockHeight ctx) ++
-                    enforceKeysetFormats' (_chainwebVersion ctx) (_chainId ctx) (ctxCurrentBlockHeight ctx) ++
-                    disableReturnRTC (_chainwebVersion ctx) (_chainId ctx) (ctxCurrentBlockHeight ctx)
-
-            cr <- applyLocal
-              _psLogger _psGasLogger (_cpPactDbEnv dbEnv)
-              gasModel ctx spv
-              cwtx mc execConfig
-
-            let cr' = toHashCommandResult cr
-            pure $ LocalResultLegacy cr'
-
-        return r
+    case timeoutLimit of
+      Nothing -> act
+      Just limit -> withPactState $ \run -> timeout limit (run act) >>= \case
+        Just r -> pure r
+        Nothing -> do
+          logError_ _psLogger $ "Mempool local action timed out for cwtx:\n" <> sshow cwtx
+          pure LocalTimeout
 
 execSyncToBlock
     :: (CanReadablePayloadCas tbl, Logger logger)

--- a/src/Chainweb/Pact/Types.hs
+++ b/src/Chainweb/Pact/Types.hs
@@ -85,6 +85,7 @@ module Chainweb.Pact.Types
   , psGasLogger
   , psAllowReadsInLocal
   , psBlockGasLimit
+  , psEnableLocalTimeout
 
     -- * TxContext
   , TxContext(..)
@@ -434,6 +435,8 @@ data PactServiceEnv logger tbl = PactServiceEnv
     , _psGasLogger :: !(Maybe logger)
 
     , _psBlockGasLimit :: !GasLimit
+
+    , _psEnableLocalTimeout :: !Bool
     }
 makeLenses ''PactServiceEnv
 
@@ -471,6 +474,7 @@ testPactServiceConfig = PactServiceConfig
       , _pactLogGas = False
       , _pactModuleCacheLimit = defaultModuleCacheLimit
       , _pactFullHistoryRequired = False
+      , _pactEnableLocalTimeout = False
       }
 
 -- | This default value is only relevant for testing. In a chainweb-node the @GasLimit@

--- a/test/Chainweb/Test/Pact/PactExec.hs
+++ b/test/Chainweb/Test/Pact/PactExec.hs
@@ -557,6 +557,7 @@ execLocalTest runPact name (trans',check) = testCase name (go >>= check)
       case results' of
         Right (MetadataValidationFailure e) ->
           return $ Left $ show e
+        Right LocalTimeout -> return $ Left "LocalTimeout"
         Right (LocalResultLegacy cr) -> return $ Right cr
         Right (LocalResultWithWarns cr _) -> return $ Right cr
         Left e -> return $ Left $ show e

--- a/test/Chainweb/Test/Pact/RemotePactTest.hs
+++ b/test/Chainweb/Test/Pact/RemotePactTest.hs
@@ -554,6 +554,8 @@ localPreflightSimTest t cenv step = do
         assertFailure "Preflight /local call produced legacy result"
       Right MetadataValidationFailure{} ->
         assertFailure "Preflight produced an impossible result"
+      Right LocalTimeout ->
+        assertFailure "Preflight should never produce a timeout"
       Right LocalResultWithWarns{} -> pure ()
 
     step "Execute preflight /local tx - preflight+signoverify known /send success"
@@ -606,6 +608,8 @@ localPreflightSimTest t cenv step = do
       Left e -> assertFailure $ show e
       Right LocalResultLegacy{} ->
         assertFailure "Preflight /local call produced legacy result"
+      Right LocalTimeout ->
+        assertFailure "Preflight should never produce a timeout"
       Right MetadataValidationFailure{} ->
         assertFailure "Preflight produced an impossible result"
       Right (LocalResultWithWarns cr' ws) -> do
@@ -627,6 +631,8 @@ localPreflightSimTest t cenv step = do
       Left e -> assertFailure $ show e
       Right LocalResultLegacy{} ->
         assertFailure "Preflight /local call produced legacy result"
+      Right LocalTimeout ->
+        assertFailure "Preflight should never produce a timeout"
       Right MetadataValidationFailure{} ->
         assertFailure "Preflight produced an impossible result"
       Right (LocalResultWithWarns cr' ws) -> do

--- a/test/Chainweb/Test/Pact/Utils.hs
+++ b/test/Chainweb/Test/Pact/Utils.hs
@@ -706,6 +706,7 @@ testPactCtxSQLite logger v cid bhdb pdb sqlenv conf gasmodel = do
                 $ _cpLogger $ _cpReadCp cp
 
         , _psBlockGasLimit = _pactBlockGasLimit conf
+        , _psEnableLocalTimeout = False
         }
 
 freeGasModel :: TxContext -> GasModel

--- a/tools/cwtool/TxSimulator.hs
+++ b/tools/cwtool/TxSimulator.hs
@@ -175,6 +175,7 @@ simulate sc@(SimConfig dbDir txIdx' _ _ cid ver gasLog doTypecheck) = do
                 , _psLogger = logger
                 , _psGasLogger = gasLogger
                 , _psBlockGasLimit = testBlockGasLimit
+                , _psEnableLocalTimeout = False
                 }
               pss = PactServiceState
                 { _psInitCache = mempty


### PR DESCRIPTION
To prevent transactions with long table-scans from taking too long and backing up others.