### PR TITLE
Periodically freshen up payloads in the primeWork loop

### DIFF
--- a/src/Chainweb/CutDB.hs
+++ b/src/Chainweb/CutDB.hs
@@ -59,7 +59,7 @@ module Chainweb.CutDB
 , cutStm
 , awaitNewCut
 , awaitNewCutByChainId
-, awaitNewBlock
+, awaitNewBlockInCut
 , awaitNewCutByChainIdStm
 , cutStream
 , addCutHashes
@@ -346,8 +346,8 @@ awaitNewCutByChainId cdb cid c = atomically $ awaitNewCutByChainIdStm cdb cid c
 
 -- | As in `awaitNewCut`, but only updates when the header at the specified
 -- `ChainId` has changed, and only returns that new header.
-awaitNewBlock :: CutDb tbl -> ChainId -> BlockHeader -> IO BlockHeader
-awaitNewBlock cdb cid bh = atomically $ do
+awaitNewBlockInCut :: CutDb tbl -> ChainId -> BlockHeader -> IO BlockHeader
+awaitNewBlockInCut cdb cid bh = atomically $ do
     c <- _cutStm cdb
     case HM.lookup cid (_cutMap c) of
         Just bh' | _blockHash bh' /= _blockHash bh -> return bh'


### PR DESCRIPTION
Testing ideas:

on testnet, and eventually mainnet once deployed:

- checking that a miner earns the same amount of revenue using this patch, and
- checking that transaction latency decreases, maybe via a histogram.

You can probably make this even clearer using a devnet with a long block time. A test like:

- submit tx, poll tx, submit tx, poll tx, ...
- then check the final block height. it should be less using this patch.

