### PR TITLE
Add quirks to ChainwebVersion

### DIFF
--- a/node/ChainwebNode.hs
+++ b/node/ChainwebNode.hs
@@ -339,7 +339,7 @@ node conf logger = do
     pactDbDir <- getPactDbDir conf
     dbBackupsDir <- getBackupsDir conf
     withRocksDb' <-
-        if _configOnlySyncPact cwConf
+        if _configOnlySyncPact cwConf || _configReadOnlyReplay cwConf
         then
             if _cutPruneChainDatabase (_configCuts cwConf) == GcNone
             then withReadOnlyRocksDb <$ logFunctionText logger Info "Opening RocksDB in read-only mode"

--- a/src/Chainweb/Pact/PactService.hs
+++ b/src/Chainweb/Pact/PactService.hs
@@ -992,7 +992,7 @@ execPreInsertCheckReq txs = pactLabel "execPreInsertCheckReq" $ do
                   [ P.FlagDisableModuleInstall
                   , P.FlagDisableHistoryInTransactionalMode ] ++
                   disableReturnRTC (_chainwebVersion pd) (_chainId pd) (ctxCurrentBlockHeight pd)
-            return $! TransactionEnv P.Transactional (_cpPactDbEnv dbEnv) l Nothing (ctxToPublicData pd) spv nid gp rk gl ec
+            return $! TransactionEnv P.Transactional (_cpPactDbEnv dbEnv) l Nothing (ctxToPublicData pd) spv nid gp rk gl ec Nothing
           where
             !nid = networkIdOf cmd
             !rk = P.cmdToRequestKey cmd

--- a/src/Chainweb/Pact/Types.hs
+++ b/src/Chainweb/Pact/Types.hs
@@ -62,6 +62,7 @@ module Chainweb.Pact.Types
   , txGasPrice
   , txRequestKey
   , txExecutionConfig
+  , txQuirkGasFee
 
     -- * Transaction Execution Monad
   , TransactionM(..)
@@ -335,6 +336,7 @@ data TransactionEnv logger db = TransactionEnv
     , _txRequestKey :: !RequestKey
     , _txGasLimit :: !Gas
     , _txExecutionConfig :: !ExecutionConfig
+    , _txQuirkGasFee :: !(Maybe Gas)
     }
 makeLenses ''TransactionEnv
 

--- a/src/Chainweb/Version/Development.hs
+++ b/src/Chainweb/Version/Development.hs
@@ -60,4 +60,5 @@ devnet = ChainwebVersion
         , _disableMempoolSync = False
         }
     , _versionVerifierPluginNames = AllChains $ (End $ Set.fromList $ map VerifierName ["hyperlane_v3_message"])
+    , _versionQuirks = noQuirks
     }

--- a/src/Chainweb/Version/Guards.hs
+++ b/src/Chainweb/Version/Guards.hs
@@ -175,8 +175,8 @@ pactBackCompat_v16 :: ChainwebVersion -> ChainId -> BlockHeight -> Bool
 pactBackCompat_v16 = checkFork before PactBackCompat_v16
 
 -- | Early versions of chainweb used the creation time of the current header
--- for validation of pact tx creation time and TTL. Nowadays the times of
--- the parent header a used.
+-- for validation of pact tx creation time and TTL. Nowadays the time of
+-- the parent header is used.
 --
 -- When this guard is enabled timing validation is skipped.
 --

--- a/src/Chainweb/Version/Mainnet.hs
+++ b/src/Chainweb/Version/Mainnet.hs
@@ -22,6 +22,7 @@ import Chainweb.Utils.Rule
 import Chainweb.Version
 import P2P.BootstrapNodes
 
+import Pact.Types.Runtime (Gas(..))
 import Pact.Types.Verifier
 
 import qualified Chainweb.BlockHeader.Genesis.Mainnet0Payload as MN0
@@ -211,4 +212,9 @@ mainnet = ChainwebVersion
         }
     , _versionVerifierPluginNames = AllChains $ (4_577_530, Set.fromList $ map VerifierName ["hyperlane_v3_message"]) `Above`
         End mempty
+    , _versionQuirks = VersionQuirks
+        { _quirkGasFees = HM.fromList
+            [ (fromJuste (decodeStrictOrThrow' "\"s9fUspNaCHoV4rNI-Tw-JYU1DxqZAOXS-80oEy7Zfbo\""), Gas 67618)
+            ]
+        }
     }

--- a/src/Chainweb/Version/RecapDevelopment.hs
+++ b/src/Chainweb/Version/RecapDevelopment.hs
@@ -117,4 +117,5 @@ recapDevnet = ChainwebVersion
         }
     , _versionVerifierPluginNames = AllChains $ (600, Set.fromList $ map VerifierName ["hyperlane_v3_message"]) `Above`
         End mempty
+    , _versionQuirks = noQuirks
     }

--- a/src/Chainweb/Version/Testnet.hs
+++ b/src/Chainweb/Version/Testnet.hs
@@ -22,6 +22,7 @@ import Chainweb.Utils.Rule
 import Chainweb.Version
 import P2P.BootstrapNodes
 
+import Pact.Types.Runtime (Gas(..))
 import Pact.Types.Verifier
 
 import qualified Chainweb.Pact.Transactions.CoinV3Transactions as CoinV3
@@ -182,4 +183,10 @@ testnet = ChainwebVersion
         }
     , _versionVerifierPluginNames = AllChains $ (4_100_681, Set.fromList $ map VerifierName ["hyperlane_v3_message"]) `Above`
         End mempty
+    , _versionQuirks = VersionQuirks
+        { _quirkGasFees = HM.fromList
+            [ (fromJuste (decodeStrictOrThrow' "\"myHrgVbYCXlAk8KJbmWHs3TEDSlRKRuzxpFa9yaC7cQ\""), Gas 66239)
+            , (fromJuste (decodeStrictOrThrow' "\"3fpFnFUrRsu67ItHicBGa9PVlWp71AggrcWoikht3jk\""), Gas 65130)
+            ]
+        }
     }

--- a/test/Chainweb/Test/Cut/TestBlockDb.hs
+++ b/test/Chainweb/Test/Cut/TestBlockDb.hs
@@ -45,6 +45,9 @@ data TestBlockDb = TestBlockDb
   , _bdbCut :: MVar Cut
   }
 
+instance HasChainwebVersion TestBlockDb where
+  _chainwebVersion = _chainwebVersion . _bdbWebBlockHeaderDb
+
 -- | Initialize TestBlockDb.
 withTestBlockDb :: ChainwebVersion -> (TestBlockDb -> IO a) -> IO a
 withTestBlockDb cv a = do

--- a/test/Chainweb/Test/Pact/Checkpointer.hs
+++ b/test/Chainweb/Test/Pact/Checkpointer.hs
@@ -664,7 +664,7 @@ runExec cp pactdbenv eData eCode = do
     h' = H.toUntypedHash (H.hash "" :: H.PactHash)
     cmdenv :: TransactionEnv logger (BlockEnv logger SQLiteEnv)
     cmdenv = TransactionEnv Transactional pactdbenv (_cpLogger $ _cpReadCp cp) Nothing def
-             noSPVSupport Nothing 0.0 (RequestKey h') 0 def
+             noSPVSupport Nothing 0.0 (RequestKey h') 0 def Nothing
     cmdst = TransactionState mempty mempty 0 Nothing (_geGasModel freeGasEnv) mempty
 
 runCont :: Logger logger => Checkpointer logger -> ChainwebPactDbEnv logger -> PactId -> Int -> IO EvalResult
@@ -676,7 +676,7 @@ runCont cp pactdbenv pactId step = do
 
     h' = H.toUntypedHash (H.hash "" :: H.PactHash)
     cmdenv = TransactionEnv Transactional pactdbenv (_cpLogger $ _cpReadCp cp) Nothing def
-             noSPVSupport Nothing 0.0 (RequestKey h') 0 def
+             noSPVSupport Nothing 0.0 (RequestKey h') 0 def Nothing
     cmdst = TransactionState mempty mempty 0 Nothing (_geGasModel freeGasEnv) mempty
 
 -- -------------------------------------------------------------------------- --

--- a/test/Chainweb/Test/Pact/TransactionTests.hs
+++ b/test/Chainweb/Test/Pact/TransactionTests.hs
@@ -261,7 +261,7 @@ testCoinbase797DateFix = testCaseSteps "testCoinbase791Fix" $ \step -> do
 
       let h = H.toUntypedHash (H.hash "" :: H.PactHash)
           tenv = TransactionEnv Transactional pdb logger Nothing def
-            noSPVSupport Nothing 0.0 (RequestKey h) 0 def
+            noSPVSupport Nothing 0.0 (RequestKey h) 0 def Nothing
           txst = TransactionState mempty mempty 0 Nothing (_geGasModel freeGasEnv) mempty
 
       CommandResult _ _ (PactResult pr) _ _ _ _ _ <- evalTransactionM tenv txst $!

--- a/test/Chainweb/Test/TestVersions.hs
+++ b/test/Chainweb/Test/TestVersions.hs
@@ -10,6 +10,7 @@ module Chainweb.Test.TestVersions
     , fastForkingCpmTestVersion
     , noBridgeCpmTestVersion
     , slowForkingCpmTestVersion
+    , quirkedGasSlowForkingCpmTestVersion
     , timedConsensusVersion
     ) where
 
@@ -39,6 +40,9 @@ import Chainweb.Version
 import Chainweb.Version.Registry
 import P2P.Peer
 
+import qualified Pact.Types.Command as P
+import qualified Pact.Types.Gas as P
+import qualified Pact.Types.Hash as P
 import Pact.Types.Verifier
 
 import qualified Chainweb.Pact.Transactions.CoinV3Transactions as CoinV3
@@ -100,6 +104,9 @@ testVersions = _versionName <$> concat
       | g1 :: KnownGraph <- [minBound..maxBound]
       , g2 :: KnownGraph <- [minBound..maxBound]
       ]
+    , [ quirkedGasSlowForkingCpmTestVersion (knownChainGraph g) (P.RequestKey $ P.Hash mempty)
+      | g :: KnownGraph <- [minBound..maxBound]
+      ]
     ]
 
 -- | Details common to all test versions thus far.
@@ -114,6 +121,7 @@ testVersionTemplate v = v
     & versionMaxBlockGasLimit .~ End (Just 2_000_000)
     & versionBootstraps .~ [testBootstrapPeerInfos]
     & versionVerifierPluginNames .~ AllChains (End mempty)
+    & versionQuirks .~ noQuirks
 
 -- | A set of fork heights which are relatively fast, but not fast enough to break anything.
 fastForks :: HashMap Fork (ChainMap ForkHeight)
@@ -237,43 +245,58 @@ cpmTestVersion g v = v
             ])
         (onChains [(unsafeChainId 3, HM.singleton (BlockHeight 2) (Upgrade MNKAD.transactions False))])
 
+slowForks :: HashMap Fork (ChainMap ForkHeight)
+slowForks = tabulateHashMap \case
+    SlowEpoch -> AllChains ForkAtGenesis
+    OldTargetGuard -> AllChains ForkAtGenesis
+    SkipFeatureFlagValidation -> AllChains ForkAtGenesis
+    OldDAGuard -> AllChains ForkAtGenesis
+    Vuln797Fix -> AllChains ForkAtGenesis
+    PactBackCompat_v16 -> AllChains ForkAtGenesis
+    SPVBridge -> AllChains ForkAtGenesis
+    Pact44NewTrans -> AllChains ForkAtGenesis
+    CoinV2 -> AllChains $ ForkAtBlockHeight (BlockHeight 1)
+    SkipTxTimingValidation -> AllChains $ ForkAtBlockHeight (BlockHeight 2)
+    ModuleNameFix -> AllChains $ ForkAtBlockHeight (BlockHeight 2)
+    ModuleNameFix2 -> AllChains $ ForkAtBlockHeight (BlockHeight 2)
+    Pact42 -> AllChains $ ForkAtBlockHeight (BlockHeight 5)
+    CheckTxHash -> AllChains $ ForkAtBlockHeight (BlockHeight 7)
+    EnforceKeysetFormats -> AllChains $ ForkAtBlockHeight (BlockHeight 10)
+    PactEvents -> AllChains $ ForkAtBlockHeight (BlockHeight 10)
+    Pact4Coin3 -> AllChains $ ForkAtBlockHeight (BlockHeight 20)
+    Chainweb213Pact -> AllChains $ ForkAtBlockHeight (BlockHeight 26)
+    Chainweb214Pact -> AllChains $ ForkAtBlockHeight (BlockHeight 30)
+    Chainweb215Pact -> AllChains $ ForkAtBlockHeight (BlockHeight 35)
+    Chainweb216Pact -> AllChains $ ForkAtBlockHeight (BlockHeight 53)
+    Chainweb217Pact -> AllChains $ ForkAtBlockHeight (BlockHeight 55)
+    Chainweb218Pact -> AllChains $ ForkAtBlockHeight (BlockHeight 60)
+    Chainweb219Pact -> AllChains $ ForkAtBlockHeight (BlockHeight 71)
+    Chainweb220Pact -> AllChains $ ForkAtBlockHeight (BlockHeight 85)
+    Chainweb221Pact -> AllChains $ ForkAtBlockHeight (BlockHeight 100)
+    Chainweb222Pact -> AllChains $ ForkAtBlockHeight (BlockHeight 115)
+    Chainweb223Pact -> AllChains $ ForkAtBlockHeight (BlockHeight 120)
+    Chainweb224Pact -> AllChains $ ForkAtBlockHeight (BlockHeight 125)
+
 -- | CPM version (see `cpmTestVersion`) with forks and upgrades slowly enabled.
 slowForkingCpmTestVersion :: ChainGraph -> ChainwebVersion
 slowForkingCpmTestVersion g = buildTestVersion $ \v -> v
     & cpmTestVersion g
     & versionName .~ ChainwebVersionName ("slowfork-CPM-" <> toText g)
-    & versionForks .~ tabulateHashMap \case
-        SlowEpoch -> AllChains ForkAtGenesis
-        OldTargetGuard -> AllChains ForkAtGenesis
-        SkipFeatureFlagValidation -> AllChains ForkAtGenesis
-        OldDAGuard -> AllChains ForkAtGenesis
-        Vuln797Fix -> AllChains ForkAtGenesis
-        PactBackCompat_v16 -> AllChains ForkAtGenesis
-        SPVBridge -> AllChains ForkAtGenesis
-        Pact44NewTrans -> AllChains ForkAtGenesis
-        CoinV2 -> AllChains $ ForkAtBlockHeight (BlockHeight 1)
-        SkipTxTimingValidation -> AllChains $ ForkAtBlockHeight (BlockHeight 2)
-        ModuleNameFix -> AllChains $ ForkAtBlockHeight (BlockHeight 2)
-        ModuleNameFix2 -> AllChains $ ForkAtBlockHeight (BlockHeight 2)
-        Pact42 -> AllChains $ ForkAtBlockHeight (BlockHeight 5)
-        CheckTxHash -> AllChains $ ForkAtBlockHeight (BlockHeight 7)
-        EnforceKeysetFormats -> AllChains $ ForkAtBlockHeight (BlockHeight 10)
-        PactEvents -> AllChains $ ForkAtBlockHeight (BlockHeight 10)
-        Pact4Coin3 -> AllChains $ ForkAtBlockHeight (BlockHeight 20)
-        Chainweb213Pact -> AllChains $ ForkAtBlockHeight (BlockHeight 26)
-        Chainweb214Pact -> AllChains $ ForkAtBlockHeight (BlockHeight 30)
-        Chainweb215Pact -> AllChains $ ForkAtBlockHeight (BlockHeight 35)
-        Chainweb216Pact -> AllChains $ ForkAtBlockHeight (BlockHeight 53)
-        Chainweb217Pact -> AllChains $ ForkAtBlockHeight (BlockHeight 55)
-        Chainweb218Pact -> AllChains $ ForkAtBlockHeight (BlockHeight 60)
-        Chainweb219Pact -> AllChains $ ForkAtBlockHeight (BlockHeight 71)
-        Chainweb220Pact -> AllChains $ ForkAtBlockHeight (BlockHeight 85)
-        Chainweb221Pact -> AllChains $ ForkAtBlockHeight (BlockHeight 100)
-        Chainweb222Pact -> AllChains $ ForkAtBlockHeight (BlockHeight 115)
-        Chainweb223Pact -> AllChains $ ForkAtBlockHeight (BlockHeight 120)
-        Chainweb224Pact -> AllChains $ ForkAtBlockHeight (BlockHeight 125)
+    & versionForks .~ slowForks
     & versionVerifierPluginNames .~ AllChains
         (End $ Set.fromList $ map VerifierName ["allow", "hyperlane_v3_announcement", "hyperlane_v3_message"])
+
+-- | CPM version (see `cpmTestVersion`) with forks and upgrades slowly enabled,
+-- and with a gas fee quirk.
+quirkedGasSlowForkingCpmTestVersion :: ChainGraph -> P.RequestKey -> ChainwebVersion
+quirkedGasSlowForkingCpmTestVersion g rk = buildTestVersion $ \v -> v
+    & cpmTestVersion g
+    & versionName .~ ChainwebVersionName ("quirked-slowfork-CPM-" <> toText g)
+    & versionForks .~ slowForks
+    & versionForks . at SkipTxTimingValidation .~
+        Just (AllChains $ ForkAtBlockHeight 200)
+    & versionQuirks .~
+        VersionQuirks { _quirkGasFees = HM.singleton rk (P.Gas 1) }
 
 -- | CPM version (see `cpmTestVersion`) with forks and upgrades quickly enabled.
 fastForkingCpmTestVersion :: ChainGraph -> ChainwebVersion


### PR DESCRIPTION
Adds "quirks", special one-off validation behaviors, to `ChainwebVersion`. Also some test cleanup and allows read-only replay to open rocksdb read-only.