### PR TITLE
Replace push: CI with pull_request: CI

### DIFF
--- a/.github/workflows/applications.yml
+++ b/.github/workflows/applications.yml
@@ -18,10 +18,7 @@ on:
       eventlog:
         description: link with -eventlog
         default: 'False'
-  push:
-    paths:
-    - '**'
-      #    - '!.github/**'
+  pull_request:
   merge_group:
 
 env:


### PR DESCRIPTION
Not sure why we used push:, but we do less CI overall if we use pull_request: and it seems to work better with merge queue.