### PR TITLE
Logging changes

### DIFF
--- a/src/Chainweb/Mempool/InMem.hs
+++ b/src/Chainweb/Mempool/InMem.hs
@@ -250,8 +250,8 @@ markValidatedInMem logger tcfg lock txs = withMVarMasked lock $ \mdata -> do
     x <- readIORef curTxIdxRef
     !x' <- currentTxsInsertBatch x (V.zip expiries hashes)
     when (currentTxsSize x /= currentTxsSize x') $ do
-      logg Info $ "previous current tx index size: " <> sshow (currentTxsSize x)
-      logg Info $ "new current tx index size: " <> sshow (currentTxsSize x')
+      logg Debug $ "previous current tx index size: " <> sshow (currentTxsSize x)
+      logg Debug $ "new current tx index size: " <> sshow (currentTxsSize x')
     writeIORef curTxIdxRef x'
   where
     hashes = txHasher tcfg <$> txs

--- a/src/Chainweb/Pact/Service/PactInProcApi.hs
+++ b/src/Chainweb/Pact/Service/PactInProcApi.hs
@@ -133,7 +133,7 @@ pactMemPoolGetBlock
             -> BlockHeader
             -> IO (Vector ChainwebTransaction))
 pactMemPoolGetBlock mpc theLogger bf validate height hash _bHeader = do
-    logFn theLogger Info $! "pactMemPoolAccess - getting new block of transactions for "
+    logFn theLogger Debug $! "pactMemPoolAccess - getting new block of transactions for "
         <> "height = " <> sshow height <> ", hash = " <> sshow hash
     mempoolGetBlock (mpcMempool mpc) bf validate height hash
   where

--- a/src/Chainweb/Utils.hs
+++ b/src/Chainweb/Utils.hs
@@ -1242,6 +1242,13 @@ thd (_,_,c) = c
 data T2 a b = T2 !a !b
     deriving (Show, Eq, Ord, Generic, NFData, Functor)
 
+instance (Semigroup a, Semigroup b) => Semigroup (T2 a b) where
+    T2 a b <> T2 a' b' = T2 (a <> a') (b <> b')
+
+instance (Monoid a, Monoid b) => Monoid (T2 a b) where
+    mappend = (<>)
+    mempty = T2 mempty mempty
+
 instance Bifunctor T2 where
     bimap f g (T2 a b) =  T2 (f a) (g b)
     {-# INLINE bimap #-}


### PR DESCRIPTION
Previously the number of replayed blocks was logged as (), which is not a number at all. Now, we log the number of blocks played, and even then, we avoid logging it if it doesn't exceed a reasonable fork size.

Also some logs are moved to debug level.

https://gerrit.aseipp.dev/q/I594d9500a5c1745f09a5375fc6a0a7e6f44c8807