### PR TITLE
Do not persist intra-block writes

### DIFF
--- a/bench/Chainweb/Pact/Backend/Bench.hs
+++ b/bench/Chainweb/Pact/Backend/Bench.hs
@@ -53,6 +53,7 @@ import Chainweb.MerkleLogHash
 import Chainweb.Pact.Backend.RelationalCheckpointer
 import Chainweb.Pact.Backend.Types
 import Chainweb.Pact.Backend.Utils
+import Chainweb.Pact.Service.Types
 import Chainweb.Pact.Types
 import Chainweb.Test.TestVersions
 import Chainweb.Utils.Bench
@@ -146,7 +147,7 @@ cpWithBench torun =
         let neverLogger = genericLogger Error (\_ -> return ())
         !sqliteEnv <- openSQLiteConnection dbFile chainwebPragmas
         !cenv <-
-          initRelationalCheckpointer defaultModuleCacheLimit sqliteEnv neverLogger testVer testChainId
+          initRelationalCheckpointer defaultModuleCacheLimit sqliteEnv DoNotPersistIntraBlockWrites neverLogger testVer testChainId
         return $ NoopNFData (sqliteEnv, cenv)
 
     teardown (NoopNFData (sqliteEnv, _cenv)) = closeSQLiteConnection sqliteEnv

--- a/src/Chainweb/Chainweb.hs
+++ b/src/Chainweb/Chainweb.hs
@@ -159,7 +159,7 @@ import Chainweb.Mempool.P2pConfig
 import Chainweb.Miner.Config
 import qualified Chainweb.OpenAPIValidation as OpenAPIValidation
 import Chainweb.Pact.RestAPI.Server (PactServerData(..))
-import Chainweb.Pact.Service.Types (PactServiceConfig(..))
+import Chainweb.Pact.Service.Types (PactServiceConfig(..), IntraBlockPersistence(..))
 import Chainweb.Pact.Validations
 import Chainweb.Payload.PayloadStore
 import Chainweb.Payload.PayloadStore.RocksDB
@@ -427,8 +427,12 @@ withChainwebInternal conf logger peer serviceSock rocksDb pactDbDir backupDir re
       , _pactBlockGasLimit = maybe id min maxGasLimit (_configBlockGasLimit conf)
       , _pactLogGas = _configLogGas conf
       , _pactModuleCacheLimit = _configModuleCacheLimit conf
-      , _pactFullHistoryRequired = _configRosetta conf -- this could be OR'd with other things that require full history
       , _pactEnableLocalTimeout = _configEnableLocalTimeout conf
+      , _pactFullHistoryRequired = _configFullHistoricPactState conf
+      , _pactPersistIntraBlockWrites =
+          if _configFullHistoricPactState conf
+          then PersistIntraBlockWrites
+          else DoNotPersistIntraBlockWrites
       }
 
     pruningLogger :: T.Text -> logger

--- a/src/Chainweb/Chainweb/Configuration.hs
+++ b/src/Chainweb/Chainweb/Configuration.hs
@@ -66,6 +66,7 @@ module Chainweb.Chainweb.Configuration
 , configThrottling
 , configReorgLimit
 , configRosetta
+, configFullHistoricPactState
 , configBackup
 , configServiceApi
 , configOnlySyncPact
@@ -394,6 +395,7 @@ data ChainwebConfiguration = ChainwebConfiguration
     , _configReorgLimit :: !RewindLimit
     , _configPreInsertCheckTimeout :: !Micros
     , _configAllowReadsInLocal :: !Bool
+    , _configFullHistoricPactState :: !Bool
     , _configRosetta :: !Bool
     , _configBackup :: !BackupConfig
     , _configServiceApi :: !ServiceApiConfig
@@ -421,6 +423,11 @@ validateChainwebConfiguration c = do
     validateBackupConfig (_configBackup c)
     unless (c ^. chainwebVersion . versionDefaults . disablePeerValidation) $
         validateP2pConfiguration (_configP2p c)
+    when (_configRosetta c && not (_configFullHistoricPactState c)) $
+        throwError $ T.unwords
+            [ "To enable rosetta, full historic pact state must also be enabled or"
+            , "the Rosetta index will be incomplete."
+            ]
     validateChainwebVersion (_configChainwebVersion c)
 
 validateChainwebVersion :: ConfigValidation ChainwebVersion []
@@ -459,6 +466,7 @@ defaultChainwebConfiguration v = ChainwebConfiguration
     , _configPreInsertCheckTimeout = defaultPreInsertCheckTimeout
     , _configAllowReadsInLocal = False
     , _configRosetta = False
+    , _configFullHistoricPactState = True
     , _configServiceApi = defaultServiceApiConfig
     , _configOnlySyncPact = False
     , _configReadOnlyReplay = False
@@ -486,6 +494,7 @@ instance ToJSON ChainwebConfiguration where
         , "preInsertCheckTimeout" .= _configPreInsertCheckTimeout o
         , "allowReadsInLocal" .= _configAllowReadsInLocal o
         , "rosetta" .= _configRosetta o
+        , "fullHistoricPactState" .= _configFullHistoricPactState o
         , "serviceApi" .= _configServiceApi o
         , "onlySyncPact" .= _configOnlySyncPact o
         , "readOnlyReplay" .= _configReadOnlyReplay o
@@ -517,6 +526,7 @@ instance FromJSON (ChainwebConfiguration -> ChainwebConfiguration) where
         <*< configAllowReadsInLocal ..: "allowReadsInLocal" % o
         <*< configPreInsertCheckTimeout ..: "preInsertCheckTimeout" % o
         <*< configRosetta ..: "rosetta" % o
+        <*< configFullHistoricPactState ..: "fullHistoricPactState" % o
         <*< configServiceApi %.: "serviceApi" % o
         <*< configOnlySyncPact ..: "onlySyncPact" % o
         <*< configReadOnlyReplay ..: "readOnlyReplay" % o
@@ -563,6 +573,9 @@ pChainwebConfiguration = id
     <*< configRosetta .:: boolOption_
         % long "rosetta"
         <> help "Enable the Rosetta endpoints."
+    <*< configFullHistoricPactState .:: boolOption_
+        % long "full-historic-pact-state"
+        <> help "Write full historic Pact state; only enable for custodial or archival nodes."
     <*< configCuts %:: pCutConfig
     <*< configServiceApi %:: pServiceApiConfig
     <*< configMining %:: pMiningConfig

--- a/src/Chainweb/Pact/Backend/PactState/GrandHash/Import.hs
+++ b/src/Chainweb/Pact/Backend/PactState/GrandHash/Import.hs
@@ -63,6 +63,7 @@ import Chainweb.Pact.Backend.PactState.EmbeddedSnapshot.Mainnet qualified as Mai
 import Chainweb.Pact.Backend.PactState.GrandHash.Utils (resolveLatestCutHeaders, resolveCutHeadersAtHeight, computeGrandHashesAt, exitLog, withConnections, chainwebDbFilePath, rocksParser, cwvParser)
 import Chainweb.Pact.Backend.RelationalCheckpointer (withProdRelationalCheckpointer)
 import Chainweb.Pact.Backend.Types (SQLiteEnv, _cpRewindTo)
+import Chainweb.Pact.Service.Types (IntraBlockPersistence(..))
 import Chainweb.Pact.Types (defaultModuleCacheLimit)
 import Chainweb.Storage.Table.RocksDB (RocksDb, withReadOnlyRocksDb, modernDefaultOptions)
 import Chainweb.Utils (sshow)
@@ -186,7 +187,7 @@ pactDropPostVerified logger v srcDir tgtDir snapshotBlockHeight snapshotChainHas
       let logger' = addChainIdLabel cid logger
       logFunctionText logger' Info
         $ "Dropping anything post verified state (BlockHeight " <> sshow snapshotBlockHeight <> ")"
-      withProdRelationalCheckpointer logger defaultModuleCacheLimit sqliteEnv v cid $ \cp -> do
+      withProdRelationalCheckpointer logger defaultModuleCacheLimit sqliteEnv DoNotPersistIntraBlockWrites v cid $ \cp -> do
         _cpRewindTo cp (Just $ ParentHeader $ blockHeader $ snapshotChainHashes ^?! ix cid)
 
 data PactImportConfig = PactImportConfig

--- a/src/Chainweb/Pact/Backend/Types.hs
+++ b/src/Chainweb/Pact/Backend/Types.hs
@@ -45,7 +45,6 @@ module Chainweb.Pact.Backend.Types
     , pdbsDbEnv
 
     , SQLiteRowDelta(..)
-    , SQLiteDeltaKey(..)
     , SQLitePendingTableCreations
     , SQLitePendingWrites
     , SQLitePendingData(..)
@@ -68,15 +67,16 @@ module Chainweb.Pact.Backend.Types
     , runBlockEnv
     , SQLiteEnv
     , BlockHandler(..)
+    , BlockHandlerEnv(..)
+    , mkBlockHandlerEnv
     , blockHandlerBlockHeight
     , blockHandlerModuleNameFix
     , blockHandlerSortedKeys
     , blockHandlerLowerCaseTables
     , blockHandlerDb
     , blockHandlerLogger
+    , blockHandlerPersistIntraBlockWrites
     , ParentHash
-    , BlockHandlerEnv(..)
-    , mkBlockHandlerEnv
     , SQLiteFlag(..)
 
       -- * mempool
@@ -97,9 +97,9 @@ import Data.Bits
 import Data.ByteString (ByteString)
 import Data.DList (DList)
 import Data.Functor
-import Data.Hashable (Hashable)
 import Data.HashMap.Strict (HashMap)
 import Data.HashSet (HashSet)
+import Data.List.NonEmpty(NonEmpty(..))
 import Data.Map.Strict (Map)
 import Data.Vector (Vector)
 
@@ -180,14 +180,6 @@ instance Ord SQLiteRowDelta where
         bb = (_deltaTableName b, _deltaRowKey b, _deltaTxId b)
     {-# INLINE compare #-}
 
--- | When we index 'SQLiteRowDelta' values, we need a lookup key.
-data SQLiteDeltaKey = SQLiteDeltaKey
-    { _dkTable :: !ByteString
-    , _dkRowKey :: !ByteString
-    }
-  deriving (Show, Generic, Eq, Ord)
-  deriving anyclass Hashable
-
 -- | A map from table name to a list of 'TxLog' entries. This is maintained in
 -- 'BlockState' and is cleared upon pact transaction commit.
 type TxLogMap = Map TableName (DList TxLogJson)
@@ -201,7 +193,8 @@ type SQLitePendingTableCreations = HashSet ByteString
 type SQLitePendingSuccessfulTxs = HashSet ByteString
 
 -- | Pending writes to the pact db during a block, to be recorded in 'BlockState'.
-type SQLitePendingWrites = HashMap SQLiteDeltaKey (DList SQLiteRowDelta)
+-- Structured as a map from table name to a map from rowkey to inserted row delta.
+type SQLitePendingWrites = HashMap ByteString (HashMap ByteString (NonEmpty SQLiteRowDelta))
 
 -- | A collection of pending mutations to the pact db. We maintain two of
 -- these; one for the block as a whole, and one for any pending pact
@@ -258,18 +251,20 @@ data BlockHandlerEnv logger = BlockHandlerEnv
     , _blockHandlerModuleNameFix :: !Bool
     , _blockHandlerSortedKeys :: !Bool
     , _blockHandlerLowerCaseTables :: !Bool
+    , _blockHandlerPersistIntraBlockWrites :: !IntraBlockPersistence
     }
 
 mkBlockHandlerEnv
   :: ChainwebVersion -> ChainId -> BlockHeight
-  -> SQLiteEnv -> logger -> BlockHandlerEnv logger
-mkBlockHandlerEnv v cid bh sql logger = BlockHandlerEnv
+  -> SQLiteEnv -> IntraBlockPersistence -> logger -> BlockHandlerEnv logger
+mkBlockHandlerEnv v cid bh sql p logger = BlockHandlerEnv
     { _blockHandlerDb = sql
     , _blockHandlerLogger = logger
     , _blockHandlerBlockHeight = bh
     , _blockHandlerModuleNameFix = enableModuleNameFix v cid bh
     , _blockHandlerSortedKeys = pact42 v cid bh
     , _blockHandlerLowerCaseTables = chainweb217Pact v cid bh
+    , _blockHandlerPersistIntraBlockWrites = p
     }
 
 

--- a/src/Chainweb/Pact/PactService.hs
+++ b/src/Chainweb/Pact/PactService.hs
@@ -148,7 +148,7 @@ withPactService
     -> PactServiceM logger tbl a
     -> IO (T2 a PactServiceState)
 withPactService ver cid chainwebLogger bhDb pdb sqlenv config act =
-    withProdRelationalCheckpointer checkpointerLogger (_pactModuleCacheLimit config) sqlenv ver cid $ \checkpointer -> do
+    withProdRelationalCheckpointer checkpointerLogger (_pactModuleCacheLimit config) sqlenv (_pactPersistIntraBlockWrites config) ver cid $ \checkpointer -> do
         let !rs = readRewards
         let !pse = PactServiceEnv
                     { _psMempoolAccess = Nothing

--- a/src/Chainweb/Pact/Service/Types.hs
+++ b/src/Chainweb/Pact/Service/Types.hs
@@ -37,6 +37,7 @@ module Chainweb.Pact.Service.Types
   , RequestStatus(..)
   , RequestCancelled(..)
   , PactServiceConfig(..)
+  , IntraBlockPersistence(..)
 
   , LocalPreflightSimulation(..)
   , LocalSignatureVerification(..)
@@ -117,6 +118,12 @@ newtype ConfirmationDepth = ConfirmationDepth { _confirmationDepth :: Word64 }
   deriving (Eq, Ord)
   deriving newtype (Show, FromJSON, ToJSON, Enum, Bounded)
 
+-- | Whether we write rows to the database that were already overwritten
+-- in the same block. This is temporarily necessary to do while Rosetta uses
+-- those rows to determine the contents of historic transactions.
+data IntraBlockPersistence = PersistIntraBlockWrites | DoNotPersistIntraBlockWrites
+  deriving (Eq, Ord, Show)
+
 -- | Externally-injected PactService properties.
 --
 data PactServiceConfig = PactServiceConfig
@@ -144,6 +151,9 @@ data PactServiceConfig = PactServiceConfig
     --   available. Compaction can remove history.
   , _pactEnableLocalTimeout :: !Bool
     -- ^ Whether to enable the local timeout to prevent long-running transactions
+  , _pactPersistIntraBlockWrites :: !IntraBlockPersistence
+    -- ^ Whether or not the node requires that all writes made in a block
+    --   are persisted. Useful if you want to use PactService BlockTxHistory.
   } deriving (Eq,Show)
 
 data GasPurchaseFailure = GasPurchaseFailure TransactionHash PactError

--- a/src/Chainweb/Pact/Types.hs
+++ b/src/Chainweb/Pact/Types.hs
@@ -478,6 +478,7 @@ testPactServiceConfig = PactServiceConfig
       , _pactModuleCacheLimit = defaultModuleCacheLimit
       , _pactFullHistoryRequired = False
       , _pactEnableLocalTimeout = False
+      , _pactPersistIntraBlockWrites = DoNotPersistIntraBlockWrites
       }
 
 -- | This default value is only relevant for testing. In a chainweb-node the @GasLimit@

--- a/test/Chainweb/Test/MultiNode.hs
+++ b/test/Chainweb/Test/MultiNode.hs
@@ -541,7 +541,7 @@ compactAndResumeTest logLevel v n rdb pactDbDir step = do
           void $ compactUntilAvailable (C.Target bh) cLogger' sqlEnv flags
 
     logFun "phase 3... restarting nodes and ensuring progress"
-    runNodesForSeconds logLevel logFun (multiConfig v n) n 60 rdb pactDbDir ct
+    runNodesForSeconds logLevel logFun (multiConfig v n) { _configFullHistoricPactState = False } n 60 rdb pactDbDir ct
     Just stats2 <- consensusStateSummary <$> swapMVar stateVar (emptyConsensusState v)
     -- We ensure that we've gotten to at least 1.5x the previous block count
     assertGe "average block count post-compaction" (Actual $ _statBlockCount stats2) (Expected (3 * _statBlockCount stats1 `div` 2))

--- a/test/Chainweb/Test/Pact/Checkpointer.hs
+++ b/test/Chainweb/Test/Pact/Checkpointer.hs
@@ -55,6 +55,7 @@ import Chainweb.Pact.Backend.ChainwebPactDb
 import Chainweb.Pact.Backend.RelationalCheckpointer
 import Chainweb.Pact.Backend.Types
 import Chainweb.Pact.Backend.Utils
+import Chainweb.Pact.Service.Types
 import Chainweb.Pact.TransactionExec
     (applyContinuation', applyExec', buildExecParsedCode)
 import Chainweb.Pact.Types
@@ -650,7 +651,7 @@ runSQLite'
     -> TestTree
 runSQLite' runTest sqlEnvIO = runTest $ do
     sqlenv <- sqlEnvIO
-    cp <- initRelationalCheckpointer defaultModuleCacheLimit sqlenv logger testVer testChainId
+    cp <- initRelationalCheckpointer defaultModuleCacheLimit sqlenv DoNotPersistIntraBlockWrites logger testVer testChainId
     return (cp, sqlenv)
   where
     logger = addLabel ("sub-component", "relational-checkpointer") $ dummyLogger
@@ -721,7 +722,7 @@ simpleBlockEnvInit logger f = withTempSQLiteConnection chainwebPragmas $ \sqlenv
     f chainwebPactDb (blockEnv sqlenv) (\_ -> initSchema logger sqlenv)
   where
     blockEnv sqlenv = BlockEnv
-      (mkBlockHandlerEnv testVer testChainId (BlockHeight 0) sqlenv logger)
+      (mkBlockHandlerEnv testVer testChainId (BlockHeight 0) sqlenv DoNotPersistIntraBlockWrites logger)
       (initBlockState defaultModuleCacheLimit (TxId 0))
 
 {- this should be moved to pact -}

--- a/test/Chainweb/Test/Pact/PactSingleChainTest.hs
+++ b/test/Chainweb/Test/Pact/PactSingleChainTest.hs
@@ -106,7 +106,10 @@ tests rdb = testGroup testName
   , test $ goldenNewBlock "empty-block-tests" mempty
   , test newBlockAndValidate
   , test newBlockAndValidationFailure
-  , test getHistory
+  -- this test needs to see all of the writes done in the block;
+  -- it uses the BlockTxHistory Pact request to see them.
+  , testWithConf getHistory
+    testPactServiceConfig { _pactPersistIntraBlockWrites = PersistIntraBlockWrites }
   , test testHistLookup1
   , test testHistLookup2
   , test testHistLookup3
@@ -127,6 +130,7 @@ tests rdb = testGroup testName
   where
     testName = "Chainweb.Test.Pact.PactSingleChainTest"
     test = test' rdb
+    testWithConf = testWithConf' rdb
     testTimeout = testTimeout' rdb
 
     testHistLookup1 = getHistoricalLookupNoTxs "sender00"

--- a/test/Chainweb/Test/Pact/Utils.hs
+++ b/test/Chainweb/Test/Pact/Utils.hs
@@ -672,7 +672,7 @@ testPactCtxSQLite
   -> (TxContext -> GasModel)
   -> IO (TestPactCtx logger tbl)
 testPactCtxSQLite logger v cid bhdb pdb sqlenv conf gasmodel = do
-    cp <- initRelationalCheckpointer defaultModuleCacheLimit sqlenv cpLogger v cid
+    cp <- initRelationalCheckpointer defaultModuleCacheLimit sqlenv DoNotPersistIntraBlockWrites cpLogger v cid
     let rs = readRewards
     !ctx <- TestPactCtx
       <$!> newMVar (PactServiceState mempty)

--- a/test/SlowTests.hs
+++ b/test/SlowTests.hs
@@ -32,7 +32,11 @@ loglevel = Warn
 -- note that because these tests run in parallel they must all use distinct rocksdb and sqlite dirs.
 suite :: TestTree
 suite = sequentialTestGroup "ChainwebSlowTests" AllFinish
-    [ testCaseSteps "compact-live-node" $ \step ->
+    [ testCaseSteps "compact-resume" $ \step ->
+        withTempRocksDb "compact-resume-test-rocks" $ \rdb ->
+        withSystemTempDirectory "compact-resume-test-pact" $ \pactDbDir -> do
+        Chainweb.Test.MultiNode.compactAndResumeTest loglevel (fastForkingCpmTestVersion pairChainGraph) 6 rdb pactDbDir step
+    , testCaseSteps "compact-live-node" $ \step ->
         withTempRocksDb "pact-import-test-rocks" $ \rdb ->
         withSystemTempDirectory "pact-import-test-pact" $ \pactDbDir -> do
         Chainweb.Test.MultiNode.compactLiveNodeTest loglevel (fastForkingCpmTestVersion twentyChainGraph) 1 rdb pactDbDir step
@@ -48,10 +52,6 @@ suite = sequentialTestGroup "ChainwebSlowTests" AllFinish
         withTempRocksDb "replay-test-fasttimedcpm-pair-rocks" $ \rdb ->
         withSystemTempDirectory "replay-test-fasttimedcpm-pair-pact" $ \pactDbDir ->
         Chainweb.Test.MultiNode.replayTest loglevel (fastForkingCpmTestVersion pairChainGraph) 6 rdb pactDbDir step
-    , testCaseSteps "compact-resume" $ \step ->
-        withTempRocksDb "compact-resume-test-rocks" $ \rdb ->
-        withSystemTempDirectory "compact-resume-test-pact" $ \pactDbDir -> do
-        Chainweb.Test.MultiNode.compactAndResumeTest loglevel (fastForkingCpmTestVersion pairChainGraph) 6 rdb pactDbDir step
     , testCaseSteps "pact-import" $ \step ->
         withTempRocksDb "pact-import-test-rocks" $ \rdb ->
         withSystemTempDirectory "pact-import-test-pact" $ \pactDbDir -> do

--- a/tools/cwtool/TxSimulator.hs
+++ b/tools/cwtool/TxSimulator.hs
@@ -106,7 +106,7 @@ simulate sc@(SimConfig dbDir txIdx' _ _ cid ver gasLog doTypecheck) = do
   pwos <- fetchOutputs sc cenv hdrs
   withSqliteDb cid cwLogger dbDir False $ \sqlenv -> do
     cp <-
-      initRelationalCheckpointer defaultModuleCacheLimit sqlenv logger ver cid
+      initRelationalCheckpointer defaultModuleCacheLimit sqlenv DoNotPersistIntraBlockWrites logger ver cid
     case (txIdx',doTypecheck) of
       (Just txIdx,_) -> do -- single-tx simulation
         let pwo = head pwos


### PR DESCRIPTION
This stops us writing rows to the database that are overwritten in the same block. I haven't benchmarked it, I don't know if it's faster yet, but it should at least save space.

https://gerrit.aseipp.dev/q/I88660fa4f0ee481e06808f66d98a86a3eb3722db