### PR TITLE
refactor: readFrom returns Nothing when parent is missing

### DIFF
--- a/src/Chainweb/Pact/Backend/ChainwebPactDb.hs
+++ b/src/Chainweb/Pact/Backend/ChainwebPactDb.hs
@@ -638,14 +638,25 @@ createVersionedTable tablename db = do
         "CREATE INDEX IF NOT EXISTS " <> tbl ixName <> " ON " <> tbl tablename <> "(txid DESC);"
 
 -- | Delete any state from the database newer than the input parent header.
+-- Returns the ending txid of the input parent header.
 rewindDbTo
     :: SQLiteEnv
     -> Maybe ParentHeader
-    -> IO ()
-rewindDbTo db Nothing = rewindDbToGenesis db
+    -> IO TxId
+rewindDbTo db Nothing = do
+  rewindDbToGenesis db
+  return 0
 rewindDbTo db mh@(Just (ParentHeader ph)) = do
-    !endingtxid <- getEndTxId "rewindDbToBlock" db mh
-    rewindDbToBlock db (_blockHeight ph) endingtxid
+    !maybeEndingTxId <- getEndTxId "rewindDbToBlock" db mh
+    endingTxId <- maybe
+      (throwM
+        $ BlockHeaderLookupFailure
+        $ "rewindDbTo.getEndTxId: not in db: "
+        <> sshow ph)
+      return
+      maybeEndingTxId
+    rewindDbToBlock db (_blockHeight ph) endingTxId
+    return endingTxId
 
 -- rewind before genesis, delete all user tables and all rows in all tables
 rewindDbToGenesis
@@ -862,12 +873,12 @@ initSchema logger sql =
         "CREATE INDEX IF NOT EXISTS \
          \ transactionIndexByBH ON TransactionIndex(blockheight)";
 
-getEndTxId :: Text -> SQLiteEnv -> Maybe ParentHeader -> IO TxId
+getEndTxId :: Text -> SQLiteEnv -> Maybe ParentHeader -> IO (Maybe TxId)
 getEndTxId msg sql pc = case pc of
-  Nothing -> return 0
+  Nothing -> return (Just 0)
   Just (ParentHeader ph) -> getEndTxId' msg sql (_blockHeight ph) (_blockHash ph)
 
-getEndTxId' :: Text -> SQLiteEnv -> BlockHeight -> BlockHash -> IO TxId
+getEndTxId' :: Text -> SQLiteEnv -> BlockHeight -> BlockHash -> IO (Maybe TxId)
 getEndTxId' msg sql bh bhsh = do
     r <- qry sql
       "SELECT endingtxid FROM BlockHistory WHERE blockheight = ? and hash = ?;"
@@ -876,9 +887,8 @@ getEndTxId' msg sql bh bhsh = do
       ]
       [RInt]
     case r of
-      [[SInt tid]] -> return (TxId (fromIntegral tid))
-      [] -> throwM $ BlockHeaderLookupFailure $ msg <> ".getEndTxId: not in db: " <>
-            sshow (bh, bhsh)
+      [[SInt tid]] -> return $ Just (TxId (fromIntegral tid))
+      [] -> return Nothing
       _ -> internalError $ msg <> ".getEndTxId: expected single-row int result, got " <> sshow r
 
 -- | Careful doing this! It's expensive and for our use case, probably pointless.

--- a/src/Chainweb/Pact/Backend/RelationalCheckpointer.hs
+++ b/src/Chainweb/Pact/Backend/RelationalCheckpointer.hs
@@ -27,6 +27,7 @@ import Control.Concurrent.MVar
 import Control.Monad
 import Control.Monad.Catch
 import Control.Monad.IO.Class
+import Control.Monad.Trans.Maybe
 
 import Data.ByteString (intercalate)
 import qualified Data.ByteString.Short as BS
@@ -143,7 +144,7 @@ doReadFrom
   -> MVar (DbCache PersistModuleData)
   -> Maybe ParentHeader
   -> (CurrentBlockDbEnv logger -> IO a)
-  -> IO a
+  -> IO (Maybe a)
 doReadFrom logger v cid sql moduleCacheVar parent doRead = do
   let currentHeight = maybe (genesisHeight v cid) (succ . _blockHeight . _parentHeader) parent
   -- we use the same module cache as the read-write checkpointer component
@@ -151,15 +152,15 @@ doReadFrom logger v cid sql moduleCacheVar parent doRead = do
   withMVar moduleCacheVar $ \sharedModuleCache -> do
     bracket
       (beginSavepoint sql BatchSavepoint)
-      (\_ -> abortSavepoint sql BatchSavepoint) $ \() -> do
-      txid <- getEndTxId "doReadFrom" sql parent
-      newDbEnv <- newMVar $ BlockEnv
+      (\_ -> abortSavepoint sql BatchSavepoint) $ \() -> runMaybeT $ do
+      startTxId <- MaybeT $ getEndTxId "doReadFrom" sql parent
+      newDbEnv <- liftIO $ newMVar $ BlockEnv
         (mkBlockHandlerEnv v cid currentHeight sql logger)
-        (initBlockState defaultModuleCacheLimit txid)
+        (initBlockState defaultModuleCacheLimit startTxId)
           { _bsModuleCache = sharedModuleCache }
       -- NB it's important to do this *after* you start the savepoint (and thus
       -- the db transaction) to make sure that the latestHeader check is up to date.
-      latestHeader <- doGetLatestBlock sql
+      latestHeader <- liftIO $ doGetLatestBlock sql
       let
         -- is the parent the latest header, i.e., can we get away without rewinding?
         parentIsLatestHeader = case (latestHeader, parent) of
@@ -171,7 +172,7 @@ doReadFrom logger v cid sql moduleCacheVar parent doRead = do
       let
         pactDb
           | parentIsLatestHeader = chainwebPactDb
-          | otherwise = rewoundPactDb currentHeight txid
+          | otherwise = rewoundPactDb currentHeight startTxId
         curBlockDbEnv = CurrentBlockDbEnv
           { _cpPactDbEnv = PactDbEnv pactDb newDbEnv
           , _cpRegisterProcessedTx =
@@ -179,7 +180,7 @@ doReadFrom logger v cid sql moduleCacheVar parent doRead = do
           , _cpLookupProcessedTx = \hs ->
             runBlockEnv newDbEnv (doLookupSuccessful currentHeight hs)
           }
-      doRead curBlockDbEnv
+      liftIO $ doRead curBlockDbEnv
 
 
 -- TODO: log more?
@@ -203,9 +204,8 @@ doRestoreAndSave logger v cid sql moduleCacheVar parent blocks =
           ExitCaseSuccess {} -> commitSavepoint sql BatchSavepoint
           _ -> abortSavepoint sql BatchSavepoint
         ) $ \_ -> do
-          rewindDbTo sql parent
-          txid <- getEndTxId "restoreAndSave" sql parent
-          ((q, _, _, finalModuleCache) :> r) <- extend txid moduleCache
+          startTxId <- rewindDbTo sql parent
+          ((q, _, _, finalModuleCache) :> r) <- extend startTxId moduleCache
           return (finalModuleCache, (r, q))
   where
 
@@ -351,18 +351,22 @@ doLookupSuccessful curHeight hashes = do
         return $! T3 txhash' (fromIntegral blockheight) blockhash'
     go _ = fail "impossible"
 
-doGetBlockHistory :: SQLiteEnv -> BlockHeader -> Domain RowKey RowData -> IO BlockTxHistory
-doGetBlockHistory db blockHeader d = do
-  endTxId <- fmap fromIntegral $
-    getEndTxId "doGetBlockHistory" db (Just $ ParentHeader blockHeader)
-  startTxId <- fmap fromIntegral $
-    if bHeight == genesisHeight v cid
-    then return 0
-    else getEndTxId' "doGetBlockHistory" db (pred bHeight) (_blockParent blockHeader)
+doGetBlockHistory :: SQLiteEnv -> BlockHeader -> Domain RowKey RowData -> IO (Maybe BlockTxHistory)
+doGetBlockHistory db blockHeader d = runMaybeT $ do
+  endTxId <- MaybeT
+      $ fmap fromIntegral
+      <$> getEndTxId "doGetBlockHistory" db (Just $ ParentHeader blockHeader)
+  startTxId <-
+      if bHeight == genesisHeight v cid
+      then return 0
+      else MaybeT
+        $ fmap fromIntegral
+        <$> getEndTxId' "doGetBlockHistory" db (pred bHeight) (_blockParent blockHeader)
+
   let tname = domainTableName d
-  history <- queryHistory tname startTxId endTxId
+  history <- liftIO $ queryHistory tname startTxId endTxId
   let (!hkeys,tmap) = foldl' procTxHist (S.empty,mempty) history
-  !prev <- M.fromList . catMaybes <$> mapM (queryPrev tname startTxId) (S.toList hkeys)
+  !prev <- liftIO $ M.fromList . catMaybes <$> mapM (queryPrev tname startTxId) (S.toList hkeys)
   return $ BlockTxHistory tmap prev
   where
     v = _chainwebVersion blockHeader
@@ -413,7 +417,13 @@ doGetHistoricalLookup
     -> IO (Maybe (TxLog RowData))
 doGetHistoricalLookup db blockHeader d k = do
   endTxId <-
-    fromIntegral <$> getEndTxId "doGetHistoricalLookup" db (Just $ ParentHeader blockHeader)
+    maybe
+      (throwM
+        $ BlockHeaderLookupFailure
+        $ "doGetHistoricalLookup.getEndTxId: not in db: "
+        <> sshow blockHeader)
+      (return . fromIntegral)
+    =<< getEndTxId "doGetHistoricalLookup" db (Just $ ParentHeader blockHeader)
   latestEntry <- queryHistoryLookup (domainTableName d) endTxId (convRowKey k)
   return $! latestEntry
   where

--- a/src/Chainweb/Pact/Backend/Types.hs
+++ b/src/Chainweb/Pact/Backend/Types.hs
@@ -315,11 +315,12 @@ type ParentHash = BlockHash
 data ReadCheckpointer logger = ReadCheckpointer
   { _cpReadFrom ::
     !(forall a. Maybe ParentHeader ->
-      (CurrentBlockDbEnv logger -> IO a) -> IO a)
+      (CurrentBlockDbEnv logger -> IO a) -> IO (Maybe a))
     -- ^ rewind to a particular block *in-memory*, producing a read-write snapshot
     -- ^ of the database at that block to compute some value, after which the snapshot
     -- is discarded and nothing is saved to the database.
-    -- ^ prerequisite: ParentHeader is an ancestor of the "latest block"
+    -- ^ prerequisite: ParentHeader is an ancestor of the "latest block".
+    -- if that isn't the case, Nothing is returned.
   , _cpGetEarliestBlock :: !(IO (Maybe (BlockHeight, BlockHash)))
     -- ^ get the checkpointer's idea of the earliest block. The block height
     --   is the height of the block of the block hash.
@@ -332,7 +333,7 @@ data ReadCheckpointer logger = ReadCheckpointer
     -- ^ is the checkpointer aware of the given block?
   , _cpGetBlockParent :: !((BlockHeight, BlockHash) -> IO (Maybe BlockHash))
   , _cpGetBlockHistory ::
-      !(BlockHeader -> Domain RowKey RowData -> IO BlockTxHistory)
+      !(BlockHeader -> Domain RowKey RowData -> IO (Maybe BlockTxHistory))
   , _cpGetHistoricalLookup ::
       !(BlockHeader -> Domain RowKey RowData -> RowKey -> IO (Maybe (TxLog RowData)))
   , _cpLogger :: logger

--- a/src/Chainweb/Pact/PactService/Checkpointer.hs
+++ b/src/Chainweb/Pact/PactService/Checkpointer.hs
@@ -88,6 +88,10 @@ exitOnRewindLimitExceeded = handle $ \case
         ]
 
 -- read-only rewind to the latest block.
+-- note: because there is a race between getting the latest header
+-- and doing the rewind, there's a chance that the latest header
+-- will be unavailable when we do the rewind. in that case
+-- we just keep grabbing the new "latest header" until we succeed.
 -- note: this function will never rewind before genesis.
 readFromLatest
   :: Logger logger
@@ -95,9 +99,15 @@ readFromLatest
   -> PactServiceM logger tbl a
 readFromLatest doRead = do
   latestBlockHeader <- findLatestValidBlockHeader
-  readFrom (Just latestBlockHeader) doRead
+  readFrom (Just latestBlockHeader) doRead >>= \case
+    Nothing -> readFromLatest doRead
+    Just r -> return r
 
 -- read-only rewind to the nth parent before the latest block.
+-- note: because there is a race between getting the nth header
+-- and doing the rewind, there's a chance that the nth header
+-- will be unavailable when we do the rewind. in that case
+-- we just keep grabbing the new "nth header" until we succeed.
 -- note: this function will never rewind before genesis.
 readFromNthParent
   :: Logger logger
@@ -120,12 +130,14 @@ readFromNthParent n doRead = do
                 <> ", depth " <> sshow n
             Just nthParentHeader ->
                 return $ ParentHeader nthParentHeader
-    readFrom (Just nthParent) doRead
+    readFrom (Just nthParent) doRead >>= \case
+      Nothing -> readFromNthParent n doRead
+      Just r -> return r
 
 -- read-only rewind to a target block.
 readFrom
     :: Logger logger
-    => Maybe ParentHeader -> PactBlockM logger tbl a -> PactServiceM logger tbl a
+    => Maybe ParentHeader -> PactBlockM logger tbl a -> PactServiceM logger tbl (Maybe a)
 readFrom ph doRead = do
     cp <- view psCheckpointer
     pactParent <- getPactParent ph

--- a/src/Chainweb/Pact/PactService/ExecBlock.hs
+++ b/src/Chainweb/Pact/PactService/ExecBlock.hs
@@ -379,10 +379,10 @@ applyPactCmds
     -> Maybe P.Gas
     -> Maybe Micros
     -> PactBlockM logger tbl (T2 (Vector (Either CommandInvalidError (P.CommandResult [P.TxLogJson]))) ModuleCache)
-applyPactCmds isGenesis cmds miner mc blockGas txTimeLimit = do
+applyPactCmds isGenesis cmds miner startModuleCache blockGas txTimeLimit = do
     let txsGas txs = fromIntegral $ sumOf (traversed . _Right . to P._crGas) txs
     (txOuts, T2 mcOut _) <- tracePactBlockM' "applyPactCmds" () (txsGas . fst) $
-      flip runStateT (T2 mc blockGas) $
+      flip runStateT (T2 startModuleCache blockGas) $
         go [] (V.toList cmds)
     return $! T2 (V.fromList . List.reverse $ txOuts) mcOut
   where

--- a/src/Chainweb/Pact/Service/BlockValidation.hs
+++ b/src/Chainweb/Pact/Service/BlockValidation.hs
@@ -114,7 +114,7 @@ pactBlockTxHistory
   :: BlockHeader
   -> Domain RowKey RowData
   -> PactQueue
-  -> IO BlockTxHistory
+  -> IO (Maybe BlockTxHistory)
 pactBlockTxHistory bh d reqQ = do
   let !req = BlockTxHistoryReq bh d
   let !msg = BlockTxHistoryMsg req

--- a/src/Chainweb/Pact/Service/Types.hs
+++ b/src/Chainweb/Pact/Service/Types.hs
@@ -358,7 +358,7 @@ data RequestMsg r where
     LocalMsg :: !LocalReq -> RequestMsg LocalResult
     LookupPactTxsMsg :: !LookupPactTxsReq -> RequestMsg (HashMap PactHash (T2 BlockHeight BlockHash))
     PreInsertCheckMsg :: !PreInsertCheckReq -> RequestMsg (Vector (Either InsertError ()))
-    BlockTxHistoryMsg :: !BlockTxHistoryReq -> RequestMsg BlockTxHistory
+    BlockTxHistoryMsg :: !BlockTxHistoryReq -> RequestMsg (Maybe BlockTxHistory)
     HistoricalLookupMsg :: !HistoricalLookupReq -> RequestMsg (Maybe (TxLog RowData))
     SyncToBlockMsg :: !SyncToBlockReq -> RequestMsg ()
     ReadOnlyReplayMsg :: !ReadOnlyReplayReq -> RequestMsg ()

--- a/src/Chainweb/WebPactExecutionService.hs
+++ b/src/Chainweb/WebPactExecutionService.hs
@@ -90,7 +90,7 @@ data PactExecutionService = PactExecutionService
     , _pactBlockTxHistory :: !(
         BlockHeader ->
         Domain RowKey RowData ->
-        IO BlockTxHistory
+        IO (Maybe BlockTxHistory)
         )
       -- ^ Obtain all transaction history in block for specified table/domain.
     , _pactHistoricalLookup :: !(

--- a/test/Chainweb/Test/Pact/Checkpointer.hs
+++ b/test/Chainweb/Test/Pact/Checkpointer.hs
@@ -61,7 +61,7 @@ import Chainweb.Pact.Types
 import Chainweb.Test.Pact.Utils
 import Chainweb.Test.Utils
 import Chainweb.Test.TestVersions
-import Chainweb.Utils (catchAllSynchronous)
+import Chainweb.Utils
 import Chainweb.Version
 
 import Chainweb.Test.Orphans.Internal ({- Arbitrary BlockHash -})
@@ -689,8 +689,12 @@ cpReadFrom
   -> Maybe BlockHeader
   -> (ChainwebPactDbEnv logger -> IO q)
   -> IO q
-cpReadFrom cp pc f = _cpReadFrom (_cpReadCp cp) (ParentHeader <$> pc) $
-  f . _cpPactDbEnv
+cpReadFrom cp pc f = do
+  r <- _cpReadFrom
+    (_cpReadCp cp)
+    (ParentHeader <$> pc)
+    (f . _cpPactDbEnv)
+  evaluate (fromJuste r)
 
 -- allowing a straightforward list of blocks to be passed to the API,
 -- and only exposing the PactDbEnv part of the block context

--- a/test/Chainweb/Test/Pact/PactExec.hs
+++ b/test/Chainweb/Test/Pact/PactExec.hs
@@ -59,7 +59,7 @@ import Chainweb.Test.TestVersions
 import Chainweb.Transaction
 import Chainweb.Version (ChainwebVersion(..))
 import Chainweb.Version.Utils (someChainId)
-import Chainweb.Utils (sshow, tryAllSynchronous)
+import Chainweb.Utils hiding (check)
 
 import Pact.Types.Command
 import Pact.Types.Hash
@@ -500,7 +500,7 @@ execTest
 execTest v runPact request = _trEval request $ do
     cmdStrs <- mapM getPactCode $ _trCmds request
     trans <- mkCmds cmdStrs
-    results <- runPact $
+    results <- runPact $ fmap fromJuste $
       readFrom (Just $ ParentHeader $ genesisBlockHeader v cid) $
         execTransactions False defaultMiner
           trans (EnforceCoinbaseFailure True) (CoinbaseUsePrecompiled True) Nothing Nothing
@@ -531,7 +531,7 @@ execTxsTest v runPact name (trans',check) = testCase name (go >>= check)
   where
     go = do
       trans <- trans'
-      results' <- tryAllSynchronous $ runPact $
+      results' <- tryAllSynchronous $ runPact $ fmap fromJuste $
         readFrom (Just $ ParentHeader $ genesisBlockHeader v cid) $
           execTransactions False defaultMiner trans
             (EnforceCoinbaseFailure True) (CoinbaseUsePrecompiled True) Nothing Nothing

--- a/test/Chainweb/Test/Pact/PactSingleChainTest.hs
+++ b/test/Chainweb/Test/Pact/PactSingleChainTest.hs
@@ -558,7 +558,7 @@ getHistory refIO reqIO = testCase "getHistory" $ do
   setOneShotMempool refIO goldenMemPool
   void $ runBlock q bdb second
   h <- getParentTestBlockDb bdb cid
-  BlockTxHistory hist prevBals <- pactBlockTxHistory h (UserTables "coin_coin-table") q
+  Just (BlockTxHistory hist prevBals) <- pactBlockTxHistory h (UserTables "coin_coin-table") q
   -- just check first one here
   assertEqual "check first entry of history"
     (Just [TxLog "coin_coin-table" "sender00"


### PR DESCRIPTION
 
This change makes readFrom return Nothing when the target parent is missing.  
Test plan: just our existing tests.  

https://gerrit.aseipp.dev/q/I67fd68ed09707c9bff00b0cf7906e026974a2343