### PR TITLE
ci: enable CI on gerrit branch push

### DIFF
--- a/.github/workflows/applications.yml
+++ b/.github/workflows/applications.yml
@@ -18,8 +18,10 @@ on:
       eventlog:
         description: link with -eventlog
         default: 'False'
-  pull_request:
   merge_group:
+  push:
+    branches-ignore:
+      - 'gh-readonly-queue/**'
 
 env:
   AWS_ACCESS_KEY_ID: ${{ secrets.kadena_cabal_cache_aws_access_key_id }}


### PR DESCRIPTION
This lets gerrit trigger github CI by pushing to its own github branches for each change.

Every push really should have CI. The only reason we didn't was to avoid
duplicating CI for the merge queue; looks like there's a better way to do that.

This uses the "not-pattern" in 
https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#filter-pattern-cheat-sheet

Test plan: check that opening a github PR with this change triggers
CI, but that CI is labelled as "push" CI, then check that after merge, 
the merge queue doesn't duplicate CI, and gerrit's branches trigger CI
without a PR.