### PR TITLE
fix: fix cut pruning code dimensional analysis bug

### DIFF
--- a/src/Chainweb/CutDB.hs
+++ b/src/Chainweb/CutDB.hs
@@ -378,8 +378,9 @@ pruneCuts
     -> Casify RocksDbTable CutHashes
     -> IO ()
 pruneCuts logfun v conf curAvgBlockHeight cutHashesStore = do
-    let pruneCutHeight = CutHeight $ int $ max 0
-            (int (avgCutHeightAt v curAvgBlockHeight) - int (_cutDbParamsAvgBlockHeightPruningDepth conf) :: Integer)
+    let avgBlockHeightPruningDepth = _cutDbParamsAvgBlockHeightPruningDepth conf
+    let pruneCutHeight =
+            avgCutHeightAt v (curAvgBlockHeight - max curAvgBlockHeight avgBlockHeightPruningDepth)
     logfun @T.Text Info $ "pruning CutDB before cut height " <> T.pack (show pruneCutHeight)
     deleteRangeRocksDb (unCasify cutHashesStore)
         (Nothing, Just (pruneCutHeight, 0, maxBound :: CutId))


### PR DESCRIPTION
Otherwise we prune cuts at the wrong height;
we meant to prune cuts more than 5000 blocks old,
but now it's off by a factor of the number of chains.

https://gerrit.aseipp.dev/c/chainweb-node/+/181

Change-Id: Ic76f6efe7fe49a38c0254b64d583bb9dace6050e

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207195145181778