### PR TITLE
nix: s/pkgconfig/pkg-config/

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -75,7 +75,7 @@ let haskellSrc = with nix-filter.lib; filter {
       };
       shell.buildInputs = with pkgs; [
         zlib
-        pkgconfig
+        pkg-config
       ];
       modules = [
         {


### PR DESCRIPTION
This alias is deprecated and removed in newer versions of nixpkgs, so just go ahead and get rid of it and use the proper spelling.

Change-Id: I793f11948bd47be080c5cf6e17c401f168bc68b4