### PR TITLE
[CI]: Add homebrew paths to cabal.project for the recent macos-14 runners

### DIFF
--- a/.github/workflows/applications.yml
+++ b/.github/workflows/applications.yml
@@ -230,7 +230,7 @@ jobs:
       if: startsWith(matrix.os, 'ubuntu-')
       run: sudo chown -R $USER /usr/local/.ghcup
     - name: Install GHC and Cabal
-      uses: haskell/actions/setup@v2
+      uses: haskell-actions/setup@v2
       with:
          ghc-version: ${{ matrix.ghc }}
          cabal-version: ${{ matrix.cabal }}

--- a/.github/workflows/macos.yaml
+++ b/.github/workflows/macos.yaml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         ghc: ["9.6.4"]
         cabal: ["3.10"]
-        os: ["macOS-latest"]
+        os: ["macos-14-large"]
         cabalcache: ["true"]
 
     steps:
@@ -29,7 +29,7 @@ jobs:
       if: startsWith(matrix.os, 'ubuntu-')
       run: sudo chown -R $USER /usr/local/.ghcup
     - name: Install GHC and Cabal
-      uses: haskell/actions/setup@v2
+      uses: haskell-actions/setup@v2
       with:
          ghc-version: ${{ matrix.ghc }}
          cabal-version: ${{ matrix.cabal }}
@@ -40,9 +40,7 @@ jobs:
     - name: Install non-Haskell dependencies (macOS)
       if: contains(matrix.os, 'mac')
       run: |
-        brew update && brew install gflags llvm gnu-tar snappy zstd lz4 || true
-        # work around bug in macOS and github actions cache (cf. https://github.com/actions/cache/issues/403)
-        echo PATH="/usr/local/opt/gnu-tar/libexec/gnubin:$PATH" >> $GITHUB_ENV
+        brew update && brew install gflags llvm snappy || true
     - name: Create cabal.project.local
       run: |
         cat > cabal.project.local <<EOF

--- a/cabal.project
+++ b/cabal.project
@@ -19,9 +19,13 @@ if os(darwin)
             extra-include-dirs:
                 /opt/local/include
                 /usr/local/opt/openssl/include
+                /opt/homebrew/include
+                /opt/homebrew/opt/openssl/include
             extra-lib-dirs:
                 /opt/local/lib
                 /usr/local/opt/openssl/lib/
+                /opt/homebrew/lib
+                /opt/homebrew/opt/openssl/lib
 
 -- -------------------------------------------------------------------------- --
 -- Package Specific Build Settings


### PR DESCRIPTION
- fix haskell-actions (haskell/actions was deprecated)
- switch to macos-14-large to use x86_64 because `macOS-latest` is using arm runner which is broken for now (musl test)
- remove gnu-tar work around (was fixed in runners a long time ago)
- add new homebrew openssl paths