### PR TITLE
nix: update to ghc 9.6.4

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -93,8 +93,8 @@ source-repository-package
 source-repository-package
     type: git
     location: https://github.com/kadena-io/rocksdb-haskell.git
-    tag: 1a82da5660a4cc2681eb90da6505b6897d1b12e9
-    --sha256: 020n6knl8psh5y9766amrsh706ka83fz3vfm77lrzngg5mcz45qs
+    tag: cede9de2932a4ead1bd82fd7709b19ab7b19b33d
+    --sha256: 1dngd44va6h66vwpdpwmnj0zcky87m4vzykjwv49p2km12lwq9mf
 
 source-repository-package
     type: git

--- a/default.nix
+++ b/default.nix
@@ -13,7 +13,7 @@ let flakeDefaultNix = (import (
     };
 in
 { pkgs ? pkgsDef
-, compiler ? "ghc963"
+, compiler ? "ghc964"
 , flakePath ? flakeDefaultNix.outPath
 , nix-filter ? inputs.nix-filter
 , pact ? null

--- a/default.nix
+++ b/default.nix
@@ -75,7 +75,7 @@ let haskellSrc = with nix-filter.lib; filter {
       };
       shell.buildInputs = with pkgs; [
         zlib
-        pkgconfig
+        pkg-config
       ];
       modules = [
         {

--- a/flake.lock
+++ b/flake.lock
@@ -125,7 +125,7 @@
           "hs-nix-infra",
           "empty"
         ],
-        "ghc980": [
+        "ghc98X": [
           "hs-nix-infra",
           "empty"
         ],
@@ -149,7 +149,19 @@
           "hs-nix-infra",
           "empty"
         ],
-        "hls-2.3": "hls-2.3",
+        "hls-2.3": [
+          "hs-nix-infra",
+          "empty"
+        ],
+        "hls-2.4": [
+          "hs-nix-infra",
+          "empty"
+        ],
+        "hls-2.5": [
+          "hs-nix-infra",
+          "empty"
+        ],
+        "hls-2.6": "hls-2.6",
         "hpc-coveralls": [
           "hs-nix-infra",
           "empty"
@@ -162,6 +174,7 @@
           "hs-nix-infra",
           "empty"
         ],
+        "nix-tools-static": "nix-tools-static",
         "nixpkgs": [
           "hs-nix-infra",
           "haskellNix",
@@ -191,6 +204,10 @@
           "hs-nix-infra",
           "empty"
         ],
+        "nixpkgs-2311": [
+          "hs-nix-infra",
+          "empty"
+        ],
         "nixpkgs-unstable": "nixpkgs-unstable",
         "old-ghc-nix": [
           "hs-nix-infra",
@@ -202,11 +219,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1697195891,
-        "narHash": "sha256-0L803S/wcHmVebEwFxObYCYOaB14ZtBAFCdg0aRgH70=",
+        "lastModified": 1707876653,
+        "narHash": "sha256-hsj9chw/cy9h8XuxQkxnfFR22Ek8xEm33aON2+TcUaI=",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "c6cb3ff56b001b211690da35f70827fab5bf3272",
+        "rev": "d1a608f84c9ed00ceca8571b253e79f67a1ae2d6",
         "type": "github"
       },
       "original": {
@@ -215,19 +232,19 @@
         "type": "github"
       }
     },
-    "hls-2.3": {
+    "hls-2.6": {
       "flake": false,
       "locked": {
-        "lastModified": 1695910642,
-        "narHash": "sha256-tR58doOs3DncFehHwCLczJgntyG/zlsSd7DgDgMPOkI=",
+        "lastModified": 1705325287,
+        "narHash": "sha256-+P87oLdlPyMw8Mgoul7HMWdEvWP/fNlo8jyNtwME8E8=",
         "owner": "haskell",
         "repo": "haskell-language-server",
-        "rev": "458ccdb55c9ea22cd5d13ec3051aaefb295321be",
+        "rev": "6e0b342fa0327e628610f2711f8c3e4eaaa08b1e",
         "type": "github"
       },
       "original": {
         "owner": "haskell",
-        "ref": "2.3.0.0",
+        "ref": "2.6.0.0",
         "repo": "haskell-language-server",
         "type": "github"
       }
@@ -244,11 +261,11 @@
         "nixpkgs-rec": "nixpkgs-rec"
       },
       "locked": {
-        "lastModified": 1699970998,
-        "narHash": "sha256-NgvBCRIB+lvcxJWMpU8Mulx8PG8s5jtqSR8K/natoTA=",
+        "lastModified": 1708100161,
+        "narHash": "sha256-rWwE59SfmqXcVQL7GXovYvjbDPMsb4e1GgiNH+7tlrM=",
         "owner": "kadena-io",
         "repo": "hs-nix-infra",
-        "rev": "a69071dafa3f0d12edf30ecc5a562aee1f7d138d",
+        "rev": "bcbf823a0851b41d64d4f9c87053abc3153c126e",
         "type": "github"
       },
       "original": {
@@ -272,19 +289,36 @@
         "type": "github"
       }
     },
+    "nix-tools-static": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1706266250,
+        "narHash": "sha256-9t+GRk3eO9muCtKdNAwBtNBZ5dH1xHcnS17WaQyftwA=",
+        "owner": "input-output-hk",
+        "repo": "haskell-nix-example",
+        "rev": "580cb6db546a7777dad3b9c0fa487a366c045c4e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "ref": "nix",
+        "repo": "haskell-nix-example",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1669833724,
-        "narHash": "sha256-/HEZNyGbnQecrgJnfE8d0WC5c1xuPSD2LUpB6YXlg4c=",
+        "lastModified": 1694822471,
+        "narHash": "sha256-6fSDCj++lZVMZlyqOe9SIOL8tYSBz1bI8acwovRwoX8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "4d2b37a84fad1091b9de401eb450aae66f1a741e",
+        "rev": "47585496bcb13fb72e4a90daeea2f434e2501998",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "4d2b37a84fad1091b9de401eb450aae66f1a741e",
+        "rev": "47585496bcb13fb72e4a90daeea2f434e2501998",
         "type": "github"
       }
     },
@@ -306,17 +340,17 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1695318763,
-        "narHash": "sha256-FHVPDRP2AfvsxAdc+AsgFJevMz5VBmnZglFUMlxBkcY=",
+        "lastModified": 1694822471,
+        "narHash": "sha256-6fSDCj++lZVMZlyqOe9SIOL8tYSBz1bI8acwovRwoX8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e12483116b3b51a185a33a272bf351e357ba9a99",
+        "rev": "47585496bcb13fb72e4a90daeea2f434e2501998",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixpkgs-unstable",
         "repo": "nixpkgs",
+        "rev": "47585496bcb13fb72e4a90daeea2f434e2501998",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -22,7 +22,7 @@
 
   nixConfig = {
     extra-substituters = "https://nixcache.chainweb.com https://cache.iog.io";
-    trusted-public-keys = "nixcache.chainweb.com:FVN503ABX9F8x8K0ptnc99XEz5SaA4Sks6kNcZn2pBY= iohk.cachix.org-1:DpRUyj7h7V830dp/i6Nti+NEO2/nhblbov/8MW7Rqoo= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=";
+    trusted-public-keys = "nixcache.chainweb.com:FVN503ABX9F8x8K0ptnc99XEz5SaA4Sks6kNcZn2pBY= hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=";
   };
 
   outputs = inputs@{ self, hs-nix-infra, flake-utils, nix-filter, ... }:


### PR DESCRIPTION
This requires some minor updates elsewhere because we have to update the flake lockfile. This will ensure the Nix builds match the current CI, which is 9.6.4 (and it will unbreak `devShell`, too.)