### PR TITLE
fix: add extra quirk to block 4594049, fixing catchup for some nodes

### DIFF
--- a/src/Chainweb/Version/Mainnet.hs
+++ b/src/Chainweb/Version/Mainnet.hs
@@ -216,6 +216,7 @@ mainnet = ChainwebVersion
     , _versionQuirks = VersionQuirks
         { _quirkGasFees = HM.fromList
             [ (fromJuste (decodeStrictOrThrow' "\"s9fUspNaCHoV4rNI-Tw-JYU1DxqZAOXS-80oEy7Zfbo\""), Gas 67618)
+            , (fromJuste (decodeStrictOrThrow' "\"_f1xkIQPGRcOBNBWkOvP0dGNOjmNtmXwOnXzfdwnmJQ\""), Gas 69092)
             ]
         }
     }


### PR DESCRIPTION
We have another quirk for an earlier block, but this one never made it in, 
because no nodes on mainnet had had issues at the time. However, one user 
has had issues with it recently, hence the change.