### PR TITLE
changelog: add new `rollup` tool to automatically generate changelogs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,8 @@
-# `chainweb-node` Changelog
-
+# 2.24 (2024-05-23)
 This version replaces all previous versions. Any prior version will stop working
 on **2024-05-29T00:00:00Z**. Node administrators must upgrade to this version
-before that date. The 2.24 feature upgrade will occur at block height XXXXXXX
-which is estimated to be mined at XXXXXXX.
+before that date. The 2.24 feature upgrade will occur at block height 4,819,246
+which is estimated to be mined at **2024-05-30T00:00:00Z**.
 
 This version will expire on **2024-08-21T00:00:00Z**.
 
@@ -56,7 +55,7 @@ Internal changes:
 - The coin contract directory structure was reorganized to match the directory
   structure of the namespace contract for ease of maintenance (#1892)
 
-## 2.23.2 (2023-03-13)
+## 2.23.2 (2024-03-19)
 This is a minor point release. Upgrading is recommended.
 
 To upgrade, pull the latest docker image or download the binary and restart the node.
@@ -68,7 +67,7 @@ Internal changes:
 - Fix a small internal bug in the new read-only checkpointer (#1857)
 - Fix a small bug in compaction tests, causing flakiness (#1855)
 
-## 2.23.1 (2023-03-08)
+## 2.23.1 (2024-03-08)
 This is a minor point release. Mining nodes should be upgraded as soon as
 possible; for other nodes, upgrading is recommended.
 
@@ -84,7 +83,7 @@ Internal changes:
 - Fix some invalid log messages. (#1850, #1852)
 - Various tests have been "deflaked", to hopefully make them more reliable. (#1848, #1849)
 
-## 2.23 (2023-03-03)
+## 2.23 (2024-03-03)
 This version replaces all previous versions. Any prior version will stop working
 on **2024-03-06T00:00:00Z**. Node administrators must upgrade to this version
 before that date. The 2.23 feature upgrade will occur at block height 4,577,530

--- a/changes/.gitignore
+++ b/changes/.gitignore
@@ -1,0 +1,2 @@
+# Empty; this exists so that when we clear out all the changelog entries, this
+# directory will still be tracked under version control

--- a/changes/2024-05-30T143223-0500.txt
+++ b/changes/2024-05-30T143223-0500.txt
@@ -1,0 +1,1 @@
+Automatically generate changelog; it now includes all new commits for each release.

--- a/make_change_file
+++ b/make_change_file
@@ -1,4 +1,0 @@
-#!/bin/sh
-
-mkdir -p "changes"
-${EDITOR:-vi} "changes/$(date --iso-8601=seconds | tr -d ':').txt"

--- a/tools/changelog/README.md
+++ b/tools/changelog/README.md
@@ -1,0 +1,9 @@
+# CHANGELOG tools
+
+Tools for managing the `CHANGELOG.md` file for `chainweb-node`.
+
+## `create-entry`
+
+Run `create-entry` in order to launch your `$EDITOR` and write a single file
+into the top-level `changes/` dir. These files will be used to create changelog
+entries.

--- a/tools/changelog/README.md
+++ b/tools/changelog/README.md
@@ -7,3 +7,8 @@ Tools for managing the `CHANGELOG.md` file for `chainweb-node`.
 Run `create-entry` in order to launch your `$EDITOR` and write a single file
 into the top-level `changes/` dir. These files will be used to create changelog
 entries.
+
+## `rollup`
+
+Automatically rolls up all entries in the `changes/` dir into a nice list,
+and updates `CHANGELOG.md` for you automatically.

--- a/tools/changelog/create-entry
+++ b/tools/changelog/create-entry
@@ -2,6 +2,6 @@
 
 set -eux
 
-ROOT=$(git rev-parse --show-top-level)
+ROOT=$(git rev-parse --show-toplevel)
 mkdir -p "${ROOT}/changes"
 ${EDITOR:-vi} "${ROOT}/changes/$(date --iso-8601=seconds | tr -d ':').txt"

--- a/tools/changelog/create-entry
+++ b/tools/changelog/create-entry
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+set -eux
+
+ROOT=$(git rev-parse --show-top-level)
+mkdir -p "${ROOT}/changes"
+${EDITOR:-vi} "${ROOT}/changes/$(date --iso-8601=seconds | tr -d ':').txt"

--- a/tools/changelog/rollup
+++ b/tools/changelog/rollup
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+
+# for information on all this bullshit:
+# https://stackoverflow.com/questions/192249/how-do-i-parse-command-line-arguments-in-bash
+
+set -o errexit -o pipefail -o nounset
+
+# ignore errexit with `&& true`
+getopt --test > /dev/null && true
+if [[ $? -ne 4 ]]; then
+    echo 'I’m sorry, `getopt --test` failed in this environment.'
+    exit 1
+fi
+
+# option --output/-o requires 1 argument
+LONGOPTS=debug,major:,minor:
+OPTIONS=dM:m:
+
+# -temporarily store output to be able to check for errors
+# -activate quoting/enhanced mode (e.g. by writing out “--options”)
+# -pass arguments only via   -- "$@"   to separate them correctly
+# -if getopt fails, it complains itself to stdout
+PARSED=$(getopt --options=$OPTIONS --longoptions=$LONGOPTS --name "$0" -- "$@") || exit 2
+# read getopt’s output this way to handle the quoting right:
+eval set -- "$PARSED"
+
+major=-
+minor=-
+# now enjoy the options in order and nicely split until we see --
+while true; do
+    case "$1" in
+        -d|--debug)
+            set -x
+            shift
+            ;;
+        -M|--major)
+            major="$2"
+            shift 2
+            ;;
+        -m|--minor)
+            minor="$2"
+            shift 2
+            ;;
+        --)
+            shift
+            break
+            ;;
+        *)
+            echo "Internal error"
+            exit 3
+            ;;
+    esac
+done
+
+# handle non-option arguments
+if [[ $# -ne 0 ]]; then
+    echo "$0: Extra arguments are not supported"
+    exit 6
+fi
+
+if [ "$major" = "-" ] && [ "$minor" = "-" ]; then
+    echo "$0: You must supply either --major=X.Y or --minor=X.Y.Z"
+    exit 4
+fi
+
+if [ "$major" != "-" ] && [ "$minor" != "-" ]; then
+    echo "$0: --major and --minor are mutually exclusive"
+    exit 5
+fi
+
+
+if [ "$major" != "-" ]; then
+newver="$major"
+TEMPLATE=$(cat <<-EOM
+# $major (FIXME)
+This is a major version update. This release replaces all previous versions.
+
+Any prior version will stop working on FIXME. Node administrators must
+upgrade to this version before that date. The $major feature upgrade will
+occur at block height FIXME which is estimated to be mined at FIXME.
+
+EOM
+)
+else
+newver="$minor"
+TEMPLATE=$(cat <<-EOM
+# $minor (FIXME)
+This is a minor point release. Upgrading is **strongly recommended**.
+
+To upgrade, pull the latest docker image, or download the binary and
+restart the node with the same configuration file as before.
+EOM
+)
+fi
+
+ROOT=$(git rev-parse --show-toplevel)
+
+# before going any further, ensure the version is in chainweb.cabal
+if ! grep -qP "version:\s+$newver" "$ROOT/chainweb.cabal"; then
+    echo "$0: error: the version '$newver' is not in chainweb.cabal"
+    echo "Please update the version in chainweb.cabal before running this script."
+    exit 7
+fi
+
+# first, get all the high-level changelog entries
+CHANGES="## Changes\n\n"
+for file in $(find "$ROOT/changes" -type f -iname '*.txt' | sort); do
+    CHANGES+=$(printf -- "- %s\\\\n" "$(cat "$file")")
+done
+
+# now, list every commit since the last tag, too
+COMMITS="## Commits\n\n"
+
+while IFS= read -r line; do
+    cid="${line%% *}"
+    msg="${line#* }"
+    COMMITS+=$(printf -- "- [\`%s\`](https://github.com/kadena-io/chainweb-node/commit/%s) %s\\\\n" "$cid" "$cid" "$msg")
+done < <(git log $(git describe --tags --abbrev=0)..HEAD --oneline)
+
+contents=$(printf -- "$TEMPLATE\n\n$CHANGES\n$COMMITS\n" | cat - "$ROOT/CHANGELOG.md")
+
+# delete the old changelog and write the new one, and delete the changes.txt files
+rm -f "$ROOT/changes/"*.txt
+echo -e "$contents" > "$ROOT/CHANGELOG.md"
+echo "Wrote new changelog to $ROOT/CHANGELOG.md; please review the changes before committing."


### PR DESCRIPTION
This should be much easier and much more fullproof. As a bonus, we can stop doing the "Internal changes" section because the new `Commits` section will include everything anyway, leaving only user-visible entries in the `Changes` section.