### PR TITLE
log: P2P task failures are logged at Debug, not Info

### DIFF
--- a/changes/2024-05-30T144824-0400.txt
+++ b/changes/2024-05-30T144824-0400.txt
@@ -1,0 +1,2 @@
+Single P2P task failures are logged at Debug instead of Info level, while they're still being retried
+

--- a/src/P2P/TaskQueue.hs
+++ b/src/P2P/TaskQueue.hs
@@ -199,7 +199,7 @@ session_ limit q logFun env = E.mask $ \restore -> do
         let attempts = _taskAttemptsCount task'
         if
             | _taskAttemptsCount task' < limit -> do
-                logg task' Info $ "task failed: " <> sshow attempts
+                logg task' Debug $ "task failed: " <> sshow attempts
                 pQueueInsert q task'
                 return False
             | otherwise -> do


### PR DESCRIPTION
P2P task failures that are followed by retries aren't very interesting, but if they're past the retry limit that's more interesting.

Change-Id: I982be55277f5637be4c28df1320f9643d1a9a064