### PR TITLE
log: disable top-level monitors when telemetry is disabled

### DIFF
--- a/changes/2024-05-30T145629-0400.txt
+++ b/changes/2024-05-30T145629-0400.txt
@@ -1,0 +1,1 @@
+Disable telemetry monitor threads when telemetry is disabled anyway

--- a/node/ChainwebNode.hs
+++ b/node/ChainwebNode.hs
@@ -351,15 +351,22 @@ node conf logger = do
         logFunctionText logger Info $ "backup config: " <> sshow (_configBackup cwConf)
         withChainweb cwConf logger rocksDb pactDbDir dbBackupsDir (_nodeConfigResetChainDbs conf) $ \case
             Replayed _ _ -> return ()
-            StartedChainweb cw ->
+            StartedChainweb cw -> do
+                let telemetryEnabled =
+                        _enableConfigEnabled $ _logConfigTelemetryBackend $ _nodeConfigLog conf
                 concurrentlies_
                     [ runChainweb cw (\_ -> return ())
                     -- we should probably push 'onReady' deeper here but this should be ok
-                    , runCutMonitor (_chainwebLogger cw) (_cutResCutDb $ _chainwebCutResources cw)
-                    , runQueueMonitor (_chainwebLogger cw) (_cutResCutDb $ _chainwebCutResources cw)
-                    , runRtsMonitor (_chainwebLogger cw)
-                    , runBlockUpdateMonitor (_chainwebLogger cw) (_cutResCutDb $ _chainwebCutResources cw)
-                    , runDatabaseMonitor (_chainwebLogger cw) rocksDbDir pactDbDir
+                    , when telemetryEnabled $
+                        runCutMonitor (_chainwebLogger cw) (_cutResCutDb $ _chainwebCutResources cw)
+                    , when telemetryEnabled $
+                        runQueueMonitor (_chainwebLogger cw) (_cutResCutDb $ _chainwebCutResources cw)
+                    , when telemetryEnabled $
+                        runRtsMonitor (_chainwebLogger cw)
+                    , when telemetryEnabled $
+                        runBlockUpdateMonitor (_chainwebLogger cw) (_cutResCutDb $ _chainwebCutResources cw)
+                    , when telemetryEnabled $
+                        runDatabaseMonitor (_chainwebLogger cw) rocksDbDir pactDbDir
                     ]
   where
     cwConf = _nodeConfigChainweb conf


### PR DESCRIPTION
This has the nice side effect of also disabling the warning that RTS stats are disabled when telemetry is off, because RTS stats don't matter in that case.

Change-Id: I4111672ccc18760184d3325c0cd998c3c91fd6d2