### PR TITLE
log: disable telemetry backend by default

### DIFF
--- a/changes/2024-05-30T145746-0400.txt
+++ b/changes/2024-05-30T145746-0400.txt
@@ -1,0 +1,1 @@
+Disable telemetry backend by default for less verbosity

--- a/src/Chainweb/Logging/Config.hs
+++ b/src/Chainweb/Logging/Config.hs
@@ -91,7 +91,7 @@ defaultLogConfig :: LogConfig
 defaultLogConfig = LogConfig
     { _logConfigLogger = defaultLoggerConfig
     , _logConfigBackend = defaultBackendConfig
-    , _logConfigTelemetryBackend = defaultEnableConfig defaultBackendConfig
+    , _logConfigTelemetryBackend = defaultDisableConfig defaultBackendConfig
     , _logConfigClusterId = Nothing
     , _logConfigFilter = mempty
     }
@@ -183,4 +183,3 @@ pFilter_ prefix = id
                 then return $ LogFilter [] l (Probability r)
                 else Left "failed to read log rule rate. The value must be between zero and one"
         _ -> Left $ "expecting LOGLEVEL[:RATE], but got " <> s
-

--- a/src/Chainweb/Utils.hs
+++ b/src/Chainweb/Utils.hs
@@ -154,6 +154,7 @@ module Chainweb.Utils
 , enableConfigConfig
 , enableConfigEnabled
 , defaultEnableConfig
+, defaultDisableConfig
 , pEnableConfig
 , enabledConfig
 , validateEnableConfig
@@ -983,6 +984,14 @@ makeLenses ''EnableConfig
 defaultEnableConfig :: a -> EnableConfig a
 defaultEnableConfig a = EnableConfig
     { _enableConfigEnabled = True
+    , _enableConfigConfig = a
+    }
+
+-- | The default is that the configured component is disabled.
+--
+defaultDisableConfig :: a -> EnableConfig a
+defaultDisableConfig a = EnableConfig
+    { _enableConfigEnabled = False
     , _enableConfigConfig = a
     }
 


### PR DESCRIPTION
Just to be clear for any readers: "telemetry" is structured logging for node operators to use to monitor their nodes. It is not sent to Kadena. By default, it is sent to stdout, and it can be configured to be sent to an Elasticsearch instance of the user's choosing.

This commit disables even logging telemetry to the terminal by default, because usually it's very verbose and not useful.

Change-Id: I83ed57c79fa99151909c76d7de70f6edc88106f8