### PR TITLE
log: log rewinds in execValidateBlock instead of blocks played

### DIFF
--- a/changes/2024-05-30T144952-0400.txt
+++ b/changes/2024-05-30T144952-0400.txt
@@ -1,0 +1,1 @@
+Log rewound blocks during catchup instead of played blocks 


### PR DESCRIPTION
Change-Id: Id2d597d6e72b0bbd6825184b9dd122261502d035