### PR TITLE
log: telemetry log current cut periodically, instead of on changes

### DIFF
--- a/changes/2024-06-19T182508-0400.txt
+++ b/changes/2024-06-19T182508-0400.txt
@@ -1,0 +1,2 @@
+Log current cut periodically, instead of when it changes, for more
+consistency and less space use.

--- a/node/ChainwebNode.hs
+++ b/node/ChainwebNode.hs
@@ -215,9 +215,9 @@ runMonitorLoop actionLabel logger = runForeverThrottled
 runCutMonitor :: Logger logger => logger -> CutDb tbl -> IO ()
 runCutMonitor logger db = L.withLoggerLabel ("component", "cut-monitor") logger $ \l ->
     runMonitorLoop "ChainwebNode.runCutMonitor" l $ do
-        S.mapM_ (logFunctionJson l Info)
-            $ S.map (cutToCutHashes Nothing)
-            $ cutStream db
+        logFunctionJson l Info . cutToCutHashes Nothing
+            =<< _cut db
+        threadDelay 15_000_000
 
 data BlockUpdate = BlockUpdate
     { _blockUpdateBlockHeader :: !(ObjectEncoded BlockHeader)


### PR DESCRIPTION
This makes telemetry more reliable in the case of stalls and also much less expensive in terms of disk space.

Change-Id: I28b5efa9d89323b1e381c1bd9085e46fb9afb040