### PR TITLE
log: better progress for read-only replay

### DIFF
--- a/changes/2024-06-19T182544-0400.txt
+++ b/changes/2024-06-19T182544-0400.txt
@@ -1,0 +1,2 @@
+Better progress messages for read-only replay, including a time
+estimate and smoothed rate calculation.


### PR DESCRIPTION
Shows a time estimate now as well as a smoother estimated rate.

Change-Id: I2839ccab331ef9493d7059af598930372ffdf6b9