### PR TITLE
perf: stop replaying empty blocks

### DIFF
--- a/changes/2024-06-19T182611-0400.txt
+++ b/changes/2024-06-19T182611-0400.txt
@@ -1,0 +1,1 @@
+Speed up read-only replay by avoiding playing empty blocks


### PR DESCRIPTION
Simply do not replay empty blocks and reap the performance rewards. I'm careful here to still keep any upgrade blocks.

Change-Id: I601cb81cd5e241fa3ceaa315d80b33ae9f17c75d