### PR TITLE
perf: use module cache output from readFrom

### DIFF
--- a/changes/2024-06-19T182645-0400.txt
+++ b/changes/2024-06-19T182645-0400.txt
@@ -1,0 +1,2 @@
+Fix a performance bug in read-only replay which was not using a cache
+for module data


### PR DESCRIPTION
All of our time was being spent reading modules from the database, because the new readFrom didn't persist its cache back to the database state. I think originally the reason why it didn't was to avoid state leakage, but this is safe because the module cache is guaranteed correct (it just does JSON parsing).

Change-Id: I405069a2ee17cfb4581df20402ff66c39675d90b