### PR TITLE
fix: make ctrl-C work for replays (and perhaps more generally)

### DIFF
--- a/changes/2024-06-19T182722-0400.txt
+++ b/changes/2024-06-19T182722-0400.txt
@@ -1,0 +1,2 @@
+Small fixes to exception safety result in Ctrl-C now working properly
+during read-only replay (and other scenarios)

--- a/src/Chainweb/Mempool/InMem.hs
+++ b/src/Chainweb/Mempool/InMem.hs
@@ -191,9 +191,7 @@ withInMemoryMempool_ l cfg _v f = do
         logFunctionText l Debug "Initialized Mempool Monitor"
         runForeverThrottled lf "Chainweb.Mempool.InMem.withInMemoryMempool_.monitor" 10 (10 * mega) $ do
             stats <- getMempoolStats m
-            logFunctionText l Debug "got stats"
             logFunctionJson l Info stats
-            logFunctionText l Debug "logged stats"
             approximateThreadDelay 60_000_000 {- 1 minute -}
 
 ------------------------------------------------------------------------------

--- a/src/Chainweb/Pact/Service/PactQueue.hs
+++ b/src/Chainweb/Pact/Service/PactQueue.hs
@@ -124,9 +124,9 @@ waitForSubmittedRequest statusRef = atomically $ do
 -- When the continuation terminates, *cancel the request*.
 --
 submitRequestAnd :: PactQueue -> RequestMsg r -> (TVar (RequestStatus r) -> IO a) -> IO a
-submitRequestAnd q msg k = mask $ \restore -> do
+submitRequestAnd q msg k = uninterruptibleMask $ \restore -> do
     status <- addRequest q msg
-    restore (k status) `finally`
+    restore (k status) `onException`
         uninterruptibleMask_ (cancelSubmittedRequest status)
 
 -- | Submit a request and wait for it to finish; if interrupted by an


### PR DESCRIPTION
I don't understand why this fixes the issue, but it is actually a correct thing to do; this PR just makes sure that we are masked when we fork off the Pact task thread.

Change-Id: I98ac853da9efd086be749d388a5eb559f7866af0