### PR TITLE
Improve integration test call

### DIFF
--- a/.github/workflows/applications.yml
+++ b/.github/workflows/applications.yml
@@ -53,6 +53,7 @@ jobs:
       eventlog: ${{ steps.compile-flags.outputs.eventlog }}
       tag-suffix: ${{ steps.compile-flags.outputs.tag-suffix }}
       chainweb-network-version: ${{ steps.compile-flags.outputs.chainweb-network-version }}
+      github-app-auth: ${{ steps.githubAppAuth.outputs.access-token }}
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
@@ -175,6 +176,12 @@ jobs:
         echo "config.outputs.matrix=${{ steps.set-matrix.outputs.matrix }}"
         echo "::endgroup::"
 
+    - uses: Nastaliss/get-github-app-pat@v1
+      id: githubAppAuth
+      with:
+        app-id: ${{ secrets.GH_KADENAINFRA_APP_ID }}
+        app-installation-id: ${{ secrets.GH_KADENAINFRA_APP_INSTALLATION_ID }}
+        app-private-key: ${{ secrets.GH_KADENAINFRA_APP_PRIVATE_KEY }}
   # ########################################################################## #
   # Download Development Database for Testing
   #
@@ -740,16 +747,12 @@ jobs:
     name: Run Integration Tests from remote repo
     needs: [ config, docker-image ]
     runs-on: ubuntu-latest
-
-    env:
-      GIT_SHA_SHORT: ${{ needs.config.outputs.git-sha-short }}
-
     steps:
     - name: Start remote integration tests
-      uses: aurelien-baudet/workflow-dispatch@93e95b157d791ae7f42aef8f8a0d3d723eba1c31
+      uses: aurelien-baudet/workflow-dispatch@2.1.1
       with:
         workflow: Integration Tests on devnet chain
-        token: ${{ secrets.GH_WORKFLOW_PAT_FOR_TESTS }}
+        token: ${{ needs.config.outputs.github-app-auth }}
         inputs: '{ "chainweb_node_container_id" : "sha-${{ needs.config.outputs.git-sha-short }}${{ needs.docker-image.outputs.docker-suffix }}" }'
         ref: refs/heads/master
         repo: kadena-io/integration-tests

--- a/.github/workflows/applications.yml
+++ b/.github/workflows/applications.yml
@@ -53,7 +53,6 @@ jobs:
       eventlog: ${{ steps.compile-flags.outputs.eventlog }}
       tag-suffix: ${{ steps.compile-flags.outputs.tag-suffix }}
       chainweb-network-version: ${{ steps.compile-flags.outputs.chainweb-network-version }}
-      github-app-auth: ${{ steps.githubAppAuth.outputs.access-token }}
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
@@ -176,12 +175,6 @@ jobs:
         echo "config.outputs.matrix=${{ steps.set-matrix.outputs.matrix }}"
         echo "::endgroup::"
 
-    - uses: Nastaliss/get-github-app-pat@v1
-      id: githubAppAuth
-      with:
-        app-id: ${{ secrets.GH_KADENAINFRA_APP_ID }}
-        app-installation-id: ${{ secrets.GH_KADENAINFRA_APP_INSTALLATION_ID }}
-        app-private-key: ${{ secrets.GH_KADENAINFRA_APP_PRIVATE_KEY }}
   # ########################################################################## #
   # Download Development Database for Testing
   #
@@ -748,11 +741,18 @@ jobs:
     needs: [ config, docker-image ]
     runs-on: ubuntu-latest
     steps:
+    - name: Get auth token
+      uses: Nastaliss/get-github-app-pat@683b0b370911354c411dbbc586b7c64f32b2b850
+      id: githubAppAuth
+      with:
+        app-id: ${{ secrets.GH_KADENAINFRA_APP_ID }}
+        app-installation-id: ${{ secrets.GH_KADENAINFRA_APP_INSTALLATION_ID }}
+        app-private-key: ${{ secrets.GH_KADENAINFRA_APP_PRIVATE_KEY }}
     - name: Start remote integration tests
       uses: the-actions-org/workflow-dispatch@v4.0.0
       with:
         workflow: Integration Tests on devnet chain
-        token: ${{ needs.config.outputs.github-app-auth }}
+        token: ${{ steps.githubAppAuth.outputs.access-token }}
         inputs: '{ "chainweb_node_container_id" : "sha-${{ needs.config.outputs.git-sha-short }}${{ needs.docker-image.outputs.docker-suffix }}" }'
         ref: refs/heads/master
         repo: kadena-io/integration-tests

--- a/.github/workflows/applications.yml
+++ b/.github/workflows/applications.yml
@@ -617,6 +617,8 @@ jobs:
     name: Build and publish docker image
     needs: [config, build]
     runs-on: ${{ matrix.os }}
+    outputs:
+      docker-suffix: ${{ steps.frozen-tag.outputs.value }}${{ needs.config.outputs.tag-suffix }}
     if: "${{ github.event_name != 'schedule' }}"
     strategy:
       fail-fast: false
@@ -631,7 +633,7 @@ jobs:
       OS: ${{ matrix.os }}
       ARTIFACTS_NAME: chainweb-applications.${{ matrix.use-freeze-file }}.${{ matrix.ghc }}.${{ matrix.os }}
       ARTIFACTS_ARCHIVE: chainweb.${{ matrix.use-freeze-file }}.${{ matrix.ghc }}.${{ matrix.os }}.${{ needs.config.outputs.git-sha-short }}${{ needs.config.outputs.tag-suffix }}.tar.gz
-
+  
     steps:
     - name: Get build artifacts
       uses: actions/download-artifact@v4
@@ -748,8 +750,8 @@ jobs:
       with:
         workflow: Integration Tests on devnet chain
         token: ${{ secrets.GH_WORKFLOW_PAT_FOR_TESTS }}
-        inputs: '{ "chainweb_node_container_id" : "sha-${{ needs.config.outputs.git-sha-short }}" }'
+        inputs: '{ "chainweb_node_container_id" : "sha-${{ needs.config.outputs.git-sha-short }}${{ needs.docker-image.outputs.docker-suffix }}" }'
         ref: refs/heads/master
         repo: kadena-io/integration-tests
         display-workflow-run-url: true
-        wait-for-completion: false # here you could make this pipeline wait them out
+        wait-for-completion: true # here you could make this pipeline wait them out

--- a/.github/workflows/applications.yml
+++ b/.github/workflows/applications.yml
@@ -749,7 +749,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Start remote integration tests
-      uses: aurelien-baudet/workflow-dispatch@2.1.1
+      uses: the-actions-org/workflow-dispatch@v4.0.0
       with:
         workflow: Integration Tests on devnet chain
         token: ${{ needs.config.outputs.github-app-auth }}


### PR DESCRIPTION
* fixes docker tag when invoking integration tests to account for -frozen (this fixes non-running tests)
* Uses github app generated token to identify test run
* Waits for tests to run to finish build; failing tests will cause the calling step to fail

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207791393032892