### PR TITLE
deprecate rosetta

### DIFF
--- a/src/Chainweb/Chainweb.hs
+++ b/src/Chainweb/Chainweb.hs
@@ -914,7 +914,10 @@ runChainweb cw nowServing = do
             pactDbsToServe
             (_chainwebCoordinator cw)
             (HeaderStream . _configHeaderStream $ _chainwebConfig cw)
-            (Rosetta . _configRosetta $ _chainwebConfig cw)
+            (Rosetta
+                (_configRosetta $ _chainwebConfig cw)
+                (_configRosettaConstructionApi (_chainwebConfig cw))
+            )
             (_chainwebBackup cw <$ guard backupApiEnabled)
             (_serviceApiPayloadBatchLimit . _configServiceApi $ _chainwebConfig cw)
             mw

--- a/src/Chainweb/Rosetta/RestAPI.hs
+++ b/src/Chainweb/Rosetta/RestAPI.hs
@@ -16,6 +16,8 @@ module Chainweb.Rosetta.RestAPI
   ( -- * Endpoints
     RosettaApi
   , rosettaApi
+  , RosettaConstructionApi
+  , rosettaConstructionApi
     -- * Standalone APIs for client derivation
   , RosettaAccountBalanceApi
   , rosettaAccountBalanceApi
@@ -82,15 +84,6 @@ type RosettaApi_ = "rosetta" :>
       -- Blocks --
     :<|> RosettaBlockTransactionApi_
     :<|> RosettaBlockApi_
-      -- Construction --
-    :<|> RosettaConstructionDeriveApi_
-    :<|> RosettaConstructionPreprocessApi_
-    :<|> RosettaConstructionMetadataApi_
-    :<|> RosettaConstructionPayloadsApi_
-    :<|> RosettaConstructionParseApi_
-    :<|> RosettaConstructionCombineApi_
-    :<|> RosettaConstructionHashApi_
-    :<|> RosettaConstructionSubmitApi_
       -- Mempool --
     :<|> RosettaMempoolTransactionApi_
     :<|> RosettaMempoolApi_
@@ -104,6 +97,27 @@ rosettaApi
     :: forall (v :: ChainwebVersionT)
     . Proxy (RosettaApi v)
 rosettaApi = Proxy
+
+-- ------------------------------------------------------------------ --
+-- Rosetta Construction Api
+
+type RosettaConstructionApi (v :: ChainwebVersionT) = 'ChainwebEndpoint v :> Reassoc RosettaConstructionApi_
+
+type RosettaConstructionApi_ = "rosetta" :>
+    ( RosettaConstructionDeriveApi_
+    :<|> RosettaConstructionPreprocessApi_
+    :<|> RosettaConstructionMetadataApi_
+    :<|> RosettaConstructionPayloadsApi_
+    :<|> RosettaConstructionParseApi_
+    :<|> RosettaConstructionCombineApi_
+    :<|> RosettaConstructionHashApi_
+    :<|> RosettaConstructionSubmitApi_
+    )
+
+rosettaConstructionApi
+    :: forall (v :: ChainwebVersionT)
+    . Proxy (RosettaConstructionApi v)
+rosettaConstructionApi = Proxy
 
 -- ------------------------------------------------------------------ --
 -- Standalone Endpoints + Witnesses

--- a/src/Chainweb/Rosetta/Utils.hs
+++ b/src/Chainweb/Rosetta/Utils.hs
@@ -1104,6 +1104,7 @@ data RosettaFailure
     | RosettaInvalidSignature
     | RosettaInvalidAccountProvided
     | RosettaInvalidKAccount
+    | RosettaConstructionApiDeprecated
     deriving (Show, Enum, Bounded, Eq)
 
 
@@ -1145,6 +1146,7 @@ rosettaError RosettaInvalidPublicKey = RosettaError 31 "Invalid PublicKey" False
 rosettaError RosettaInvalidSignature = RosettaError 32 "Invalid Signature" False
 rosettaError RosettaInvalidAccountProvided = RosettaError 33 "Invalid Account was provided" False
 rosettaError RosettaInvalidKAccount = RosettaError 34 "Invalid k:Account" False
+rosettaError RosettaConstructionApiDeprecated = RosettaError 35 "The construction API is deprecated. It is disabled by default and can be enabled via the 'rosettaConstructionApi' configuration flag" False
 
 rosettaError' :: RosettaFailure -> RosettaError
 rosettaError' f = rosettaError f Nothing


### PR DESCRIPTION
The current Rosetta implementation makes unsound assumptions about the format and ordering of internal database logs. The Rosetta test suite also relies on unstable `Hashable` instances and the implied ordering of values in several places. This makes it unfeasible to maintain the implementation without compromising test coverage and soundness.

This PR deprecates Rosetta:

* [x] Add appropriate warnings to configuration validation.
* [x] Split the Rosetta construction API out of the general Rosetta API.
* [x] Remove flaky / broken tests of the Rosetta construction API.
* [x] Add configuration to enable the Rosetta configuration API (which is off by default, even when Rosetta is generally enabled).
* [x] Return informative failure message from Rosetta construction API endpoints when Rosetta is enabled but the construction API is not enabled.
* [x] Fail configuration validation when the Rosetta construction API is enabled but Rosetta is disabled.