### PR TITLE
response size logging

### DIFF
--- a/src/Chainweb/Chainweb/CheckReachability.hs
+++ b/src/Chainweb/Chainweb/CheckReachability.hs
@@ -150,4 +150,3 @@ peerServerSettings peer
     = W.setPort (int . _hostAddressPort . _peerAddr $ _peerInfo peer)
     . W.setHost (_peerInterface peer)
     $ W.defaultSettings
-


### PR DESCRIPTION
Logs response size with requestResponseLogger, after the response completes. If the response doesn't complete, we still log it as it goes out if it's large.