### PR TITLE
compute peerCount using ixset's size function

### DIFF
--- a/src/P2P/Node.hs
+++ b/src/P2P/Node.hs
@@ -559,7 +559,7 @@ findNextPeer conf node = do
         --
         peers <- peerDbSnapshotSTM peerDbVar
         !sessions <- readTVar sessionsVar
-        let peerCount = length peers
+        let peerCount = IXS.size peers
         let sessionCount = M.size sessions
 
         -- Check that there are peers


### PR DESCRIPTION
Should be faster than using the Foldable `length` because it's using the default impl