### PR TITLE
wip: use mapMonotonic to compute session peer addresses

### DIFF
--- a/src/P2P/Node.hs
+++ b/src/P2P/Node.hs
@@ -570,7 +570,7 @@ findNextPeer conf node = do
         --
         check (int sessionCount < _p2pConfigMaxSessionCount conf)
 
-        let addrs = S.fromList (_peerAddr <$> M.keys sessions)
+        let addrs = S.mapMonotonic _peerAddr (M.keysSet sessions)
 
             -- peerList and candidates are supposed to be lazy. With the
             -- transation we only check that the result is not empty, which


### PR DESCRIPTION
not sure if this needs to change the Ord instance for PeerInfo to use _peerAddr as the first entry.