### PR TITLE
Send new transactions to remote mempools immediately

### DIFF
--- a/src/Chainweb/Mempool/InMem.hs
+++ b/src/Chainweb/Mempool/InMem.hs
@@ -28,6 +28,7 @@ module Chainweb.Mempool.InMem
 import Control.Applicative ((<|>))
 import Control.Concurrent.Async
 import Control.Concurrent.MVar
+import Control.Concurrent.STM
 import Control.DeepSeq
 import Control.Error.Util (hush)
 import Control.Exception (bracket, evaluate, mask_, throw)
@@ -35,6 +36,7 @@ import Control.Monad
 
 import Data.Aeson
 import Data.Bifunctor (bimap)
+import Data.ByteString (ByteString)
 import qualified Data.ByteString.Short as SB
 import Data.Decimal
 #if MIN_VERSION_base(4,20,0)
@@ -79,7 +81,6 @@ import Chainweb.Version (ChainwebVersion)
 import qualified Pact.Types.ChainMeta as P
 
 import Numeric.AffineSpace
-import Data.ByteString (ByteString)
 
 ------------------------------------------------------------------------------
 compareOnGasPrice :: TransactionConfig t -> t -> t -> Ordering
@@ -96,11 +97,11 @@ makeInMemPool :: InMemConfig t
 makeInMemPool cfg = mask_ $ do
     nonce <- randomIO
     dataLock <- newInMemMempoolData >>= newMVar
-    return $! InMemoryMempool cfg dataLock nonce
+    newTxsVar <- newTVarIO []
+    return $! InMemoryMempool cfg dataLock newTxsVar nonce
 
 destroyInMemPool :: InMemoryMempool t -> IO ()
 destroyInMemPool = const $ return ()
-
 
 ------------------------------------------------------------------------------
 newInMemMempoolData :: IO (InMemoryMempoolData t)
@@ -132,24 +133,27 @@ toMempoolBackend logger mempool = do
       , mempoolGetBlock = getBlock
       , mempoolPrune = prune
       , mempoolGetPendingTransactions = getPending
+      , mempoolGetNewTransactions = getNew
       , mempoolClear = clear
       }
   where
     cfg = _inmemCfg mempool
     nonce = _inmemNonce mempool
     lockMVar = _inmemDataLock mempool
+    newTxsVar = _inmemNewTxs mempool
 
     InMemConfig tcfg _ _ _ _ _ _ = cfg
     member = memberInMem lockMVar
     lookup = lookupInMem tcfg lockMVar
     lookupEncoded = lookupEncodedInMem lockMVar
-    insert = insertInMem cfg lockMVar
+    insert = insertInMem cfg lockMVar newTxsVar
     insertCheck = insertCheckInMem cfg lockMVar
     markValidated = markValidatedInMem logger tcfg lockMVar
     addToBadList = addToBadListInMem lockMVar
     checkBadList = checkBadListInMem lockMVar
     getBlock = getBlockInMem logger cfg lockMVar
     getPending = getPendingInMem cfg nonce lockMVar
+    getNew = getNewInMem newTxsVar
     prune = pruneInMem lockMVar
     clear = clearInMem lockMVar
 
@@ -479,10 +483,11 @@ insertInMem
     .  NFData t
     => InMemConfig t    -- ^ in-memory config
     -> MVar (InMemoryMempoolData t)  -- ^ in-memory state
+    -> TVar [t]
     -> InsertType
     -> Vector t  -- ^ new transactions
     -> IO ()
-insertInMem cfg lock runCheck txs0 = do
+insertInMem cfg lock newTxsVar runCheck txs0 = do
     txhashes <- insertCheck
     withMVarMasked lock $ \mdata -> do
         pending <- readIORef (_inmemPending mdata)
@@ -495,9 +500,13 @@ insertInMem cfg lock runCheck txs0 = do
             recordRecentTransactions maxRecent newHashes
   where
     insertCheck :: IO (Vector (T2 TransactionHash t))
-    insertCheck = if runCheck == CheckedInsert
-                  then insertCheckInMem' cfg lock txs0
-                  else return $! V.map (\tx -> T2 (hasher tx) tx) txs0
+    insertCheck = case runCheck of
+      CheckedInsert -> insertCheckInMem' cfg lock txs0
+      UncheckedInsert -> return $! V.map (\tx -> T2 (hasher tx) tx) txs0
+      NewInsert -> do
+        -- we trust the caller to have done all necessary pre-insert checks
+        atomically $ modifyTVar newTxsVar $ (V.toList txs0 ++)
+        return $! V.map (\tx -> T2 (hasher tx) tx) txs0
 
     txcfg = _inmemTxCfg cfg
     encodeTx = codecEncode (txCodec txcfg)
@@ -705,6 +714,13 @@ getPendingInMem cfg nonce lock since callback = do
 
     sendChunk _ 0 = return ()
     sendChunk dl _ = callback $! V.fromList $ dl []
+
+getNewInMem :: TVar [t] -> IO [t]
+getNewInMem v = atomically $ do
+  ts <- readTVar v
+  guard (not $ null ts)
+  writeTVar v []
+  return ts
 
 ------------------------------------------------------------------------------
 clearInMem :: MVar (InMemoryMempoolData t) -> IO ()

--- a/src/Chainweb/Mempool/P2pConfig.hs
+++ b/src/Chainweb/Mempool/P2pConfig.hs
@@ -4,6 +4,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE NumericUnderscores #-}
 
 -- |
 -- Module: Chainweb.Mempool.P2pConfig
@@ -19,6 +20,7 @@ module Chainweb.Mempool.P2pConfig
 , mempoolP2pConfigMaxSessionCount
 , mempoolP2pConfigSessionTimeout
 , mempoolP2pConfigPollInterval
+, mempoolP2pConfigSendNewTxsDelay
 , defaultMempoolP2pConfig
 , pMempoolP2pConfig
 ) where
@@ -42,6 +44,7 @@ data MempoolP2pConfig = MempoolP2pConfig
     , _mempoolP2pConfigSessionTimeout :: !Seconds
         -- ^ timeout in seconds
     , _mempoolP2pConfigPollInterval :: !Seconds
+    , _mempoolP2pConfigSendNewTxsDelay :: !Micros
     }
     deriving (Show, Eq, Ord, Generic)
 
@@ -51,7 +54,8 @@ defaultMempoolP2pConfig :: MempoolP2pConfig
 defaultMempoolP2pConfig = MempoolP2pConfig
     { _mempoolP2pConfigMaxSessionCount = 6
     , _mempoolP2pConfigSessionTimeout = 300
-    , _mempoolP2pConfigPollInterval = 30
+    , _mempoolP2pConfigPollInterval = Seconds 30
+    , _mempoolP2pConfigSendNewTxsDelay = Micros 500_000
     }
 
 instance ToJSON MempoolP2pConfig where
@@ -72,6 +76,7 @@ instance FromJSON MempoolP2pConfig where
         <$> o .: "maxSessionCount"
         <*> o .: "sessionTimeout"
         <*> o .: "pollInterval"
+        <*> o .: "sendNewTxsDelay"
 
 pMempoolP2pConfig :: MParser MempoolP2pConfig
 pMempoolP2pConfig = id
@@ -84,3 +89,6 @@ pMempoolP2pConfig = id
     <*< mempoolP2pConfigPollInterval .:: textOption
         % long "mempool-p2p-poll-interval"
         <> help "poll interval for synchronizing mempools in seconds"
+    <*< mempoolP2pConfigPollInterval .:: textOption
+        % long "mempool-p2p-send-new-txs-delay"
+        <> help "delay between sending new transactions to other mempools in micros"

--- a/src/Chainweb/Mempool/RestAPI/Client.hs
+++ b/src/Chainweb/Mempool/RestAPI/Client.hs
@@ -64,6 +64,7 @@ toMempool version chain txcfg env =
     , mempoolCheckBadList = const unsupported
     , mempoolGetBlock = \_ _ _ _ -> unsupported
     , mempoolGetPendingTransactions = getPending
+    , mempoolGetNewTransactions = unsupported
     , mempoolPrune = unsupported
     , mempoolClear = clear
     }

--- a/src/Chainweb/Pact/RestAPI/Server.hs
+++ b/src/Chainweb/Pact/RestAPI/Server.hs
@@ -258,7 +258,7 @@ sendHandler logger v cid mempool (SubmitBatch cmds) = Handler $ do
            let txs = V.fromList $ NEL.toList enriched
            -- If any of the txs in the batch fail validation, we reject them all.
            liftIO (mempoolInsertCheck mempool txs) >>= checkResult
-           liftIO (mempoolInsert mempool UncheckedInsert txs)
+           liftIO (mempoolInsert mempool NewInsert txs)
            return $! RequestKeys $ NEL.map cmdToRequestKey enriched
        Left err -> failWith $ "Validation failed: " <> T.pack err
   where


### PR DESCRIPTION
Instead of waiting for the first sync, send them ~immediately to cut down on a mempool hop for ~free. This may not actually be worth doing after we start penalizing peers for unreachability.