### PR TITLE
Make RuleZipper to replace Measurement

### DIFF
--- a/src/Chainweb/BlockHeader/Internal.hs
+++ b/src/Chainweb/BlockHeader/Internal.hs
@@ -699,7 +699,7 @@ makeGenesisBlockHeader'
 makeGenesisBlockHeader' v p ct@(BlockCreationTime t) n =
     fromLog @ChainwebMerkleHashAlgorithm mlog
   where
-    g = genesisGraph v p
+    (h, g) = genesisHeightAndGraph v p
     cid = _chainId p
 
     mlog = newMerkleLog
@@ -710,7 +710,7 @@ makeGenesisBlockHeader' v p ct@(BlockCreationTime t) n =
         :+: genesisBlockPayloadHash v cid
         :+: cid
         :+: BlockWeight 0
-        :+: genesisBlockHeight v cid -- because of chain graph changes (new chains) not all chains start at 0
+        :+: h -- because of chain graph changes (new chains) not all chains start at 0
         :+: _versionCode v
         :+: EpochStartTime t
         :+: n

--- a/src/Chainweb/RestAPI/NodeInfo.hs
+++ b/src/Chainweb/RestAPI/NodeInfo.hs
@@ -95,7 +95,7 @@ nodeInfoHandler v (SomeCutDb (CutDbT db :: CutDbT cas v)) = do
       , nodeGraphHistory = graphs
       , nodeLatestBehaviorHeight = latestBehaviorAt v
       , nodeGenesisHeights = map (\c -> (chainIdToText c, genesisHeight v c)) $ HS.toList (chainIds v)
-      , nodeHistoricalChains = ruleElems 0 $ fmap (HM.toList . HM.map HS.toList . toAdjacencySets) $ _versionGraphs v
+      , nodeHistoricalChains = ruleElems $ fmap (HM.toList . HM.map HS.toList . toAdjacencySets) $ _versionGraphs v
       , nodeServiceDate = T.pack <$> _versionServiceDate v
       , nodeBlockDelay = _versionBlockDelay v
       }
@@ -105,7 +105,6 @@ nodeInfoHandler v (SomeCutDb (CutDbT db :: CutDbT cas v)) = do
 unpackGraphs :: ChainwebVersion -> [(BlockHeight, [(Int, [Int])])]
 unpackGraphs v = gs
   where
-    gs = map (second graphAdjacencies) $ NE.toList $ ruleElems (BlockHeight 0) $ _versionGraphs v
+    gs = map (second graphAdjacencies) $ NE.toList $ ruleElems $ _versionGraphs v
     graphAdjacencies = map unChain . HM.toList . fmap HS.toList . G.adjacencySets . view chainGraphGraph
     unChain (a, bs) = (chainIdInt a, map chainIdInt bs)
-

--- a/src/Chainweb/Utils/Rule.hs
+++ b/src/Chainweb/Utils/Rule.hs
@@ -6,7 +6,21 @@
 {-# language LambdaCase #-}
 {-# language TupleSections #-}
 
-module Chainweb.Utils.Rule where
+module Chainweb.Utils.Rule
+  ( Rule(..)
+  , ruleHead
+  , ruleDropWhile
+  , ruleTakeWhile
+  , ruleValid
+  , ruleElems
+  , RuleZipper(..)
+  , ruleZipperHere
+  , unzipRule
+  , ruleZipperFind
+  , ruleSeek
+  , ruleZipperDown
+
+  ) where
 
 import Control.DeepSeq
 
@@ -29,7 +43,7 @@ import GHC.Generics
 -- we often lookup chain properties (e.g. forks) where we are interested in the
 -- latest occurrence.
 --
-data Rule h a = Above (h, a) (Rule h a) | End a
+data Rule h a = Above (h, a) (Rule h a) | Bottom (h, a)
     deriving stock (Eq, Ord, Show, Foldable, Functor, Generic, Generic1, Traversable)
     deriving anyclass (Hashable, NFData)
 
@@ -39,29 +53,26 @@ instance Bifunctor Rule where
     where
       go = \case
         Above (h, a) r -> Above (fh h, fa a) (go r)
-        End a -> End (fa a)
+        Bottom (h, a) -> Bottom (fh h, fa a)
 
 instance Foldable1 (Rule h) where foldMap1 = foldMap1Default
 instance Traversable1 (Rule h) where
-    traverse1 f (Above (h, a) t) = Above <$> ((h,) <$> f a) <.> traverse1 f t
-    traverse1 f (End a) = End <$> f a
+    traverse1 f (Above (h, a) t) = Above . (h,) <$> f a <.> traverse1 f t
+    traverse1 f (Bottom (h, a)) = Bottom . (h,) <$> f a
 
 instance (ToJSON h, ToJSON a) => ToJSON (Rule h a) where
-    toJSON = toJSON . go
-      where
-        go (Above (h, a) t) = toJSON (toJSON h, toJSON a) : go t
-        go (End a) = [toJSON a]
+    toJSON = toJSON . ruleElems
 
 instance (FromJSON h, FromJSON a) => FromJSON (Rule h a) where
     parseJSON = withArray "Rule" $ go . V.toList
       where
         go [] = fail "empty list"
-        go [a] = End <$> parseJSON a
+        go [a] = Bottom <$> parseJSON a
         go (x:xs) = Above <$> parseJSON x <*> go xs
 
-ruleHead :: Rule h a -> (Maybe h, a)
-ruleHead (Above (h, a) _) = (Just h, a)
-ruleHead (End a) = (Nothing, a)
+ruleHead :: Rule h a -> (h, a)
+ruleHead (Above (h, a) _) = (h, a)
+ruleHead (Bottom (h, a)) = (h, a)
 
 ruleTakeWhile :: (h -> Bool) -> Rule h a -> Rule h a
 ruleTakeWhile p (Above (h, a) t)
@@ -75,73 +86,58 @@ ruleDropWhile p (Above (h, a) t)
     | otherwise = Above (h, a) t
 ruleDropWhile _ t = t
 
--- | A measurement on a rule tells you where a condition starts to be true; at
--- the Top, at the Bottom, or Between lower and upper.
---
-data Measurement h a = Bottom a | Top (h, a) | Between (h, a) (h, a)
+-- | A zipper on a rule represents a measurement on the rule, either at some
+-- point on the rule (including the top) or at the bottom of the rule.
+-- Leftmost fields are "below", rightmost fields are "above".
+data RuleZipper h a
+  = BetweenZipper (Rule h a) [(h, a)]
+  deriving Show
 
--- | Takes a measurement on a rule using a monotone function.
---
-measureRule' :: (h -> Bool) -> Rule h a -> Measurement h a
-measureRule' p ((topH, topA) `Above` topTail)
-    | p topH = Top (topH, topA)
-    | otherwise = go topH topA topTail
+ruleZipperHere :: RuleZipper h a -> (h, a)
+ruleZipperHere (BetweenZipper r _) = ruleHead r
+
+-- | Construct a zipper at the top of the Rule, O(1).
+unzipRule :: Rule h a -> RuleZipper h a
+unzipRule r = BetweenZipper r []
+{-# inline unzipRule #-}
+
+ruleZipperDown :: RuleZipper h a -> RuleZipper h a
+ruleZipperDown = \case
+  BetweenZipper (Bottom t) above -> BetweenZipper (Bottom t) above
+  BetweenZipper (justBelow `Above` below) above ->
+    BetweenZipper below (justBelow : above)
+
+-- | Find the place in the rule zipper that satisfies the condition.
+-- Note that if the condition is never reached, the rule is returned reversed.
+-- O(length(untrue prefix)).
+ruleZipperFind :: (h -> a -> Bool) -> RuleZipper h a -> (Bool, RuleZipper h a)
+ruleZipperFind p = go
   where
-    go lh la (Above (h, a) t)
-        | p h = Between (h, a) (lh, la)
-        | otherwise = go h a t
-    go _ _ (End a) = Bottom a
-measureRule' _ (End a) = Bottom a
+  go pl@(BetweenZipper below above)
+    | (h, a) <- ruleHead below, p h a =
+      (True, pl)
+    | Bottom {} <- below =
+      (False, pl)
+    | justBelow `Above` wayBelow <- below =
+      go (BetweenZipper wayBelow (justBelow : above))
+{-# inline ruleZipperFind #-}
 
-measureRule :: Ord h => h -> Rule h a -> Measurement h a
-measureRule h =
-    measureRule' (\hc -> h >= hc)
+-- | Find the place in the rule that satisfies the condition, and
+-- return it as a zipper.
+-- Note that if it reaches the bottom, the bottom is returned.
+-- O(length(untrue prefix)).
+ruleSeek :: (h -> a -> Bool) -> Rule h a -> (Bool, RuleZipper h a)
+ruleSeek p = ruleZipperFind p . unzipRule
+{-# inline ruleSeek #-}
 
--- | Returns the elements of the Rule.
+-- | Returns the elements of the Rule. O(n) and lazily produces elements.
 --
-ruleElems :: h -> Rule h a -> NE.NonEmpty (h, a)
-ruleElems h (End a) = (h, a) NE.:| []
-ruleElems he (Above (h, a) t) = (h, a) `NE.cons` ruleElems he t
-
--- | Returns the elements of the Rule in ascending order.
---
--- This does not stream. Accessing the first element takes O(n) time.
---
-ruleElemsAsc :: h -> Rule h a -> NE.NonEmpty (h, a)
-ruleElemsAsc he = go []
-  where
-    go acc (End a) = (he, a) NE.:| acc
-    go acc (Above (h, a) t) = go ((h, a) : acc) t
-
--- | Measures a monotone condition on a value. It tells you when a condition
--- started to be true most recently (it ignores any previous history).
---
--- Note that 'Top' provides a lower bound for a possible change and 'Bottom' is
--- an upper bound for a change of the evaluation of the condition: It returns
--- 'Top' when the condition is false at the latest/current grade. It returns
--- 'Bottom' if the the condition was always true.
---
-measureValue' :: Num h => (a -> Bool) -> Rule h a -> Measurement h a
-measureValue' p ((topH, topA) `Above` topTail)
-    | not (p topA) = Top (topH, topA)
-    | otherwise = go topH topA topTail
-  where
-    go lh la (Above (h, a) t)
-        | not (p a) = Between (h, a) (lh, la)
-        | otherwise = go h a t
-    go lh la (End a)
-        | not (p a) = Between (0, a) (lh, la)
-        | otherwise = Bottom a
-measureValue' _ (End a) = Bottom a
-
--- | Measures when a value most recently dropped blow the given threshold.
---
-measureValue :: Num h => Ord a => a -> Rule h a -> Measurement h a
-measureValue a =
-    measureValue' (\ac -> a >= ac)
+ruleElems :: Rule h a -> NE.NonEmpty (h, a)
+ruleElems (Bottom (h, a)) = (h, a) NE.:| []
+ruleElems (Above (h, a) t) = (h, a) `NE.cons` ruleElems t
 
 -- | Checks that a Rule is decreasing, and thus valid.
---
+-- O(n).
 ruleValid :: Ord h => Rule h a -> Bool
 ruleValid (Above (h, _) t@(Above (h', _) _)) = h > h' && ruleValid t
 ruleValid _ = True

--- a/src/Chainweb/Version.hs
+++ b/src/Chainweb/Version.hs
@@ -74,7 +74,7 @@ module Chainweb.Version
     , genesisBlockTarget
     , genesisTime
     , genesisBlockHeight
-    , genesisGraph
+    , genesisHeightAndGraph
 
     -- * Typelevel ChainwebVersionName
     , ChainwebVersionT(..)
@@ -603,11 +603,8 @@ instance HasChainGraph (ChainwebVersion, BlockHeight) where
 -- It is enforced via the 'mkChainId' smart constructor for ChainId.)
 --
 genesisBlockHeight :: HasCallStack => ChainwebVersion -> ChainId -> BlockHeight
-genesisBlockHeight v c =
-    case measureValue' (flip isWebChain c) $ _versionGraphs v of
-        Top _ -> error $ "Invalid ChainId " <> show c
-        Between _ (h, _) -> h
-        Bottom _ -> BlockHeight 0
+genesisBlockHeight v c = fst $ genesisHeightAndGraph v c
+{-# inlinable genesisBlockHeight #-}
 
 -- | The genesis graph for a given Chain
 --
@@ -617,18 +614,29 @@ genesisBlockHeight v c =
 --   (We generally assume that this invariant holds throughout the code base.
 --   It is enforced via the 'mkChainId' smart constructor for ChainId.)
 --
-genesisGraph
+genesisHeightAndGraph
     :: HasCallStack
     => HasChainwebVersion v
     => HasChainId c
     => v
     -> c
-    -> ChainGraph
-genesisGraph v c =
-    case measureValue' (flip isWebChain c) $ _versionGraphs (_chainwebVersion v) of
-        Top _ -> error $ "Invalid ChainId " <> show (_chainId c)
-        Between _ (_, a) -> a
-        Bottom a -> a
+    -> (BlockHeight, ChainGraph)
+genesisHeightAndGraph v c =
+    case ruleSeek (\_ g -> not (isWebChain g c)) (_versionGraphs (_chainwebVersion v)) of
+        -- the chain was in every graph down to the bottom,
+        -- so the bottom has the genesis graph
+        (False, z) -> ruleZipperHere z
+        (True, (BetweenZipper _ above))
+            -- the chain is not in this graph, and there is no graph above
+            -- which could have it
+            | [] <- above -> missingChainError
+            -- the chain is not in this graph but the graph above does have it
+            | (t:_) <- above -> t
+    where
+    missingChainError = error
+        $ "Invalid ChainId " <> show (_chainId c)
+        <> " for chainweb version " <> show (_versionName (_chainwebVersion v))
+{-# inlinable genesisHeightAndGraph #-}
 
 -------------------------------------------------------------------------- --
 -- Utilities for constructing chainweb versions
@@ -667,6 +675,5 @@ latestBehaviorAt v = foldlOf' behaviorChanges max 0 v + 1
     behaviorChanges = fold
         [ versionForks . folded . folded . _ForkAtBlockHeight
         , versionUpgrades . folded . ifolded . asIndex
-        , versionGraphs . to ruleHead . _1 . _Just
+        , versionGraphs . to ruleHead . _1
         ]
-

--- a/src/Chainweb/Version/Development.hs
+++ b/src/Chainweb/Version/Development.hs
@@ -33,7 +33,7 @@ devnet = ChainwebVersion
     , _versionName = ChainwebVersionName "development"
     , _versionForks = tabulateHashMap $ \_ -> AllChains ForkAtGenesis
     , _versionUpgrades = AllChains mempty
-    , _versionGraphs = End twentyChainGraph
+    , _versionGraphs = Bottom (minBound, twentyChainGraph)
     , _versionBlockDelay = BlockDelay 30_000_000
     , _versionWindow = WindowWidth 120
     , _versionHeaderBaseSizeBytes = 318 - 110
@@ -49,7 +49,7 @@ devnet = ChainwebVersion
 
     -- still the *default* block gas limit is set, see
     -- defaultChainwebConfiguration._configBlockGasLimit
-    , _versionMaxBlockGasLimit = End Nothing
+    , _versionMaxBlockGasLimit = Bottom (minBound, Nothing)
     , _versionCheats = VersionCheats
         { _disablePow = True
         , _fakeFirstEpochStart = True
@@ -59,8 +59,8 @@ devnet = ChainwebVersion
         { _disablePeerValidation = True
         , _disableMempoolSync = False
         }
-    , _versionVerifierPluginNames = AllChains $ End
-        $ Set.fromList $ map VerifierName ["hyperlane_v3_message", "allow"]
+    , _versionVerifierPluginNames = AllChains $ Bottom
+        (minBound, Set.fromList $ map VerifierName ["hyperlane_v3_message", "allow"])
     , _versionQuirks = noQuirks
     , _versionServiceDate = Nothing
     }

--- a/src/Chainweb/Version/Guards.hs
+++ b/src/Chainweb/Version/Guards.hs
@@ -267,10 +267,8 @@ pactParserVersion v cid bh
     | otherwise = PactParserGenesis
 
 maxBlockGasLimit :: ChainwebVersion -> BlockHeight -> Maybe Natural
-maxBlockGasLimit v bh = case measureRule bh $ _versionMaxBlockGasLimit v of
-    Bottom limit -> limit
-    Top (_, limit) -> limit
-    Between (_, limit) _ -> limit
+maxBlockGasLimit v bh = snd $ ruleZipperHere $ snd
+    $ ruleSeek (\h _ -> bh >= h) (_versionMaxBlockGasLimit v)
 
 
 -- | Different versions of Chainweb allow different PPKSchemes.

--- a/src/Chainweb/Version/Mainnet.hs
+++ b/src/Chainweb/Version/Mainnet.hs
@@ -155,13 +155,13 @@ mainnet = ChainwebVersion
 
     , _versionGraphs =
         (to20ChainsMainnet, twentyChainGraph) `Above`
-        End petersonChainGraph
+        Bottom (minBound, petersonChainGraph)
     , _versionBlockDelay = BlockDelay 30_000_000
     , _versionWindow = WindowWidth 120
     , _versionHeaderBaseSizeBytes = 318 - 110
     , _versionMaxBlockGasLimit =
         (succ $ mainnet ^?! versionForks . at Chainweb216Pact . _Just . onChain (unsafeChainId 0) . _ForkAtBlockHeight, Just 180_000) `Above`
-        End Nothing
+        Bottom (minBound, Nothing)
     , _versionBootstraps = domainAddr2PeerInfo mainnetBootstrapHosts
     , _versionGenesis = VersionGenesis
         { _genesisBlockTarget = OnChains $ HM.fromList $ concat
@@ -213,8 +213,9 @@ mainnet = ChainwebVersion
         { _disablePeerValidation = False
         , _disableMempoolSync = False
         }
-    , _versionVerifierPluginNames = AllChains $ (4_577_530, Set.fromList $ map VerifierName ["hyperlane_v3_message"]) `Above`
-        End mempty
+    , _versionVerifierPluginNames = AllChains $
+        (4_577_530, Set.fromList $ map VerifierName ["hyperlane_v3_message"]) `Above`
+        Bottom (minBound, mempty)
     , _versionQuirks = VersionQuirks
         { _quirkGasFees = HM.fromList
             [ (fromJuste (decodeStrictOrThrow' "\"s9fUspNaCHoV4rNI-Tw-JYU1DxqZAOXS-80oEy7Zfbo\""), Gas 67_618)

--- a/src/Chainweb/Version/RecapDevelopment.hs
+++ b/src/Chainweb/Version/RecapDevelopment.hs
@@ -89,7 +89,7 @@ recapDevnet = ChainwebVersion
 
     , _versionGraphs =
         (to20ChainsHeight, twentyChainGraph) `Above`
-        End petersonChainGraph
+        Bottom (minBound, petersonChainGraph)
 
     , _versionBlockDelay = BlockDelay 30_000_000
     , _versionWindow = WindowWidth 120
@@ -108,7 +108,7 @@ recapDevnet = ChainwebVersion
             ]
         }
 
-    , _versionMaxBlockGasLimit = End (Just 180_000)
+    , _versionMaxBlockGasLimit = Bottom (minBound, Just 180_000)
     , _versionCheats = VersionCheats
         { _disablePow = False
         , _fakeFirstEpochStart = True
@@ -120,7 +120,7 @@ recapDevnet = ChainwebVersion
         }
     , _versionVerifierPluginNames = AllChains $
         (600, Set.fromList $ map VerifierName ["hyperlane_v3_message", "allow"]) `Above`
-        End mempty
+        Bottom (minBound, mempty)
     , _versionQuirks = noQuirks
     , _versionServiceDate = Nothing
     }

--- a/src/Chainweb/Version/Testnet.hs
+++ b/src/Chainweb/Version/Testnet.hs
@@ -135,13 +135,13 @@ testnet = ChainwebVersion
 
     , _versionGraphs =
         (to20ChainsTestnet, twentyChainGraph) `Above`
-        End petersonChainGraph
+        Bottom (minBound, petersonChainGraph)
     , _versionBlockDelay = BlockDelay 30_000_000
     , _versionWindow = WindowWidth 120
     , _versionHeaderBaseSizeBytes = 318 - 110
     , _versionMaxBlockGasLimit =
         (succ $ testnet ^?! versionForks . at Chainweb216Pact . _Just . onChain (unsafeChainId 0) . _ForkAtBlockHeight, Just 180_000) `Above`
-        End Nothing
+        Bottom (minBound, Nothing)
     , _versionBootstraps = domainAddr2PeerInfo testnetBootstrapHosts
     , _versionGenesis = VersionGenesis
         { _genesisBlockTarget = OnChains $ HM.fromList $ concat
@@ -185,7 +185,7 @@ testnet = ChainwebVersion
         , _disableMempoolSync = False
         }
     , _versionVerifierPluginNames = AllChains $ (4_100_681, Set.fromList $ map VerifierName ["hyperlane_v3_message"]) `Above`
-        End mempty
+        Bottom (minBound, mempty)
     , _versionQuirks = VersionQuirks
         { _quirkGasFees = HM.fromList
             [ (fromJuste (decodeStrictOrThrow' "\"myHrgVbYCXlAk8KJbmWHs3TEDSlRKRuzxpFa9yaC7cQ\""), Gas 66239)

--- a/src/Chainweb/Version/Utils.hs
+++ b/src/Chainweb/Version/Utils.hs
@@ -131,9 +131,9 @@ chainGraphs :: HasChainwebVersion v => v -> M.Map BlockHeight ChainGraph
 chainGraphs = \case
     (_chainwebVersion -> v)
         | _versionCode v == _versionCode mainnet -> mainnetGraphs
-        | otherwise -> M.fromDistinctDescList . toList . ruleElems minBound $ _versionGraphs v
+        | otherwise -> M.fromDistinctDescList . toList . ruleElems $ _versionGraphs v
     where
-    mainnetGraphs = M.fromDistinctDescList . toList . ruleElems minBound $ _versionGraphs mainnet
+    mainnetGraphs = M.fromDistinctDescList . toList . ruleElems $ _versionGraphs mainnet
 
 -- | BlockHeight intervals for the chain graphs of a chainweb version up to a
 -- given block height.
@@ -462,10 +462,7 @@ verifiersAt v cid bh =
     M.restrictKeys allVerifierPlugins activeVerifierNames
     where
     activeVerifierNames =
-        case measureRule bh $ _versionVerifierPluginNames v ^?! onChain cid of
-            Bottom vs -> vs
-            Top (_, vs) -> vs
-            Between (_, vs) _ -> vs
+        snd $ ruleZipperHere $ snd $ ruleSeek (\h _ -> bh >= h) $ _versionVerifierPluginNames v ^?! onChain cid
 
 -- the mappings from names to verifier plugins is global. the list of verifier
 -- plugins active in any particular block validation context is the only thing

--- a/test/lib/Chainweb/Test/Orphans/Internal.hs
+++ b/test/lib/Chainweb/Test/Orphans/Internal.hs
@@ -296,7 +296,7 @@ instance Arbitrary NodeInfo where
             , nodeGraphHistory = graphs
             , nodeLatestBehaviorHeight = latestBehaviorAt v
             , nodeGenesisHeights = map (\c -> (chainIdToText c, genesisHeight v c)) $ HS.toList $ chainIds v
-            , nodeHistoricalChains = ruleElems 0 $ fmap (HM.toList . HM.map HS.toList . toAdjacencySets) $ _versionGraphs v
+            , nodeHistoricalChains = ruleElems $ fmap (HM.toList . HM.map HS.toList . toAdjacencySets) $ _versionGraphs v
             , nodeServiceDate = T.pack <$> _versionServiceDate v
             , nodeBlockDelay = _versionBlockDelay v
             }

--- a/test/lib/Chainweb/Test/TestVersions.hs
+++ b/test/lib/Chainweb/Test/TestVersions.hs
@@ -124,9 +124,9 @@ testVersionTemplate v = v
     & versionCode .~ ChainwebVersionCode (int (fromJuste $ List.elemIndex (_versionName v) testVersions) + 0x80000000)
     & versionHeaderBaseSizeBytes .~ 318 - 110
     & versionWindow .~ WindowWidth 120
-    & versionMaxBlockGasLimit .~ End (Just 2_000_000)
+    & versionMaxBlockGasLimit .~ Bottom (minBound, Just 2_000_000)
     & versionBootstraps .~ [testBootstrapPeerInfos]
-    & versionVerifierPluginNames .~ AllChains (End mempty)
+    & versionVerifierPluginNames .~ AllChains (Bottom (minBound, mempty))
     & versionQuirks .~ noQuirks
     & versionServiceDate .~ Nothing
 
@@ -173,7 +173,7 @@ barebonesTestVersion g = buildTestVersion $ \v ->
         & versionWindow .~ WindowWidth 120
         & versionBlockDelay .~ BlockDelay 1_000_000
         & versionName .~ ChainwebVersionName ("test-" <> toText g)
-        & versionGraphs .~ End g
+        & versionGraphs .~ Bottom (minBound, g)
         & versionCheats .~ VersionCheats
             { _disablePow = True
             , _fakeFirstEpochStart = True
@@ -204,7 +204,7 @@ timedConsensusVersion g1 g2 = buildTestVersion $ \v -> v
         _ -> AllChains ForkAtGenesis
     )
     & versionUpgrades .~ AllChains HM.empty
-    & versionGraphs .~ (BlockHeight 8, g2) `Above` (End g1)
+    & versionGraphs .~ (BlockHeight 8, g2) `Above` Bottom (minBound, g1)
     & versionCheats .~ VersionCheats
         { _disablePow = True
         , _fakeFirstEpochStart = True
@@ -228,7 +228,7 @@ cpmTestVersion g v = v
     & testVersionTemplate
     & versionWindow .~ WindowWidth 120
     & versionBlockDelay .~ BlockDelay (Micros 100_000)
-    & versionGraphs .~ End g
+    & versionGraphs .~ Bottom (minBound, g)
     & versionCheats .~ VersionCheats
         { _disablePow = True
         , _fakeFirstEpochStart = True
@@ -297,7 +297,7 @@ slowForkingCpmTestVersion g = buildTestVersion $ \v -> v
     & versionName .~ ChainwebVersionName ("slowfork-CPM-" <> toText g)
     & versionForks .~ slowForks
     & versionVerifierPluginNames .~ AllChains
-        (End $ Set.fromList $ map VerifierName ["allow", "hyperlane_v3_announcement", "hyperlane_v3_message"])
+        (Bottom (minBound, Set.fromList $ map VerifierName ["allow", "hyperlane_v3_announcement", "hyperlane_v3_message"]))
 
 -- | CPM version (see `cpmTestVersion`) with forks and upgrades slowly enabled,
 -- and with a gas fee quirk.

--- a/test/unit/Chainweb/Test/Version.hs
+++ b/test/unit/Chainweb/Test/Version.hs
@@ -28,7 +28,6 @@ import Test.Tasty.QuickCheck (testProperty)
 
 import Chainweb.BlockHash
 import Chainweb.BlockHeader
-import Chainweb.BlockHeight
 import Chainweb.Graph
 import Chainweb.Test.Orphans.Internal
 import Chainweb.Test.Orphans.Internal ()
@@ -75,7 +74,7 @@ prop_chainGraphs_sorted v
 prop_chainGraphs_order :: ChainwebVersion -> Property
 prop_chainGraphs_order v = orders === NE.reverse (NE.sort orders)
   where
-    orders = ruleElems (BlockHeight 0) $ fmap order $ _versionGraphs v
+    orders = ruleElems $ fmap order $ _versionGraphs v
 
 prop_genesisHeight :: ChainwebVersion -> Property
 prop_genesisHeight v = property $ all ((>= 0) . genesisHeight v) $ chainIds v
@@ -113,12 +112,12 @@ prop_headerBaseSizeBytes v = property $ do
 
 prop_headerSizes_sorted :: ChainwebVersion -> Property
 prop_headerSizes_sorted v
-    = NE.reverse (NE.sort (ruleElems (BlockHeight 0) (headerSizes v))) === ruleElems (BlockHeight 0) (headerSizes v)
+    = NE.reverse (NE.sort (ruleElems (headerSizes v))) === ruleElems (headerSizes v)
 
 prop_headerSizes_order :: ChainwebVersion -> Property
 prop_headerSizes_order v = orders === NE.reverse (NE.sort orders)
   where
-    orders = ruleElems (BlockHeight 0) $ fmap order $ _versionGraphs v
+    orders = ruleElems $ fmap order $ _versionGraphs v
 
 prop_headerSizeBytes_gen :: ChainwebVersion -> Property
 prop_headerSizeBytes_gen v = property $ do


### PR DESCRIPTION
This generalizes the "measurement" idea so that measurements of rules are represented by zippers, allowing the caller to navigate around a measurement themselves.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1208701053549686