### PR TITLE
Add HasCallStack to help debugging Rosetta errors

### DIFF
--- a/src/Chainweb/Utils.hs
+++ b/src/Chainweb/Utils.hs
@@ -274,7 +274,7 @@ import qualified Data.Vector.Mutable as MV
 import Data.Word
 
 import GHC.Generics
-import GHC.Stack (HasCallStack, CallStack, callStack, prettyCallStack)
+import GHC.Stack (HasCallStack, callStack, prettyCallStack)
 import GHC.TypeLits (KnownSymbol, symbolVal)
 
 import qualified Network.Connection as HTTP

--- a/test/unit/Chainweb/Test/Pact5/RemotePactTest.hs
+++ b/test/unit/Chainweb/Test/Pact5/RemotePactTest.hs
@@ -25,24 +25,20 @@ module Chainweb.Test.Pact5.RemotePactTest
     ( tests
     ) where
 
-import Data.Foldable qualified as F
 import Pact.Core.DefPacts.Types
 import Pact.Core.SPV
 import Data.ByteString.Base64.URL qualified as B64U
 import Data.ByteString.Lazy qualified as BL
 import Data.Aeson qualified as A
 import Pact.Core.Command.RPC (ContMsg(..))
-import Control.Monad (forM_, replicateM_)
+import Control.Monad (replicateM_)
 import Chainweb.SPV.CreateProof (createTransactionOutputProof_)
-import Chainweb.Cut (cutMap)
 import Chainweb.BlockHeader (blockHeight)
 import Data.Maybe (fromMaybe)
-import Chainweb.CutDB (cut)
 import Pact.Core.Names
 import Pact.Core.Capabilities
 import Pact.Core.PactValue
 import Pact.Core.Command.Server qualified as Pact5
-import Pact.Core.Evaluate (Info)
 import Chainweb.CutDB.RestAPI.Server (someCutGetServer)
 import Network.Connection qualified as HTTP
 import Network.HTTP.Client.TLS qualified as HTTP
@@ -72,31 +68,26 @@ import Chainweb.WebPactExecutionService
 import Control.Concurrent
 import Control.Exception (Exception, AsyncException(..))
 import Control.Lens
-import Control.Monad.Catch (Handler(..), throwM)
+import Control.Monad.Catch (throwM)
 import Control.Monad.IO.Class (liftIO)
 import Control.Monad.Trans.Resource (ResourceT, runResourceT, allocate)
-import Control.Retry
 import Data.Aeson qualified as Aeson
-import Data.Vector qualified as Vector
 import Data.HashMap.Strict (HashMap)
-import Data.Map.Strict qualified as Map
 import Data.HashMap.Strict qualified as HashMap
 import Data.HashSet qualified as HashSet
 import Data.List qualified as List
 import Data.List.NonEmpty (NonEmpty)
 import Data.List.NonEmpty qualified as NE
 import Data.Text (Text)
-import Data.Text qualified as Text
 import Network.X509.SelfSigned
 import Pact.Core.Command.Types
-import Pact.Core.Errors
 import Pact.Core.Gas.Types
 import Pact.Core.Hash qualified as Pact5
 import Pact.JSON.Encode qualified as J
 import PredicateTransformers as PT
 import Servant.Client
 import Test.Tasty
-import Test.Tasty.HUnit (assertBool, assertEqual, assertFailure, testCase)
+import Test.Tasty.HUnit (assertEqual, testCase)
 import qualified Pact.Types.Command as Pact4
 
 data Fixture = Fixture

--- a/test/unit/Chainweb/Test/Rosetta/RestAPI.hs
+++ b/test/unit/Chainweb/Test/Rosetta/RestAPI.hs
@@ -172,6 +172,7 @@ accountBalanceTests tio envIo =
   where
     req = AccountBalanceReq nid (AccountId "sender00" Nothing Nothing) Nothing
 
+    checkBalance :: HasCallStack => AccountBalanceResp -> Decimal -> IO ()
     checkBalance resp bal1 = do
       let b0 = head $ _accountBalanceResp_balances resp
           b1 = kdaToRosettaAmount bal1


### PR DESCRIPTION
Rosetta's RestAPI errors have some kind of issue with them right now, which is helped by adding a `HasCallStack` constraint to this assertion function.