### PR TITLE
optimize RemotePactTest and add new invalid tx test

### DIFF
--- a/test/unit/Chainweb/Test/Pact5/CutFixture.hs
+++ b/test/unit/Chainweb/Test/Pact5/CutFixture.hs
@@ -131,6 +131,7 @@ advanceAllChains Fixture{..} = do
     let blockHeights = fmap (view blockHeight) $ latestCut ^. cutMap
     let latestBlockHeight = maximum blockHeights
 
+    -- TODO: rejig this to do parallel mining.
     (finalCut, perChainCommandResults) <- foldM
         (\ (prevCut, !acc) cid -> do
             (newCut, _minedChain, pwo) <-


### PR DESCRIPTION
This test is optimized by sharing the TLS cert and HTTP manager between tests. Otherwise the rest of the testing fixture is *not* shared.

This PR also adds some tasty steps to a few tests, which makes it clearer what they're spending their time on.

There's one extra invalid tx test as well, testing the error from sending to the wrong chain.