### PR TITLE
Make versionquirks testable

### DIFF
--- a/src/Chainweb/Pact/PactService.hs
+++ b/src/Chainweb/Pact/PactService.hs
@@ -836,7 +836,7 @@ execLocal cwtx preflight sigVerify rdepth = pactLabel "execLocal" $ do
                         let initialGas = Pact4.initialGasOf $ Pact4._cmdPayload pact4Cwtx
                         T3 cr _mc warns <- liftIO $ Pact4.applyCmd
                             _psVersion _psLogger _psGasLogger Nothing dbEnv
-                            noMiner gasModel ctx spv (Pact4.payloadObj <$> pact4Cwtx)
+                            noMiner gasModel ctx (TxBlockIdx 0) spv (Pact4.payloadObj <$> pact4Cwtx)
                             initialGas mc ApplyLocal
 
                         let cr' = hashPact4TxLogs cr

--- a/src/Chainweb/Pact4/TransactionExec.hs
+++ b/src/Chainweb/Pact4/TransactionExec.hs
@@ -321,6 +321,7 @@ applyCmd
       -- ^ Gas model (pact Service config)
     -> TxContext
       -- ^ tx metadata and parent header
+    -> TxIdxInBlock
     -> SPVSupport
       -- ^ SPV support (validates cont proofs)
     -> Command (Payload PublicMeta ParsedCode)
@@ -332,7 +333,7 @@ applyCmd
     -> ApplyCmdExecutionContext
       -- ^ is this a local or send execution context?
     -> IO (T3 (CommandResult [TxLogJson]) ModuleCache (S.Set PactWarning))
-applyCmd v logger gasLogger txFailuresCounter pdbenv miner gasModel txCtx spv cmd initialGas mcache0 callCtx = do
+applyCmd v logger gasLogger txFailuresCounter pdbenv miner gasModel txCtx txIdxInBlock spv cmd initialGas mcache0 callCtx = do
     T2 cr st <- runTransactionM cenv txst applyBuyGas
 
     let cache = _txCache st
@@ -344,7 +345,7 @@ applyCmd v logger gasLogger txFailuresCounter pdbenv miner gasModel txCtx spv cm
       | chainweb217Pact' = gasModel
       | otherwise = _geGasModel freeGasEnv
     txst = TransactionState mcache0 mempty 0 Nothing stGasModel mempty
-    quirkGasFee = v ^? versionQuirks . quirkGasFees . ix requestKey
+    quirkGasFee = v ^? versionQuirks . quirkGasFees . ixg cid . ix (ctxCurrentBlockHeight txCtx, txIdxInBlock)
 
     executionConfigNoHistory = ExecutionConfig
       $ S.singleton FlagDisableHistoryInTransactionalMode

--- a/src/Chainweb/Version/Mainnet.hs
+++ b/src/Chainweb/Version/Mainnet.hs
@@ -219,9 +219,9 @@ mainnet = ChainwebVersion
         (4_577_530, Set.fromList $ map VerifierName ["hyperlane_v3_message"]) `Above`
         Bottom (minBound, mempty)
     , _versionQuirks = VersionQuirks
-        { _quirkGasFees = HM.fromList
-            [ (fromJuste (decodeStrictOrThrow' "\"s9fUspNaCHoV4rNI-Tw-JYU1DxqZAOXS-80oEy7Zfbo\""), Gas 67_618)
-            , (fromJuste (decodeStrictOrThrow' "\"_f1xkIQPGRcOBNBWkOvP0dGNOjmNtmXwOnXzfdwnmJQ\""), Gas 69_092)
+        { _quirkGasFees = onChains
+            [ (unsafeChainId 0, HM.fromList [((BlockHeight 4585419, TxBlockIdx 0), Gas 67_618)])
+            , (unsafeChainId 9, HM.fromList [((BlockHeight 4594049, TxBlockIdx 0), Gas 69_092)])
             ]
         }
     , _versionServiceDate = Just "2025-02-05T00:00:00Z"

--- a/src/Chainweb/Version/Testnet04.hs
+++ b/src/Chainweb/Version/Testnet04.hs
@@ -187,9 +187,9 @@ testnet04 = ChainwebVersion
     , _versionVerifierPluginNames = AllChains $ (4_100_681, Set.fromList $ map VerifierName ["hyperlane_v3_message"]) `Above`
         Bottom (minBound, mempty)
     , _versionQuirks = VersionQuirks
-        { _quirkGasFees = HM.fromList
-            [ (fromJuste (decodeStrictOrThrow' "\"myHrgVbYCXlAk8KJbmWHs3TEDSlRKRuzxpFa9yaC7cQ\""), Gas 66239)
-            , (fromJuste (decodeStrictOrThrow' "\"3fpFnFUrRsu67ItHicBGa9PVlWp71AggrcWoikht3jk\""), Gas 65130)
+        { _quirkGasFees = onChains
+            [ (unsafeChainId 1, HM.fromList [((BlockHeight 4104500, TxBlockIdx 0), Gas 66_239)])
+            , (unsafeChainId 2, HM.fromList [((BlockHeight 4108311, TxBlockIdx 0), Gas 65_130)])
             ]
         }
     , _versionServiceDate = Just "2025-02-05T00:00:00Z"

--- a/src/Chainweb/Version/Testnet05.hs
+++ b/src/Chainweb/Version/Testnet05.hs
@@ -99,8 +99,6 @@ testnet05 = ChainwebVersion
         }
     , _versionVerifierPluginNames = AllChains $
         Bottom (minBound, Set.fromList $ map VerifierName ["hyperlane_v3_message"])
-    , _versionQuirks = VersionQuirks
-        { _quirkGasFees = mempty
-        }
+    , _versionQuirks = noQuirks
     , _versionServiceDate = Nothing
     }


### PR DESCRIPTION
Prior, we'd say "the command with request key X has gas Y". Now we say "the command on chain X with block height H and at index I has gas Y". This makes it possible to test without tying the knot anywhere, because the request key is a hash that includes the version name, and also lets us integrate it into Pact 5 later.

Change-Id: Id00000007bbb29b009a2b2e4a0cf36180c8df1a7