### PR TITLE
add a mempool insertCheck variant that doesn't short-circuit. improve error messages in /send api

### DIFF
--- a/src/Chainweb/Mempool/RestAPI/Client.hs
+++ b/src/Chainweb/Mempool/RestAPI/Client.hs
@@ -59,6 +59,7 @@ toMempool version chain txcfg env =
     , mempoolLookupEncoded = const unsupported
     , mempoolInsert = insert
     , mempoolInsertCheck = const unsupported
+    , mempoolInsertCheckVerbose = const unsupported
     , mempoolMarkValidated = const unsupported
     , mempoolAddToBadList = const unsupported
     , mempoolCheckBadList = const unsupported

--- a/src/Chainweb/Pact/PactService/Pact4/ExecBlock.hs
+++ b/src/Chainweb/Pact/PactService/Pact4/ExecBlock.hs
@@ -327,8 +327,11 @@ checkTxSigs
   -> f ()
 checkTxSigs logger v cid bh t = do
   liftIO $ logFunctionText logger Debug $ "Pact4.checkTxSigs: " <> sshow (Pact4._cmdHash t)
-  if | isRight (Pact4.assertValidateSigs validSchemes webAuthnPrefixLegal hsh signers sigs) -> pure ()
-     | otherwise -> throwError InsertErrorInvalidSigs
+  case Pact4.assertValidateSigs validSchemes webAuthnPrefixLegal hsh signers sigs of
+      Right _ -> do
+          pure ()
+      Left err -> do
+        throwError $ InsertErrorInvalidSigs (displayAssertValidateSigsError err)
   where
     hsh = Pact4._cmdHash t
     sigs = Pact4._cmdSigs t


### PR DESCRIPTION
Change-Id: I435856410fb82c59f8170d32bf12e5cea69833d1