### PR TITLE
Include difficulty as Double in BlockUpdate telemetry

### DIFF
--- a/node/src/ChainwebNode.hs
+++ b/node/src/ChainwebNode.hs
@@ -86,6 +86,7 @@ import Chainweb.Chainweb.CutResources
 import Chainweb.Counter
 import Chainweb.Cut.CutHashes
 import Chainweb.CutDB
+import Chainweb.Difficulty
 import Chainweb.Logger
 import Chainweb.Logging.Config
 import Chainweb.Logging.Miner
@@ -223,6 +224,7 @@ data BlockUpdate = BlockUpdate
     { _blockUpdateBlockHeader :: !(ObjectEncoded BlockHeader)
     , _blockUpdateOrphaned :: !Bool
     , _blockUpdateTxCount :: !Int
+    , _blockUpdateDifficultyDouble :: !Double
     }
     deriving (Show, Eq, Ord, Generic, NFData)
 
@@ -231,10 +233,12 @@ instance ToJSON BlockUpdate where
         $ "header" .= _blockUpdateBlockHeader o
         <> "orphaned" .= _blockUpdateOrphaned o
         <> "txCount" .= _blockUpdateTxCount o
+        <> "difficultyDouble" .= _blockUpdateDifficultyDouble o
     toJSON o = object
         [ "header" .= _blockUpdateBlockHeader o
         , "orphaned" .= _blockUpdateOrphaned o
         , "txCount" .= _blockUpdateTxCount o
+        , "difficultyDouble" .= _blockUpdateDifficultyDouble o
         ]
 
     {-# INLINE toEncoding #-}
@@ -261,10 +265,12 @@ runBlockUpdateMonitor logger db = L.withLoggerLabel ("component", "block-update-
         <$> pure (ObjectEncoded bh) -- _blockUpdateBlockHeader
         <*> pure False -- _blockUpdateOrphaned
         <*> txCount bh -- _blockUpdateTxCount
+        <*> pure (difficultyToDouble (targetToDifficulty (view blockTarget bh))) -- _blockUpdateDifficultyDouble
     toUpdate (Left bh) = BlockUpdate
         <$> pure (ObjectEncoded bh) -- _blockUpdateBlockHeader
         <*> pure True -- _blockUpdateOrphaned
         <*> ((0 -) <$> txCount bh) -- _blockUpdateTxCount
+        <*> pure (difficultyToDouble (targetToDifficulty (view blockTarget bh))) -- _blockUpdateDifficultyDouble
 
 -- type CutLog = HM.HashMap ChainId (ObjectEncoded BlockHeader)
 

--- a/src/Chainweb/BlockWeight.hs
+++ b/src/Chainweb/BlockWeight.hs
@@ -22,6 +22,7 @@ module Chainweb.BlockWeight
 (
 -- * Block Weight
   BlockWeight(..)
+, blockWeightToDouble
 , encodeBlockWeight
 , decodeBlockWeight
 , encodeBlockWeightBe
@@ -66,6 +67,9 @@ instance MerkleHashAlgorithm a => IsMerkleLogEntry a ChainwebHashTag BlockWeight
     {-# INLINE toMerkleNode #-}
     {-# INLINE fromMerkleNode #-}
 
+blockWeightToDouble :: BlockWeight -> Double
+blockWeightToDouble (BlockWeight diff) = difficultyToDouble diff
+
 encodeBlockWeight :: BlockWeight -> Put
 encodeBlockWeight (BlockWeight w) = encodeHashDifficulty w
 {-# INLINE encodeBlockWeight #-}
@@ -81,4 +85,3 @@ encodeBlockWeightBe (BlockWeight w) = encodeHashDifficultyBe w
 decodeBlockWeightBe :: Get BlockWeight
 decodeBlockWeightBe = BlockWeight <$> decodeHashDifficultyBe
 {-# INLINE decodeBlockWeightBe #-}
-


### PR DESCRIPTION
This allows it to be more easily ingested by ElasticSearch.

Change-Id: Id0000000010fc50d9363200a7d4ea8c251a2f25a

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1209151718815716