### PR TITLE
Use deleteRange to clean up testRocksDb

### DIFF
--- a/libs/chainweb-storage/src/Chainweb/Storage/Table/RocksDB.hs
+++ b/libs/chainweb-storage/src/Chainweb/Storage/Table/RocksDB.hs
@@ -84,6 +84,7 @@ module Chainweb.Storage.Table.RocksDB
   -- * RocksDB-specific tools
   , checkpointRocksDb
   , deleteRangeRocksDb
+  , deleteNamespaceRocksDb
   , compactRangeRocksDb
   ) where
 
@@ -692,6 +693,18 @@ deleteRangeRocksDb table range = do
         BU.unsafeUseAsCStringLen (fst range') $ \(minKeyPtr, minKeyLen) ->
         BU.unsafeUseAsCStringLen (snd range') $ \(maxKeyPtr, maxKeyLen) ->
         checked "Chainweb.Storage.Table.RocksDB.deleteRangeRocksDb" $
+            C.rocksdb_delete_range dbPtr optsPtr
+                minKeyPtr (fromIntegral minKeyLen :: CSize)
+                maxKeyPtr (fromIntegral maxKeyLen :: CSize)
+
+-- | Batch delete all contents of rocksdb
+deleteNamespaceRocksDb :: HasCallStack => RocksDb -> IO ()
+deleteNamespaceRocksDb rdb = do
+    let R.DB dbPtr = _rocksDbHandle rdb
+    R.withCWriteOpts R.defaultWriteOptions $ \optsPtr ->
+        BU.unsafeUseAsCStringLen (namespaceFirst $ _rocksDbNamespace rdb) $ \(minKeyPtr, minKeyLen) ->
+        BU.unsafeUseAsCStringLen (namespaceLast $ _rocksDbNamespace rdb) $ \(maxKeyPtr, maxKeyLen) ->
+        checked "Chainweb.Storage.Table.RocksDB.deleteAllContentsRocksDb" $
             C.rocksdb_delete_range dbPtr optsPtr
                 minKeyPtr (fromIntegral minKeyLen :: CSize)
                 maxKeyPtr (fromIntegral maxKeyLen :: CSize)

--- a/test/lib/Chainweb/Test/Cut.hs
+++ b/test/lib/Chainweb/Test/Cut.hs
@@ -97,8 +97,9 @@ import Chainweb.Cut
 import Chainweb.Cut.Create
 import Chainweb.Graph
 import Chainweb.Payload
-import Chainweb.Test.Utils.BlockHeader
 import Chainweb.Test.TestVersions
+import Chainweb.Test.Utils.BlockHeader
+import Chainweb.Test.Utils
 import Chainweb.Time (Micros(..), Time, TimeSpan)
 import qualified Chainweb.Time as Time (second)
 import Chainweb.Utils
@@ -665,9 +666,10 @@ ioTest
     -> ChainwebVersion
     -> (WebBlockHeaderDb -> T.PropertyM IO Bool)
     -> T.Property
-ioTest db v f = T.monadicIO $
-    liftIO (initWebBlockHeaderDb db v) >>= f >>= T.assert
+ioTest baseDb v f = T.monadicIO $ do
+    db' <- liftIO $ testRocksDb "Chainweb.Test.Cut" baseDb
+    liftIO (initWebBlockHeaderDb db' v) >>= f >>= T.assert
+    liftIO $ deleteNamespaceRocksDb db'
 
 pickBlind :: T.Gen a -> T.PropertyM IO a
 pickBlind = fmap T.getBlind . T.pick . fmap T.Blind
-

--- a/test/unit/Chainweb/Test/Pact4/ModuleCacheOnRestart.hs
+++ b/test/unit/Chainweb/Test/Pact4/ModuleCacheOnRestart.hs
@@ -79,7 +79,7 @@ tests :: RocksDb -> TestTree
 tests rdb =
     withResource' (newMVar mempty) $ \iom ->
     withResource' newEmptyMVar $ \rewindDataM ->
-    withResource' (mkTestBlockDb testVer rdb) $ \bdbio ->
+    withResourceT (mkTestBlockDb testVer rdb) $ \bdbio ->
     withResourceT withTempSQLiteResource $ \ioSqlEnv ->
     independentSequentialTestGroup "Chainweb.Test.Pact4.ModuleCacheOnRestart"
     [ testCaseSteps "testInitial" $ withPact' bdbio ioSqlEnv iom testInitial

--- a/test/unit/Chainweb/Test/Pact4/VerifierPluginTest.hs
+++ b/test/unit/Chainweb/Test/Pact4/VerifierPluginTest.hs
@@ -4,11 +4,13 @@ module Chainweb.Test.Pact4.VerifierPluginTest
 
 import Test.Tasty
 
+import Chainweb.Storage.Table.RocksDB
+
 import qualified Chainweb.Test.Pact4.VerifierPluginTest.Transaction
 import qualified Chainweb.Test.Pact4.VerifierPluginTest.Unit
 
-tests :: TestTree
-tests = testGroup "Chainweb.Test.Pact4.VerifierPluginTest"
+tests :: RocksDb -> TestTree
+tests rdb = testGroup "Chainweb.Test.Pact4.VerifierPluginTest"
   [ Chainweb.Test.Pact4.VerifierPluginTest.Unit.tests
-  , Chainweb.Test.Pact4.VerifierPluginTest.Transaction.tests
+  , Chainweb.Test.Pact4.VerifierPluginTest.Transaction.tests rdb
   ]

--- a/test/unit/Chainweb/Test/Pact5/CutFixture.hs
+++ b/test/unit/Chainweb/Test/Pact5/CutFixture.hs
@@ -64,7 +64,7 @@ import Chainweb.Payload.PayloadStore
 import Chainweb.Storage.Table.RocksDB
 import Chainweb.Sync.WebBlockHeaderStore
 import Chainweb.Test.Pact5.Utils
-import Chainweb.Test.Utils(TestPact5CommandResult)
+import Chainweb.Test.Utils
 import Chainweb.Time
 import Chainweb.Utils
 import Chainweb.Utils.Serialization (runGetS, runPutS)

--- a/test/unit/Chainweb/Test/Pact5/PactServiceTest.hs
+++ b/test/unit/Chainweb/Test/Pact5/PactServiceTest.hs
@@ -45,7 +45,7 @@ import Chainweb.Payload
 import Chainweb.Storage.Table.RocksDB
 import Chainweb.Test.Cut.TestBlockDb (TestBlockDb (_bdbPayloadDb, _bdbWebBlockHeaderDb), addTestBlockDb, getCutTestBlockDb, getParentTestBlockDb, mkTestBlockDb, setCutTestBlockDb)
 import Chainweb.Test.Pact5.CmdBuilder
-import Chainweb.Test.Pact5.Utils hiding (withTempSQLiteResource, testRocksDb)
+import Chainweb.Test.Pact5.Utils hiding (withTempSQLiteResource)
 import Chainweb.Test.TestVersions
 import Chainweb.Test.Utils
 import Chainweb.Time
@@ -94,7 +94,7 @@ data Fixture = Fixture
 mkFixtureWith :: PactServiceConfig -> RocksDb -> ResourceT IO Fixture
 mkFixtureWith pactServiceConfig baseRdb = do
     sqlite <- withTempSQLiteResource
-    tdb <- liftIO $ mkTestBlockDb v =<< testRocksDb "fixture" baseRdb
+    tdb <- mkTestBlockDb v baseRdb
     perChain <- iforM (HashSet.toMap (chainIds v)) $ \chain () -> do
         bhdb <- liftIO $ getWebBlockHeaderDb (_bdbWebBlockHeaderDb tdb) chain
         pactQueue <- liftIO $ newPactQueue 2_000

--- a/test/unit/Chainweb/Test/Pact5/TransactionExecTest.hs
+++ b/test/unit/Chainweb/Test/Pact5/TransactionExecTest.hs
@@ -47,7 +47,7 @@ import Data.String (fromString)
 import Data.Text qualified as T
 import Data.Text.Encoding qualified as T
 import Data.Text.IO qualified as T
-import Chainweb.Test.Pact5.Utils hiding (testRocksDb, withTempSQLiteResource)
+import Chainweb.Test.Pact5.Utils hiding (withTempSQLiteResource)
 import GHC.Stack
 import Pact.Core.Capabilities
 import Pact.Core.Command.Types
@@ -104,8 +104,8 @@ tests baseRdb = testGroup "Pact5 TransactionExecTest"
 readFromAfterGenesis :: ChainwebVersion -> RocksDb -> PactBlockM GenericLogger RocksDbTable a -> IO a
 readFromAfterGenesis ver rdb act = runResourceT $ do
     sql <- withTempSQLiteResource
+    tdb <- mkTestBlockDb ver rdb
     liftIO $ do
-        tdb <- mkTestBlockDb ver =<< testRocksDb "testBuyGasShouldTakeGasTokensFromTheTransactionSender" rdb
         bhdb <- getWebBlockHeaderDb (_bdbWebBlockHeaderDb tdb) cid
         logger <- testLogger
         T2 a _finalPactState <- withPactService ver cid logger Nothing bhdb (_bdbPayloadDb tdb) sql testPactServiceConfig $ do

--- a/test/unit/ChainwebTests.hs
+++ b/test/unit/ChainwebTests.hs
@@ -127,11 +127,11 @@ pactTestSuite rdb = testGroup "Chainweb-Pact Tests"
     , Chainweb.Test.Pact4.DbCacheTest.tests
     , Chainweb.Test.Pact4.Checkpointer.tests
 
-    , Chainweb.Test.Pact4.PactMultiChainTest.tests -- BROKEN few tests
+    , Chainweb.Test.Pact4.PactMultiChainTest.tests rdb -- BROKEN few tests
 
     , Chainweb.Test.Pact4.PactSingleChainTest.tests rdb
 
-    , Chainweb.Test.Pact4.VerifierPluginTest.tests -- BROKEN
+    , Chainweb.Test.Pact4.VerifierPluginTest.tests rdb -- BROKEN
 
     , Chainweb.Test.Pact4.PactReplay.tests rdb
     , Chainweb.Test.Pact4.ModuleCacheOnRestart.tests rdb
@@ -170,7 +170,7 @@ suite rdb =
         , Chainweb.Test.RestAPI.tests rdb
         , testGroup "SPV"
             [ Chainweb.Test.SPV.tests rdb
-            , Chainweb.Test.Pact4.SPV.tests
+            , Chainweb.Test.Pact4.SPV.tests rdb
             , Chainweb.Test.SPV.EventProof.properties
             ]
         , Chainweb.Test.Mempool.InMem.tests


### PR DESCRIPTION
This makes our rocksdb smaller, which makes certain tests faster, especially the Cut property tests like meetAssociative which mine a lot of blocks.
Change-Id: Id000000077e9012e622fc8577efd411f2fbb3993