### PR TITLE
Fix request logging on Debug log level

### DIFF
--- a/src/Chainweb/Utils/RequestLog.hs
+++ b/src/Chainweb/Utils/RequestLog.hs
@@ -170,6 +170,7 @@ logRequest lvl req = do
             fetchedChunk <- newIORef False
             let fetchChunk = do
                     fetched <- readIORef fetchedChunk
+                    writeIORef fetchedChunk True
                     if fetched then return mempty
                     else return finalStrictBody
             return (setRequestBodyChunks fetchChunk req, Right finalStrictBody)


### PR DESCRIPTION
Because of a bug in request logging on the debug log level specifically when telemetry is enabled, all request bodies delivered to chainweb have their contents repeated infinitely. 

Change-Id: Id0000000fcfba9b9c67184fc89a07944f416f739