### PR TITLE
Stop double- encoding and decoding in the mempool

### DIFF
--- a/src/Chainweb/Pact/RestAPI/Server.hs
+++ b/src/Chainweb/Pact/RestAPI/Server.hs
@@ -268,7 +268,7 @@ sendHandler logger mempool (Pact4.SubmitBatch cmds) = Handler $ do
           let cmdsWithParsedPayloadsV = V.fromList $ NEL.toList cmdsWithParsedPayloads
           -- If any of the txs in the batch fail validation, we reject them all.
           liftIO (mempoolInsertCheckVerbose mempool cmdsWithParsedPayloadsV) >>= checkResult
-          liftIO (mempoolInsert mempool UncheckedInsert cmdsWithParsedPayloadsV)
+          liftIO (mempoolInsert mempool UncheckedInsert HM.empty cmdsWithParsedPayloadsV)
           return $! Pact4.RequestKeys $ NEL.map Pact4.cmdToRequestKey cmdsWithParsedPayloads
       Left err -> failWith $ "reading JSON for transaction failed: " <> T.pack err
   where

--- a/src/Chainweb/Pact/Service/PactInProcApi.hs
+++ b/src/Chainweb/Pact/Service/PactInProcApi.hs
@@ -159,7 +159,7 @@ pactProcessFork mpc theLogger bHeader = do
         "pactMemPoolAccess - " <> sshow (length reintroTxs) <> " transactions to reintroduce"
     -- No need to run pre-insert check here -- we know these are ok, and
     -- calling the pre-check would block here (it calls back into pact service)
-    mempoolInsert (mpcMempool mpc) UncheckedInsert reintroTxs
+    mempoolInsert (mpcMempool mpc) UncheckedInsert mempty reintroTxs
     mempoolMarkValidated (mpcMempool mpc) validatedTxs
 
   where

--- a/test/lib/Chainweb/Test/Pact5/Utils.hs
+++ b/test/lib/Chainweb/Test/Pact5/Utils.hs
@@ -209,7 +209,7 @@ mempoolInsertPact5 mp insertType txs = do
             case codecDecode Pact4.rawCommandCodec (codecEncode Pact5.payloadCodec tx) of
                 Left err -> error err
                 Right a -> a
-    mempoolInsert mp insertType $ Vector.fromList unparsedTxs
+    mempoolInsert mp insertType mempty $ Vector.fromList unparsedTxs
 
 -- | Looks up transactions in the mempool. Returns a set which indicates pending membership of the mempool.
 mempoolLookupPact5 :: MempoolBackend Pact4.UnparsedTransaction -> Vector Pact5.Hash -> IO (HashSet Pact5.Hash)

--- a/test/unit/Chainweb/Test/Mempool.hs
+++ b/test/unit/Chainweb/Test/Mempool.hs
@@ -184,7 +184,7 @@ propOverlarge (txs, overlarge0) _ mempool = runExceptT $ do
   where
     txcfg = mempoolTxConfig mempool
     hash = txHasher txcfg
-    insert v = mempoolInsert mempool CheckedInsert $ V.fromList v
+    insert v = mempoolInsert mempool CheckedInsert mempty $ V.fromList v
     lookup = mempoolLookup mempool . V.fromList . map hash
     overlarge = setOverlarge overlarge0
     setOverlarge = map (\x -> x { mockGasLimit = mockBlockGasLimit + 100 })
@@ -218,7 +218,7 @@ propBadlistPreblock (txs, badTxs) _ mempool = runExceptT $ do
 
     txcfg = mempoolTxConfig mempool
     hash = txHasher txcfg
-    insert v = mempoolInsert mempool CheckedInsert $ V.fromList v
+    insert v = mempoolInsert mempool CheckedInsert mempty $ V.fromList v
     lookup = mempoolLookup mempool . V.fromList . map hash
 
 propAddToBadList
@@ -243,7 +243,7 @@ propAddToBadList tx _ mempool = runExceptT $ do
   where
     txcfg = mempoolTxConfig mempool
     hash = txHasher txcfg
-    insert v = mempoolInsert mempool CheckedInsert $ V.fromList v
+    insert v = mempoolInsert mempool CheckedInsert mempty $ V.fromList v
     lookup = mempoolLookup mempool . V.fromList . map hash
     getBlock = liftIO
       $ V.toList <$> mempoolGetBlock mempool mockBlockFill noopMempoolPreBlockCheck 1 nullBlockHash
@@ -267,7 +267,7 @@ propPreInsert (txs, badTxs) gossipMV mempool =
         liftIO (lookup badTxs) >>= V.mapM_ lookupIsMissing
     txcfg = mempoolTxConfig mempool
     hash = txHasher txcfg
-    insert v = mempoolInsert mempool CheckedInsert $ V.fromList v
+    insert v = mempoolInsert mempool CheckedInsert mempty $ V.fromList v
     lookup = mempoolLookup mempool . V.fromList . map hash
 
     checkOne :: MockTx -> Either InsertError MockTx
@@ -300,7 +300,7 @@ propTrivial txs _ mempool = runExceptT $ do
                   in V.and ffs
     txcfg = mempoolTxConfig mempool
     hash = txHasher txcfg
-    insert v = mempoolInsert mempool CheckedInsert $ V.fromList v
+    insert v = mempoolInsert mempool CheckedInsert mempty $ V.fromList v
     lookup = mempoolLookup mempool . V.fromList . map hash
 
     getBlock = mempoolGetBlock mempool mockBlockFill noopMempoolPreBlockCheck 0 nullBlockHash
@@ -332,7 +332,7 @@ propGetPending txs0 _ mempool = runExceptT $ do
     onFees x = (Down (mockGasPrice x), mockGasLimit x, mockNonce x)
     hash = txHasher $ mempoolTxConfig mempool
     getPending = mempoolGetPendingTransactions mempool
-    insert v = mempoolInsert mempool CheckedInsert $ V.fromList v
+    insert v = mempoolInsert mempool CheckedInsert mempty $ V.fromList v
 
 propHighWater
     :: ([MockTx], [MockTx])
@@ -364,7 +364,7 @@ propHighWater (txs0, txs1) _ mempool = runExceptT $ do
     txdata = sort $ map hash txs1
     hash = txHasher $ mempoolTxConfig mempool
     getPending = mempoolGetPendingTransactions mempool
-    insert txs = mempoolInsert mempool CheckedInsert $ V.fromList txs
+    insert txs = mempoolInsert mempool CheckedInsert mempty $ V.fromList txs
 
 
 uniq :: Eq a => [a] -> [a]

--- a/test/unit/Chainweb/Test/Pact5/PactServiceTest.hs
+++ b/test/unit/Chainweb/Test/Pact5/PactServiceTest.hs
@@ -327,7 +327,7 @@ testNewBlockExcludesInvalid baseRdb = runResourceT $ do
             return $ finalizeBlock bip
 
         _ <- advanceAllChains fixture $ onChain chain0 $ \ph pactQueue mempool -> do
-            mempoolInsert mempool UncheckedInsert $ Vector.fromList [badParse, badSigs]
+            mempoolInsert mempool UncheckedInsert mempty $ Vector.fromList [badParse, badSigs]
             mempoolInsertPact5 mempool UncheckedInsert [badChain, badUnique, badFuture, badPast, badTxHash]
             bip <- throwIfNotPact5 =<< throwIfNoHistory =<< newBlock noMiner NewBlockFill (ParentHeader ph) pactQueue
             let expectedTxs = []


### PR DESCRIPTION
Prior, when we fetch a tx from a remote mempool, we decode it, then re-encode it to insert it in the local mempool. This deletes the re-encoding.

Prior, when we send a tx to a remote mempool, we decode it, deepseq it, then encode the decoded tx to send to the remote mempool. This deletes the deepseq and the re-decoding. This is probably a big deal.

Prior, when a tx was inserted into the local mempool via the mempool insert endpoint, we would decode it in the handler, then re-encode it to insert it in the local mempool. This deletes the re-encoding.

Change-Id: Id0000000adb067b5766554c94d8188a2b804cd9b