### PR TITLE
Put Cabal 3.12.1.0 back in the freeze file

### DIFF
--- a/cabal.project.freeze
+++ b/cabal.project.freeze
@@ -1,6 +1,6 @@
 active-repositories: hackage.haskell.org:merge
-constraints: any.Cabal ==3.10.2.0,
-             any.Cabal-syntax ==3.10.2.0,
+constraints: any.Cabal ==3.12.1.0,
+             any.Cabal-syntax ==3.12.1.0,
              any.Decimal ==0.5.2,
              any.Diff ==1.0.2,
              any.Glob ==0.10.2,


### PR DESCRIPTION
I have no idea why cabal freeze doesn't do this, because I'm using cabal 3.12, but it's *required* to use multi-repl, and thus multicomponent in HLS.
Change-Id: Id000000002414c895259bf7f3152077affd40e59