### PR TITLE
Stop including unknown errors in outputs

### DIFF
--- a/src/Chainweb/Pact4/Types.hs
+++ b/src/Chainweb/Pact4/Types.hs
@@ -262,7 +262,7 @@ catchesPactError logger exnPrinting action = catches (Right <$> action)
             return (viaShow e)
           CensorsUnexpectedError -> do
             liftIO $ logWarn_ logger ("catchesPactError: unknown error: " <> sshow e)
-            return ("unknown error " <> sshow e)
+            return "unknown error"
       return $ Left $ PactError EvalError noInfo [] err
   ]
 


### PR DESCRIPTION
This must've been from early work in Pact 5 integration, which we didn't spot because we weren't doing normal mainnet replays, just parity replays.

Change-Id: Id0000000b119e36484da926eaf598f98ecc885e2