### PR TITLE
Produce NoSuchTable Pact error, and clean up ChainwebPactDb

### DIFF
--- a/src/Chainweb/Pact/Backend/Types.hs
+++ b/src/Chainweb/Pact/Backend/Types.hs
@@ -47,18 +47,21 @@ import Control.Lens
 import Chainweb.Pact.Backend.DbCache
 import Chainweb.Version
 import Database.SQLite3.Direct (Database)
-import qualified Pact.Types.Persistence as Pact4
 import Control.Concurrent.MVar
 import Data.ByteString (ByteString)
-import GHC.Generics
-import qualified Pact.Types.Names as Pact4
+import Data.Text (Text)
 import Data.DList (DList)
 import Data.Map (Map)
 import Data.HashSet (HashSet)
 import Data.HashMap.Strict (HashMap)
 import Data.List.NonEmpty (NonEmpty)
 import Control.DeepSeq (NFData)
+import GHC.Generics
+
 import qualified Chainweb.Pact.Backend.InMemDb as InMemDb
+
+import qualified Pact.Types.Persistence as Pact4
+import qualified Pact.Types.Names as Pact4
 
 -- | Whether we write rows to the database that were already overwritten
 -- in the same block.
@@ -83,7 +86,7 @@ type SQLiteEnv = Database
 -- the row value.
 --
 data SQLiteRowDelta = SQLiteRowDelta
-    { _deltaTableName :: !ByteString -- utf8?
+    { _deltaTableName :: !Text
     , _deltaTxId :: {-# UNPACK #-} !Pact4.TxId
     , _deltaRowKey :: !ByteString
     , _deltaData :: !ByteString
@@ -103,14 +106,14 @@ type TxLogMap = Map Pact4.TableName (DList Pact4.TxLogJson)
 -- | Between a @restore..save@ bracket, we also need to record which tables
 -- were created during this block (so the necessary @CREATE TABLE@ statements
 -- can be performed upon block save).
-type SQLitePendingTableCreations = HashSet ByteString
+type SQLitePendingTableCreations = HashSet Text
 
 -- | Pact transaction hashes resolved during this block.
 type SQLitePendingSuccessfulTxs = HashSet ByteString
 
 -- | Pending writes to the pact db during a block, to be recorded in 'BlockState'.
 -- Structured as a map from table name to a map from rowkey to inserted row delta.
-type SQLitePendingWrites = HashMap ByteString (HashMap ByteString (NonEmpty SQLiteRowDelta))
+type SQLitePendingWrites = HashMap Text (HashMap ByteString (NonEmpty SQLiteRowDelta))
 
 -- Note [TxLogs in SQLitePendingData]
 -- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/test/unit/Chainweb/Test/Pact4/Checkpointer.hs
+++ b/test/unit/Chainweb/Test/Pact4/Checkpointer.hs
@@ -66,6 +66,7 @@ import Chainweb.Version
 import Chainweb.Test.Orphans.Internal ({- Arbitrary BlockHash -})
 import Chainweb.Pact.Backend.Types
 import qualified Chainweb.Pact.PactService.Checkpointer.Internal as Checkpointer
+import qualified Chainweb.Pact5.Backend.ChainwebPactDb as Pact5
 
 -- -------------------------------------------------------------------------- --
 -- Tests
@@ -761,7 +762,7 @@ simpleBlockEnvInit
     -> (PactDb (BlockEnv logger) -> BlockEnv logger -> (MVar (BlockEnv logger) -> IO ()) -> IO a)
     -> IO a
 simpleBlockEnvInit logger f = withTempSQLiteConnection chainwebPragmas $ \sqlenv ->
-    f chainwebPactDb (blockEnv sqlenv) (\_ -> initSchema logger sqlenv)
+    f chainwebPactDb (blockEnv sqlenv) (\_ -> Pact5.initSchema sqlenv)
   where
     blockEnv sqlenv = BlockEnv
       (mkBlockHandlerEnv testVer testChainId (BlockHeight 0) sqlenv DoNotPersistIntraBlockWrites logger)

--- a/test/unit/Chainweb/Test/Pact4/PactSingleChainTest.hs
+++ b/test/unit/Chainweb/Test/Pact4/PactSingleChainTest.hs
@@ -1295,7 +1295,7 @@ goldenNewBlock name mpIO mpRefIO reqIO = golden name $ do
         [ "pendingSuccessfulTxs" J..= J.array
           (encodeB64UrlNoPaddingText <$> List.sort (toList _pendingSuccessfulTxs))
         , "pendingTableCreation" J..= J.array
-            (T.decodeUtf8 <$> List.sort (toList _pendingTableCreation))
+            (List.sort (toList _pendingTableCreation))
         , "pendingWrites" J..= pendingWritesJson
         ]
       , "txId" J..= J.Aeson (fromIntegral @_ @Int $ _blockHandleTxId _blockInProgressHandle)
@@ -1303,7 +1303,7 @@ goldenNewBlock name mpIO mpRefIO reqIO = golden name $ do
       where
       SQLitePendingData{..} = _blockHandlePending _blockInProgressHandle
       pendingWritesJson = J.Object
-            [ (T.decodeUtf8 _dkTable, J.Object
+            [ (_dkTable, J.Object
                 [ (T.decodeUtf8 _dkRowKey, J.Object
                     [ ((sshow @_ @T.Text. fromIntegral @TxId @Word) _deltaTxId, T.decodeUtf8 _deltaData)
                     | SQLiteRowDelta {..} <- toList rowKeyWrites

--- a/test/unit/Chainweb/Test/Pact5/CheckpointerTest.hs
+++ b/test/unit/Chainweb/Test/Pact5/CheckpointerTest.hs
@@ -57,7 +57,6 @@ import Test.Tasty.Hedgehog
 import Chainweb.Test.Pact5.Utils
 import Chainweb.Pact5.Backend.ChainwebPactDb (Pact5Db(doPact5DbTransaction))
 import Chainweb.Pact5.Types (noInfo)
-import GHC.Stack
 import Chainweb.Pact.Backend.Types
 import qualified Chainweb.Pact.PactService.Checkpointer.Internal as Checkpointer
 
@@ -203,7 +202,7 @@ runBlocks cp ph blks = do
 
 -- Check that a block's result at the time it was added to the checkpointer
 -- is consistent with us executing that block with `readFrom`
-assertBlock :: HasCallStack => Checkpointer GenericLogger -> ParentHeader -> (BlockHeader, DbBlock Identity) -> IO ()
+assertBlock :: Checkpointer GenericLogger -> ParentHeader -> (BlockHeader, DbBlock Identity) -> IO ()
 assertBlock cp ph (expectedBh, blk) = do
     hist <- Checkpointer.readFrom cp (Just ph) Pact5T $ \db startHandle -> do
         ((), _endHandle) <- doPact5DbTransaction db startHandle Nothing $ \txdb -> do
@@ -240,7 +239,7 @@ tests = testGroup "Pact5 Checkpointer tests"
     , withResourceT (liftIO . initCheckpointer testVer cid =<< withTempSQLiteResource) $ \cpIO ->
         testProperty "readFrom with linear block history is valid" $ withTests 1000 $ property $ do
             blocks <- forAll genBlockHistory
-            liftIO $ do
+            evalIO $ do
                 cp <- cpIO
                 -- extend this empty chain with the genesis block
                 ((), ()) <- Checkpointer.restoreAndSave cp Nothing $ Stream.yield $ Pact5RunnableBlock $ \_ _ hndl ->


### PR DESCRIPTION
NoSuchTable is a new Pact error case as of Pact 5, but we never throw it. Instead, when a table is missing, sqlite throws an exception, and this is recorded as an "unknown database error" by Pact. But we can easily throw it, as shown here, and simultaneously clean up some of the more repetitious and error-prone conditionals in Pact 5's ChainwebPactDb.

Change-Id: Id000000030817f20e355d569ca29864db3d777cf