### PR TITLE
Attempt to optimize doKeys

### DIFF
--- a/src/Chainweb/Pact5/Backend/ChainwebPactDb.hs
+++ b/src/Chainweb/Pact5/Backend/ChainwebPactDb.hs
@@ -550,7 +550,7 @@ doKeys mlim d = do
               Nothing -> internalDbError $ "doKeys.DModuleSources: unexpected decoding"
     case ordDict of
         Dict () ->
-            return $ sort (parsedKeys ++ memKeys)
+            return $ sort (memKeys ++ parsedKeys)
 
     where
     blockLimitStmt = maybe "" (const " WHERE txid < ?;") mlim


### PR DESCRIPTION
Straightforward algorithmic optimization, owing to the fact that we will usually have more keys for a table in the database than we'll have pending rows for the table in memory.


Change-Id: Id00000007b294fb0f5c33d185109df33f1d88bfa