### PR TITLE
Fix restarting after Pact 5 transition

### DIFF
--- a/src/Chainweb/Pact/PactService.hs
+++ b/src/Chainweb/Pact/PactService.hs
@@ -276,7 +276,7 @@ initializeCoinContract v cid pwo = do
         Just currentBlockHeader ->
             if currentBlockHeader /= ParentHeader genesisHeader
             then
-                unless (pact5 v cid (view blockHeight genesisHeader)) $ do
+                unless (pact5 v cid (view (parentHeader . blockHeight . to succ) currentBlockHeader)) $ do
                     !mc <- Checkpointer.readFrom (Just currentBlockHeader)
                         (SomeBlockM $ Pair Pact4.readInitModules (error "pact5")) >>= \case
                             NoHistory -> throwM $ BlockHeaderLookupFailure

--- a/test/multinode/MultiNodeNetworkTests.hs
+++ b/test/multinode/MultiNodeNetworkTests.hs
@@ -35,7 +35,7 @@ suite = independentSequentialTestGroup "MultiNodeNetworkTests"
         withTempRocksDb "multinode-tests-timedconsensus-peterson-twenty-rocks" $ \rdb ->
         withSystemTempDirectory "multinode-tests-timedconsensus-peterson-twenty-pact" $ \pactDbDir ->
         Chainweb.Test.MultiNode.test loglevel (timedConsensusVersion petersonChainGraph twentyChainGraph) 10 30 rdb pactDbDir step
-    , testCaseSteps "ConsensusNetwork - FastTimedCPM pairChainGraph - 10 nodes - 30 seconds" $ \step ->
+    , testCaseSteps "ConsensusNetwork - FastTimedCPM singleChainGraph - 10 nodes - 30 seconds" $ \step ->
         withTempRocksDb "multinode-tests-fasttimedcpm-single-rocks" $ \rdb ->
         withSystemTempDirectory "multinode-tests-fasttimedcpm-single-pact" $ \pactDbDir ->
         Chainweb.Test.MultiNode.test loglevel (fastForkingCpmTestVersion singletonChainGraph) 10 30 rdb pactDbDir step
@@ -43,4 +43,8 @@ suite = independentSequentialTestGroup "MultiNodeNetworkTests"
         withTempRocksDb "replay-test-fasttimedcpm-pair-rocks" $ \rdb ->
         withSystemTempDirectory "replay-test-fasttimedcpm-pair-pact" $ \pactDbDir ->
         Chainweb.Test.MultiNode.replayTest loglevel (fastForkingCpmTestVersion pairChainGraph) 6 rdb pactDbDir step
+    , testCaseSteps "Replay - TransitionTimedCPM - 6 nodes" $ \step ->
+        withTempRocksDb "replay-test-transitiontimedcpm-pair-rocks" $ \rdb ->
+        withSystemTempDirectory "replay-test-transitiontimedcpm-pair-pact" $ \pactDbDir ->
+        Chainweb.Test.MultiNode.replayTest loglevel (instantCpmTransitionTestVersion pairChainGraph) 1 rdb pactDbDir step
     ]


### PR DESCRIPTION
This case is exclusive to restarting a node after a Pact 5 transition:
we're still running the Pact 4 initialization code when we start a
Pact 5 node, which causes a crash.

Change-Id: Id0000000d523a8dc8809e5ff12ae7bb53f82f393