### PR TITLE
Update to newer Pact 5

### DIFF
--- a/bench/Chainweb/Utils/Bench.hs
+++ b/bench/Chainweb/Utils/Bench.hs
@@ -64,29 +64,8 @@ instance NFData (MempoolBackend a) where
 instance NFData PactQueue where
     rnf !_ = ()
 
-instance (NFData info) => NFData (PactErrorCompat info) where
-    rnf = \case
-        PEPact5Error errorCode -> rnf errorCode
-        PELegacyError legacyError -> rnf legacyError
-
-instance (NFData info) => NFData (PactErrorCode info) where
-    rnf (PactErrorCode a b c) = rnf a `seq` rnf b `seq` rnf c
-
-deriving newtype instance NFData ErrorCode
-
-instance NFData (BoundedText k) where
-    rnf !_ = ()
-
 instance NFData LegacyPactErrorType where
     rnf !_ = ()
 
 instance NFData LegacyPactError where
     rnf (LegacyPactError a b c d) = rnf a `seq` rnf b `seq` rnf c `seq` rnf d
-
-instance (NFData info) => NFData (LocatedErrorInfo info) where
-    rnf (LocatedErrorInfo a b) = rnf a `seq` rnf b
-
-instance NFData PactErrorOrigin where
-    rnf = \case
-        TopLevelErrorOrigin -> ()
-        FunctionErrorOrigin fqn -> rnf fqn

--- a/cabal.project
+++ b/cabal.project
@@ -101,8 +101,8 @@ source-repository-package
 source-repository-package
     type: git
     location: https://github.com/kadena-io/pact-5.git
-    tag: c1e4b32e23c38602313f2018e57481b230e948d0
-    --sha256: 1n3n3h9lzw6yzbh4hi2ff05k04zi83nzr3jkhv8h8zr870yizwlq
+    tag: 65918ff881f7a2d44a08bf55ac2a1d3bb59319f9
+    --sha256: 1swp7gkjvsg0hiciczdm3c8j4a5s86d69mjl0wkdynckclgim6xm
 
 source-repository-package
     type: git

--- a/src/Chainweb/Pact/RestAPI/Server.hs
+++ b/src/Chainweb/Pact/RestAPI/Server.hs
@@ -132,10 +132,10 @@ import qualified Pact.Types.Hash as Pact4
 import qualified Pact.Core.Command.Types as Pact5
 import qualified Pact.Core.Pretty as Pact5
 import qualified Chainweb.Pact5.Transaction as Pact5
+import qualified Chainweb.Pact5.Types as Pact5
 import qualified Chainweb.Pact5.Validations as Pact5
 import Data.Coerce
 import qualified Pact.Core.Command.Server as Pact5
-import qualified Pact.Core.Evaluate as Pact5
 import qualified Pact.Core.Errors as Pact5
 import qualified Pact.Core.Hash as Pact5
 import qualified Pact.Core.Gas as Pact5
@@ -614,7 +614,7 @@ internalPoll
     -> PactExecutionService
     -> Maybe ConfirmationDepth
     -> NonEmpty Pact5.RequestKey
-    -> IO (HashMap Pact5.RequestKey (Pact5.CommandResult Pact5.Hash (Pact5.PactErrorCompat (Pact5.LocatedErrorInfo Pact5.Info))))
+    -> IO (HashMap Pact5.RequestKey (Pact5.CommandResult Pact5.Hash Pact5.PactOnChainError))
 internalPoll logger pdb bhdb mempool pactEx confDepth requestKeys0 = do
     let dbg txt = logFunctionText logger Debug txt
     -- get leaf block header for our chain from current best cut
@@ -639,14 +639,14 @@ internalPoll logger pdb bhdb mempool pactEx confDepth requestKeys0 = do
 
     lookup
         :: (Pact5.RequestKey, T2 BlockHeight BlockHash)
-        -> IO (Either String (Maybe (Pact5.RequestKey, Pact5.CommandResult Pact5.Hash (Pact5.PactErrorCompat (Pact5.LocatedErrorInfo Pact5.Info)))))
+        -> IO (Either String (Maybe (Pact5.RequestKey, Pact5.CommandResult Pact5.Hash Pact5.PactOnChainError)))
     lookup (key, T2 _ ha) = (fmap . fmap . fmap) (key,) $ lookupRequestKey key ha
 
     -- TODO: group by block for performance (not very important right now)
     lookupRequestKey
       :: Pact5.RequestKey
       -> BlockHash
-      -> IO (Either String (Maybe (Pact5.CommandResult Pact5.Hash (Pact5.PactErrorCompat (Pact5.LocatedErrorInfo Pact5.Info)))))
+      -> IO (Either String (Maybe (Pact5.CommandResult Pact5.Hash Pact5.PactOnChainError)))
     lookupRequestKey key bHash = runExceptT $ do
         let pactHash = Pact5.unRequestKey key
         let matchingHash = (== pactHash) . Pact5._cmdHash . fst
@@ -678,7 +678,7 @@ internalPoll logger pdb bhdb mempool pactEx confDepth requestKeys0 = do
           (\decodeErr -> "Transaction failed to decode: " <> decodeErr)
         return (tx', out)
 
-    checkBadList :: Vector Pact5.RequestKey -> IO (Vector (Pact5.RequestKey, Pact5.CommandResult Pact5.Hash (Pact5.PactErrorCompat (Pact5.LocatedErrorInfo Pact5.Info))))
+    checkBadList :: Vector Pact5.RequestKey -> IO (Vector (Pact5.RequestKey, Pact5.CommandResult Pact5.Hash Pact5.PactOnChainError))
     checkBadList rkeys = do
         let !hashes = V.map pact5RequestKeyToTransactionHash rkeys
         out <- mempoolCheckBadList mempool hashes
@@ -686,11 +686,15 @@ internalPoll logger pdb bhdb mempool pactEx confDepth requestKeys0 = do
                   V.filter snd $ V.zip hashes out
         return $! V.map hashIsOnBadList bad
 
-    hashIsOnBadList :: Pact5.RequestKey -> (Pact5.RequestKey, Pact5.CommandResult Pact5.Hash (Pact5.PactErrorCompat (Pact5.LocatedErrorInfo Pact5.Info)))
+    hashIsOnBadList :: Pact5.RequestKey -> (Pact5.RequestKey, Pact5.CommandResult Pact5.Hash Pact5.PactOnChainError)
     hashIsOnBadList rk =
         let res = Pact5.PactResultErr err
-            err = Pact5.PELegacyError $
-              Pact5.LegacyPactError Pact5.LegacyTxFailure "" [] "Transaction is badlisted because it previously failed to validate."
+            err = Pact5.PactOnChainError
+              -- the only legal error type, once chainweaver is really gone, we
+              -- can use a real error type
+              (Pact5.ErrorType "TxFailure")
+              (Pact5.mkBoundedText "Transaction is badlisted because it previously failed to validate.")
+              (Pact5.LocatedErrorInfo Pact5.TopLevelErrorOrigin Pact5.noInfo)
             !cr = Pact5.CommandResult rk Nothing res (mempty :: Pact5.Gas) Nothing Nothing Nothing []
         in (rk, cr)
 

--- a/test/lib/Chainweb/Test/Utils.hs
+++ b/test/lib/Chainweb/Test/Utils.hs
@@ -253,7 +253,6 @@ import Data.Semigroup
 import qualified Pact.Core.Command.Types as Pact5
 import qualified Data.Aeson as Aeson
 import qualified Pact.Core.Errors as Pact5
-import qualified Pact.Core.Info as Pact5
 import qualified Pact.Types.Command as Pact4
 import qualified Pact.Core.Hash as Pact5
 import qualified Pact.Types.Hash as Pact4
@@ -1186,7 +1185,7 @@ independentSequentialTestGroup tn tts =
 unsafeHeadOf :: HasCallStack => Getting (Endo a) s a -> s -> a
 unsafeHeadOf l s = s ^?! l
 
-type TestPact5CommandResult = Pact5.CommandResult Pact5.Hash (Pact5.PactErrorCompat (Pact5.LocatedErrorInfo Pact5.LineInfo))
+type TestPact5CommandResult = Pact5.CommandResult Pact5.Hash Pact5.PactOnChainError
 
 toPact4RequestKey :: Pact5.RequestKey -> Pact4.RequestKey
 toPact4RequestKey = \case

--- a/test/unit/Chainweb/Test/Pact5/HyperlanePluginTests.hs
+++ b/test/unit/Chainweb/Test/Pact5/HyperlanePluginTests.hs
@@ -140,8 +140,8 @@ hyperlaneValidatorAnnouncementTest baseRdb step = runResourceT $ do
         poll fx v chain0 [cmdToRequestKey useBadSignature]
             >>= P.list
                 [ P.match _Just ? P.checkAll
-                    [ P.fun _crResult ? P.match (_PactResultErr  . _PEPact5Error) ? P.checkAll
-                        [ P.fun _peCode ? P.equals (ErrorCode 1407374883553280)
+                    [ P.fun _crResult ? P.match _PactResultErr ? P.checkAll
+                        [ P.fun _peType ? P.equals (ErrorType "EvalError")
                         , P.fun _peMsg ? P.equals "Failed to recover the address from the signature"
                         ]
                     , P.fun _crGas ? P.equals (Gas 100000)
@@ -191,8 +191,8 @@ hyperlaneValidatorAnnouncementTest baseRdb step = runResourceT $ do
         poll fx v chain0 [cmdToRequestKey useWrongSigner]
             >>= P.list
                 [ P.match _Just ? P.checkAll
-                    [ P.fun _crResult ? P.match (_PactResultErr  . _PEPact5Error) ? P.checkAll
-                        [ P.fun _peCode ? P.equals (ErrorCode 1407374883553280)
+                    [ P.fun _crResult ? P.match _PactResultErr ? P.checkAll
+                        [ P.fun _peType ? P.equals (ErrorType "EvalError")
                         , P.fun _peMsg ? P.equals "Incorrect signer. Expected: PLiteral (LString {_lString = \"0x6c414e7a15088023e28af44ad0e1d593671e4b15\"}) but got PLiteral (LString {_lString = \"0x5c414e7a15088023e28af44ad0e1d593671e4b15\"})"
                         ]
                     , P.fun _crGas ? P.equals (Gas 100000)
@@ -357,9 +357,8 @@ checkVerifierNotInTx fx pluginName = do
         [ P.match _Just
             ? P.fun _crResult
             ? P.match _PactResultErr
-            ? P.match _PEPact5Error
             ? P.checkAll
-                [ P.fun _peCode ? P.equals (ErrorCode 1133596488237056)
+                [ P.fun _peType ? P.equals (ErrorType "TxFailure")
                 , P.fun _peMsg ? P.fun _boundedText ? P.equals
                     ("Verifier " <> pluginName <> " failed with the message: not in transaction")
                 ]
@@ -451,9 +450,9 @@ hyperlaneVerifyThresholdZeroError baseRdb step = runResourceT $ do
             [ P.match _Just
             ? P.checkAll
                 [ P.fun _crResult
-                    ? P.match (_PactResultErr . _PEPact5Error)
+                    ? P.match _PactResultErr
                     ? P.checkAll
-                        [ P.fun _peCode ? P.equals (ErrorCode 1407374883553280)
+                        [ P.fun _peType ? P.equals (ErrorType "EvalError")
                         , P.fun _peMsg ? P.equals "Threshold should be greater than 0"
                         ]
                 , P.fun _crGas ? P.equals (Gas 20000)
@@ -476,9 +475,9 @@ hyperlaneVerifyWrongSignersFailure baseRdb step = runResourceT $ do
             [ P.match _Just
             ? P.checkAll
                 [ P.fun _crResult
-                    ? P.match (_PactResultErr . _PEPact5Error)
+                    ? P.match _PactResultErr
                     ? P.checkAll
-                        [ P.fun _peCode ? P.equals (ErrorCode 1407374883553280)
+                        [ P.fun _peType ? P.equals (ErrorType "EvalError")
                         , P.fun _peMsg ? P.equals "Verification failed"
                         ]
                 , P.fun _crGas ? P.equals (Gas 20000)
@@ -503,9 +502,9 @@ hyperlaneVerifyNotEnoughRecoveredSignaturesFailure baseRdb step = runResourceT $
             [ P.match _Just
             ? P.checkAll
                 [ P.fun _crResult
-                    ? P.match (_PactResultErr . _PEPact5Error)
+                    ? P.match _PactResultErr
                     ? P.checkAll
-                        [ P.fun _peCode ? P.equals (ErrorCode 1407374883553280)
+                        [ P.fun _peType ? P.equals (ErrorType "EvalError")
                         , P.fun _peMsg ? P.equals "The number of signatures can't be less than threshold"
                         ]
                 , P.fun _crGas ? P.equals (Gas 20000)
@@ -533,9 +532,9 @@ hyperlaneVerifyNotEnoughCapabilitySignaturesFailure baseRdb step = runResourceT 
             [ P.match _Just
             ? P.checkAll
                 [ P.fun _crResult
-                    ? P.match (_PactResultErr . _PEPact5Error)
+                    ? P.match _PactResultErr
                     ? P.checkAll
-                        [ P.fun _peCode ? P.equals (ErrorCode 1407374883553280)
+                        [ P.fun _peType ? P.equals (ErrorType "EvalError")
                         , P.fun _peMsg ? P.equals "Verification failed"
                         ]
                 , P.fun _crGas ? P.equals (Gas 40000)
@@ -562,9 +561,9 @@ hyperlaneVerifyMerkleIncorrectProofFailure baseRdb step = runResourceT $ do
             [ P.match _Just
             ? P.checkAll
                 [ P.fun _crResult
-                    ? P.match (_PactResultErr . _PEPact5Error)
+                    ? P.match _PactResultErr
                     ? P.checkAll
-                        [ P.fun _peCode ? P.equals (ErrorCode 1407374883553280)
+                        [ P.fun _peType ? P.equals (ErrorType "EvalError")
                         , P.fun _peMsg ? P.equals "Verification failed"
                         ]
                 , P.fun _crGas ? P.equals (Gas 20000)
@@ -594,9 +593,9 @@ hyperlaneVerifyFailureNotEnoughSignaturesToPassThreshold baseRdb step = runResou
             [ P.match _Just
             ? P.checkAll
                 [ P.fun _crResult
-                    ? P.match (_PactResultErr . _PEPact5Error)
+                    ? P.match _PactResultErr
                     ? P.checkAll
-                        [ P.fun _peCode ? P.equals (ErrorCode 1407374883553280)
+                        [ P.fun _peType ? P.equals (ErrorType "EvalError")
                         , P.fun _peMsg ? P.equals "Verification failed"
                         ]
                 , P.fun _crGas ? P.equals (Gas 40000)


### PR DESCRIPTION
This provides us with a more compatible format for errors in CommandResults, avoiding some breakage to wallets, in particular Chainweaver.
Change-Id: Id0000000525b3f854ef3d89b28a22593fcc39612