### PR TITLE
Add some more to crosschainTest

### DIFF
--- a/test/unit/Chainweb/Test/Pact5/RemotePactTest.hs
+++ b/test/unit/Chainweb/Test/Pact5/RemotePactTest.hs
@@ -272,7 +272,7 @@ crosschainTest baseRdb step = runResourceT $ do
             ? P.equals "SPV target not reachable: target chain not reachable. Chainweb instance is too young"
 
         step "waiting"
-        replicateM_ (int $ diameter petersonChainGraph + 1) $ advanceAllChains_ fx
+        replicateM_ (int $ diameter petersonChainGraph) $ advanceAllChains_ fx
         TransactionOutputProofB64 spvProof <- spvTxOutProof fx v targetChain srcChain initiatorReqKey
         let contMsg = ContMsg
                 { _cmPactId = _peDefPactId cont

--- a/test/unit/Chainweb/Test/Pact5/RemotePactTest.hs
+++ b/test/unit/Chainweb/Test/Pact5/RemotePactTest.hs
@@ -138,7 +138,7 @@ httpManager = unsafePerformIO $ HTTP.newTlsManagerWith (HTTP.mkManagerSettings d
 tests :: RocksDb -> TestTree
 tests rdb = withResource' (evaluate httpManager >> evaluate cert) $ \_ ->
     testGroup "Pact5 RemotePactTest"
-        [ testCaseSteps "spvTest" (spvTest rdb)
+        [ testCaseSteps "crosschainTest" (crosschainTest rdb)
         , sendInvalidTxsTest rdb
         , testCaseSteps "caplistTest" (caplistTest rdb)
         , testCaseSteps "pollingInvalidRequestKeyTest" (pollingInvalidRequestKeyTest rdb)
@@ -229,8 +229,8 @@ pollingConfirmationDepthTest baseRdb _step = runResourceT $ do
 
         return ()
 
-spvTest :: RocksDb -> Step -> IO ()
-spvTest baseRdb step = runResourceT $ do
+crosschainTest :: RocksDb -> Step -> IO ()
+crosschainTest baseRdb step = runResourceT $ do
     let v = pact5InstantCpmTestVersion petersonChainGraph
     fx <- mkFixture v baseRdb
 


### PR DESCRIPTION
By covering more error cases, we can obviate cross-chain-transfer.test in the JS integration test suite.