### PR TITLE
Use Map instead of HashMap in the mempool

### DIFF
--- a/src/Chainweb/Mempool/InMem.hs
+++ b/src/Chainweb/Mempool/InMem.hs
@@ -45,8 +45,8 @@ import Data.Foldable (foldlM)
 import Data.Foldable (foldl', foldlM)
 #endif
 import Data.Function (on)
-import Data.HashMap.Strict (HashMap)
-import qualified Data.HashMap.Strict as HashMap
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map
 import Data.IORef (modifyIORef', newIORef, readIORef, writeIORef)
 import Data.Maybe
 import Data.Ord
@@ -196,7 +196,7 @@ memberInMem lock txs = do
     V.mapM (memberOne q) txs
 
   where
-    memberOne q txHash = return $! HashMap.member txHash q
+    memberOne q txHash = return $! Map.member txHash q
 
 ------------------------------------------------------------------------------
 lookupInMem :: NFData t
@@ -216,7 +216,7 @@ lookupInMem txcfg lock txs = do
         in either (const Missing) Pending
                $! codecDecode codec
                $! SB.fromShort bs
-    lookupQ q txHash = fixup <$!> HashMap.lookup txHash q
+    lookupQ q txHash = fixup <$!> Map.lookup txHash q
 
 ------------------------------------------------------------------------------
 lookupEncodedInMem :: NFData t
@@ -231,7 +231,7 @@ lookupEncodedInMem lock txs = do
     fixup pe =
         let bs = _inmemPeBytes pe
         in Pending $! SB.fromShort bs
-    lookupQ q txHash = fixup <$!> HashMap.lookup txHash q
+    lookupQ q txHash = fixup <$!> Map.lookup txHash q
 
 ------------------------------------------------------------------------------
 markValidatedInMem
@@ -243,7 +243,7 @@ markValidatedInMem
     -> IO ()
 markValidatedInMem logger tcfg lock txs = withMVarMasked lock $ \mdata -> do
     modifyIORef' (_inmemPending mdata) $ \psq ->
-        foldl' (flip HashMap.delete) psq hashes
+        foldl' (flip Map.delete) psq hashes
 
     -- This isn't atomic, which is fine. If something goes wrong we may end up
     -- with some false negatives, which means that the mempool would use more
@@ -271,12 +271,12 @@ addToBadListInMem :: MVar (InMemoryMempoolData t)
 addToBadListInMem lock txs = withMVarMasked lock $ \mdata -> do
     !pnd <- readIORef $ _inmemPending mdata
     !bad <- readIORef $ _inmemBadMap mdata
-    let !pnd' = foldl' (flip HashMap.delete) pnd txs
+    let !pnd' = foldl' (flip Map.delete) pnd txs
     -- we don't have the expiry time here, so just use maxTTL
     now <- getCurrentTimeIntegral
     let P.TTLSeconds (ParsedInteger mt) = defaultMaxTTL
     let !endTime = add (secondsToTimeSpan $ fromIntegral mt) now
-    let !bad' = foldl' (\h tx -> HashMap.insert tx endTime h) bad txs
+    let !bad' = foldl' (\h tx -> Map.insert tx endTime h) bad txs
     writeIORef (_inmemPending mdata) pnd'
     writeIORef (_inmemBadMap mdata) bad'
 
@@ -288,7 +288,7 @@ checkBadListInMem
     -> IO (Vector Bool)
 checkBadListInMem lock hashes = withMVarMasked lock $ \mdata -> do
     !bad <- readIORef $ _inmemBadMap mdata
-    return $! V.map (`HashMap.member` bad) hashes
+    return $! V.map (`Map.member` bad) hashes
 
 
 maxNumPending :: Int
@@ -353,10 +353,10 @@ insertCheckVerboseInMem cfg lock txs
       badmap <- withMVarMasked lock $ readIORef . _inmemBadMap
       curTxIdx <- withMVarMasked lock $ readIORef . _inmemCurrentTxs
 
-      let withHashesAndPositions :: (HashMap TransactionHash (Int, InsertError), HashMap TransactionHash (Int, t))
+      let withHashesAndPositions :: (Map TransactionHash (Int, InsertError), Map TransactionHash (Int, t))
           withHashesAndPositions =
-            over _1 (HashMap.fromList . V.toList)
-            $ over _2 (HashMap.fromList . V.toList)
+            over _1 (Map.fromList . V.toList)
+            $ over _2 (Map.fromList . V.toList)
             $ V.partitionWith (\(i, h, e) -> bimap (\err -> (h, (i, err))) (\err -> (h, (i, err))) e)
             $ flip V.imap txs $ \i tx ->
                 let !h = hasher tx
@@ -364,15 +364,15 @@ insertCheckVerboseInMem cfg lock txs
 
       let (prevFailures, prevSuccesses) = withHashesAndPositions
 
-      preInsertBatchChecks <- _inmemPreInsertBatchChecks cfg (V.fromList $ List.map (\(h, (_, t)) -> T2 h t) $ HashMap.toList prevSuccesses)
+      preInsertBatchChecks <- _inmemPreInsertBatchChecks cfg (V.fromList $ List.map (\(h, (_, t)) -> T2 h t) $ Map.toList prevSuccesses)
 
       let update (failures, successes) result = case result of
               Left (T2 txHash insertError) ->
-                case HashMap.lookup txHash successes of
+                case Map.lookup txHash successes of
                   Just (i, _) ->
                     -- add to failures and remove from successes
-                    ( HashMap.insert txHash (i, insertError) failures
-                    , HashMap.delete txHash successes
+                    ( Map.insert txHash (i, insertError) failures
+                    , Map.delete txHash successes
                     )
                   Nothing -> error "insertCheckInMem: impossible"
               -- nothing to do; the successes already contains this value.
@@ -381,10 +381,10 @@ insertCheckVerboseInMem cfg lock txs
 
       let allEntries =
             [ (i, T2 txHash (Left insertError))
-            | (txHash, (i, insertError)) <- HashMap.toList failures
+            | (txHash, (i, insertError)) <- Map.toList failures
             ] ++
             [ (i, T2 txHash (Right val))
-            | (txHash, (i, val)) <- HashMap.toList successes
+            | (txHash, (i, val)) <- Map.toList successes
             ]
       let sortedEntries = V.fromList $ List.map snd $ List.sortBy (compare `on` fst) allEntries
 
@@ -405,7 +405,7 @@ validateOne
     :: forall t a
     .  NFData t
     => InMemConfig t
-    -> HashMap TransactionHash a
+    -> Map TransactionHash a
     -> CurrentTxs
     -> Time Micros
     -> t
@@ -457,7 +457,7 @@ validateOne cfg badmap curTxIdx now t h =
     ttlCheck = txTTLCheck txcfg now t
 
     notInBadMap :: Either InsertError ()
-    notInBadMap = maybe (Right ()) (const $ Left InsertErrorBadlisted) $ HashMap.lookup h badmap
+    notInBadMap = maybe (Right ()) (const $ Left InsertErrorBadlisted) $ Map.lookup h badmap
 
     notDuplicate :: Either InsertError ()
     notDuplicate
@@ -532,11 +532,11 @@ insertInMem logger cfg lock runCheck txs0 = do
     txhashes <- insertCheck
     withMVarMasked lock $ \mdata -> do
         pending <- readIORef (_inmemPending mdata)
-        logFunctionText logger Debug $ "insertInMem: pending txs: " <> sshow (HashMap.keys pending)
-        let cnt = HashMap.size pending
+        logFunctionText logger Debug $ "insertInMem: pending txs: " <> sshow (Map.keys pending)
+        let cnt = Map.size pending
         let txs = V.take (max 0 (maxNumPending - cnt)) txhashes
         let T2 !pending' !newHashesDL = V.foldl' insOne (T2 pending id) txs
-        logFunctionText logger Debug $ "insertInMem: updated pending txs: " <> sshow (HashMap.keys pending')
+        logFunctionText logger Debug $ "insertInMem: updated pending txs: " <> sshow (Map.keys pending')
         let !newHashes = V.fromList $ newHashesDL []
         writeIORef (_inmemPending mdata) $! force pending'
         modifyIORef' (_inmemRecentLog mdata) $
@@ -545,7 +545,7 @@ insertInMem logger cfg lock runCheck txs0 = do
     insertCheck :: IO (Vector (T2 TransactionHash t))
     insertCheck = case runCheck of
       CheckedInsert -> insertCheckInMem' cfg lock txs0
-      UncheckedInsert -> return $! V.map (\tx -> T2 (hasher tx) tx) txs0
+      UncheckedInsert -> return $ V.map (\tx -> T2 (hasher tx) tx) txs0
 
     txcfg = _inmemTxCfg cfg
     encodeTx = codecEncode (txCodec txcfg)
@@ -558,7 +558,7 @@ insertInMem logger cfg lock runCheck txs0 = do
             !bytes = SB.toShort $! encodeTx tx
             !expTime = txMetaExpiryTime $ txMetadata txcfg tx
             !x = PendingEntry gp gl bytes expTime
-        in T2 (HashMap.insert txhash x pending) (soFar . (txhash:))
+        in T2 (Map.insert txhash x pending) (soFar . (txhash:))
 
 
 ------------------------------------------------------------------------------
@@ -579,19 +579,19 @@ getBlockInMem logg cfg lock (BlockFill gasLimit txHashes _) txValidate bheight p
         now <- getCurrentTimeIntegral
 
         pendingDataBeforePrune <- readIORef (_inmemPending mdata)
-        logFunctionText logg Debug $ "getBlockInMem: data before prune" <> sshow (HashMap.keys pendingDataBeforePrune)
+        logFunctionText logg Debug $ "getBlockInMem: data before prune" <> sshow (Map.keys pendingDataBeforePrune)
 
         -- drop any expired transactions.
         pruneInternal logg mdata now
 
         pendingData <- readIORef (_inmemPending mdata)
-        logFunctionText logg Debug $ "getBlockInMem: pending txs (pre filter-seen): " <> sshow (HashMap.keys pendingData)
+        logFunctionText logg Debug $ "getBlockInMem: pending txs (pre filter-seen): " <> sshow (Map.keys pendingData)
 
         !(T2 psq seen) <- filterSeen <$> readIORef (_inmemPending mdata)
-        logFunctionText logg Debug $ "getBlockInMem: pending txs (post filter-seen): " <> sshow (HashMap.keys psq)
-        logFunctionText logg Debug $ "getBlockInMem: seen txs: " <> sshow (HashMap.keys seen)
+        logFunctionText logg Debug $ "getBlockInMem: pending txs (post filter-seen): " <> sshow (Map.keys psq)
+        logFunctionText logg Debug $ "getBlockInMem: seen txs: " <> sshow (Map.keys seen)
         !badmap <- readIORef (_inmemBadMap mdata)
-        logFunctionText logg Debug $ "getBlockInMem: bad txs: " <> sshow (HashMap.keys badmap)
+        logFunctionText logg Debug $ "getBlockInMem: bad txs: " <> sshow (Map.keys badmap)
         let size0 = gasLimit
 
         -- get our batch of output transactions, along with a new pending map
@@ -600,7 +600,7 @@ getBlockInMem logg cfg lock (BlockFill gasLimit txHashes _) txValidate bheight p
 
         -- put the txs chosen for the block back into the map -- they don't get
         -- expunged until they are mined and validated by consensus.
-        let !psq'' = V.foldl' ins (HashMap.union seen psq') out
+        let !psq'' = V.foldl' ins (Map.difference psq' badmap') out
         writeIORef (_inmemPending mdata) $! force psq''
         writeIORef (_inmemBadMap mdata) $! force badmap'
         mout <- V.thaw $ V.map (\(_, (_, t, tOut)) -> (t, tOut)) out
@@ -609,25 +609,25 @@ getBlockInMem logg cfg lock (BlockFill gasLimit txHashes _) txValidate bheight p
 
   where
 
-    filterSeen :: PendingMap -> T2 PendingMap (HashMap TransactionHash PendingEntry)
-    filterSeen p = HashMap.foldlWithKey' loop (T2 mempty mempty) p
+    filterSeen :: PendingMap -> T2 PendingMap (Map TransactionHash PendingEntry)
+    filterSeen p = Map.foldlWithKey' loop (T2 mempty mempty) p
       where
         loop (T2 unseens seens) k v =
           if S.member k txHashes
-          then T2 unseens (HashMap.insert k v seens)
-          else T2 (HashMap.insert k v unseens) seens
+          then T2 unseens (Map.insert k v seens)
+          else T2 (Map.insert k v unseens) seens
 
     ins !m (!h,(!b,!t,_)) =
         let !pe = PendingEntry (txGasPrice txcfg t)
                                (txGasLimit txcfg t)
                                b
                                (txMetaExpiryTime $ txMetadata txcfg t)
-        in HashMap.insert h pe m
+        in Map.insert h pe m
 
     insBadMap !m (!h,!t) = let endTime = txMetaExpiryTime (txMetadata txcfg t)
-                              in HashMap.insert h endTime m
+                              in Map.insert h endTime m
 
-    del !psq (h, _) = HashMap.delete h psq
+    del !psq (h, _) = Map.delete h psq
 
     txcfg = _inmemTxCfg cfg
     codec = txCodec txcfg
@@ -679,7 +679,7 @@ getBlockInMem logg cfg lock (BlockFill gasLimit txHashes _) txValidate bheight p
         -> GasLimit
         -> IO [(TransactionHash, (SB.ShortByteString, t))]
     nextBatch !psq !remainingGas = do
-        let !pendingTxs0 = HashMap.toList psq
+        let !pendingTxs0 = Map.toList psq
         logFunctionText logg Debug $ "nextBatch pendingTxs: " <> sshow (map fst pendingTxs0)
         mPendingTxs <- mutableVectorFromList pendingTxs0
         TimSort.sortBy (compare `on` snd) mPendingTxs
@@ -738,7 +738,7 @@ getPendingInMem cfg nonce lock since callback = do
 
   where
     sendAll psq = do
-        let keys = HashMap.keys psq
+        let keys = Map.keys psq
         (dl, sz) <- foldlM go initState keys
         void $ sendChunk dl sz
 
@@ -752,7 +752,7 @@ getPendingInMem cfg nonce lock since callback = do
         case mbTxs of
           Nothing -> sendAll psq
           Just txs -> do
-              let isPending = flip HashMap.member psq
+              let isPending = flip Map.member psq
               callback $! V.fromList $ filter isPending txs
 
     readLock = withMVar lock $ \mdata -> do
@@ -817,9 +817,9 @@ getRecentTxs maxNumRecent oldHw rlog
 getMempoolStats :: InMemoryMempool t -> IO MempoolStats
 getMempoolStats m = do
     withMVar (_inmemDataLock m) $ \d -> MempoolStats
-        <$!> (HashMap.size <$!> readIORef (_inmemPending d))
+        <$!> (Map.size <$!> readIORef (_inmemPending d))
         <*> (length . _rlRecent <$!> readIORef (_inmemRecentLog d))
-        <*> (HashMap.size <$!> readIORef (_inmemBadMap d))
+        <*> (Map.size <$!> readIORef (_inmemBadMap d))
         <*> (currentTxsSize <$!> readIORef (_inmemCurrentTxs d))
 
 ------------------------------------------------------------------------------
@@ -848,22 +848,22 @@ pruneInternal
 pruneInternal logger mdata now = do
     let pref = _inmemPending mdata
     !pending <- readIORef pref
-    logFunctionText logger Debug $ "pruneInternal: pending txs pre-filter: " <> sshow (HashMap.keys pending)
+    logFunctionText logger Debug $ "pruneInternal: pending txs pre-filter: " <> sshow (Map.keys pending)
     logFunctionText logger Debug $ "pruneInternal: current time (micros): " <> sshow now
-    forM_ (HashMap.toList pending) $ \(h, pe) ->
+    forM_ (Map.toList pending) $ \(h, pe) ->
         logFunctionText logger Debug $ "pruneInternal: (pending tx, expiration): " <> sshow (h, _inmemPeExpires pe)
-    !pending' <- evaluate $ force $ HashMap.filter flt pending
-    logFunctionText logger Debug $ "pruneInternal: pending txs post-filter: " <> sshow (HashMap.keys pending')
+    !pending' <- evaluate $ force $ Map.filter flt pending
+    logFunctionText logger Debug $ "pruneInternal: pending txs post-filter: " <> sshow (Map.keys pending')
     writeIORef pref pending'
 
     let bref = _inmemBadMap mdata
     badMapBefore <- readIORef bref
-    logFunctionText logger Debug $ "pruneInternal: bad txs before prune: " <> sshow (HashMap.keys badMapBefore)
+    logFunctionText logger Debug $ "pruneInternal: bad txs before prune: " <> sshow (Map.keys badMapBefore)
     !badmap <- (force . pruneBadMap) <$!> readIORef bref
-    logFunctionText logger Debug $ "pruneInternal: bad txs after prune: " <> sshow (HashMap.keys badMapBefore)
+    logFunctionText logger Debug $ "pruneInternal: bad txs after prune: " <> sshow (Map.keys badMapBefore)
     writeIORef bref badmap
 
   where
     -- keep transactions that expire in the future.
     flt pe = _inmemPeExpires pe > now
-    pruneBadMap = HashMap.filter (> now)
+    pruneBadMap = Map.filter (> now)

--- a/src/Chainweb/Mempool/InMemTypes.hs
+++ b/src/Chainweb/Mempool/InMemTypes.hs
@@ -28,7 +28,7 @@ import Control.DeepSeq
 import Data.Aeson
 import qualified Data.ByteString.Short as SB
 import Data.Function (on)
-import Data.HashMap.Strict (HashMap)
+import Data.Map.Strict (Map)
 import Data.IORef (IORef)
 import Data.Ord
 import qualified Data.Vector as V
@@ -55,7 +55,7 @@ data PendingEntry = PendingEntry
 instance Ord PendingEntry where
     compare = compare `on` (Down . _inmemPeGasPrice)
 
-type PendingMap = HashMap TransactionHash PendingEntry
+type PendingMap = Map TransactionHash PendingEntry
 
 ------------------------------------------------------------------------------
 -- | Configuration for in-memory mempool.
@@ -85,7 +85,7 @@ data InMemoryMempool t = InMemoryMempool {
 
 
 ------------------------------------------------------------------------------
-type BadMap = HashMap TransactionHash (Time Micros)
+type BadMap = Map TransactionHash (Time Micros)
 
 ------------------------------------------------------------------------------
 data InMemoryMempoolData t = InMemoryMempoolData {


### PR DESCRIPTION
This is safer against DoS than the HashMap is, and the performance is the same, if not slightly better.

<details>
<summary>Benchmarks before</summary>

```
benchmarking mempool/mempoolGetBlock 1
time                 12.25 μs   (11.54 μs .. 12.82 μs)
                     0.984 R²   (0.979 R² .. 0.990 R²)
mean                 11.88 μs   (11.29 μs .. 12.49 μs)
std dev              1.313 μs   (1.115 μs .. 1.604 μs)
variance introduced by outliers: 87% (severely inflated)

benchmarking mempool/mempoolGetBlock 16
time                 116.4 μs   (115.9 μs .. 116.8 μs)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 116.2 μs   (115.7 μs .. 116.6 μs)
std dev              1.370 μs   (1.118 μs .. 1.840 μs)

benchmarking mempool/mempoolGetBlock 64
time                 435.5 μs   (433.1 μs .. 437.4 μs)
                     1.000 R²   (0.999 R² .. 1.000 R²)
mean                 433.0 μs   (430.4 μs .. 434.8 μs)
std dev              7.898 μs   (6.610 μs .. 10.39 μs)
variance introduced by outliers: 10% (moderately inflated)

benchmarking mempool/mempoolGetBlock 256
time                 2.062 ms   (2.036 ms .. 2.094 ms)
                     0.997 R²   (0.994 R² .. 0.999 R²)
mean                 2.104 ms   (2.073 ms .. 2.136 ms)
std dev              123.0 μs   (81.08 μs .. 177.4 μs)
variance introduced by outliers: 45% (moderately inflated)

benchmarking mempool/mempoolGetBlock 1024
time                 8.575 ms   (8.365 ms .. 8.743 ms)
                     0.994 R²   (0.987 R² .. 0.998 R²)
mean                 8.885 ms   (8.704 ms .. 9.188 ms)
std dev              818.2 μs   (489.8 μs .. 1.325 ms)
variance introduced by outliers: 57% (severely inflated)

benchmarking mempool/mempoolGetBlock 4096
time                 36.05 ms   (34.92 ms .. 37.72 ms)
                     0.994 R²   (0.989 R² .. 0.999 R²)
mean                 35.00 ms   (34.36 ms .. 35.65 ms)
std dev              1.633 ms   (1.272 ms .. 2.360 ms)
variance introduced by outliers: 18% (moderately inflated)

benchmarking mempool/mempoolGetBlockHalfExcludedHashes 1
time                 10.81 μs   (10.48 μs .. 11.36 μs)
                     0.984 R²   (0.979 R² .. 0.990 R²)
mean                 11.20 μs   (10.73 μs .. 11.84 μs)
std dev              1.349 μs   (1.053 μs .. 1.522 μs)
variance introduced by outliers: 89% (severely inflated)

benchmarking mempool/mempoolGetBlockHalfExcludedHashes 16
time                 66.28 μs   (65.81 μs .. 66.77 μs)
                     1.000 R²   (0.999 R² .. 1.000 R²)
mean                 66.21 μs   (65.67 μs .. 66.73 μs)
std dev              1.587 μs   (1.256 μs .. 1.939 μs)
variance introduced by outliers: 20% (moderately inflated)

benchmarking mempool/mempoolGetBlockHalfExcludedHashes 64
time                 224.8 μs   (223.9 μs .. 226.0 μs)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 224.9 μs   (224.3 μs .. 225.6 μs)
std dev              2.393 μs   (1.948 μs .. 3.146 μs)

benchmarking mempool/mempoolGetBlockHalfExcludedHashes 256
time                 1.094 ms   (1.076 ms .. 1.122 ms)
                     0.997 R²   (0.995 R² .. 0.999 R²)
mean                 1.091 ms   (1.081 ms .. 1.105 ms)
std dev              48.49 μs   (37.36 μs .. 66.23 μs)
variance introduced by outliers: 35% (moderately inflated)

benchmarking mempool/mempoolGetBlockHalfExcludedHashes 1024
time                 4.638 ms   (4.558 ms .. 4.727 ms)
                     0.990 R²   (0.976 R² .. 0.998 R²)
mean                 4.746 ms   (4.648 ms .. 4.920 ms)
std dev              435.5 μs   (287.8 μs .. 719.0 μs)
variance introduced by outliers: 62% (severely inflated)

benchmarking mempool/mempoolGetBlockHalfExcludedHashes 4096
time                 18.22 ms   (17.76 ms .. 18.60 ms)
                     0.996 R²   (0.992 R² .. 0.998 R²)
mean                 18.71 ms   (18.47 ms .. 19.19 ms)
std dev              853.6 μs   (544.1 μs .. 1.266 ms)
variance introduced by outliers: 18% (moderately inflated)

benchmarking mempool/mempoolInsertChecked
time                 3.658 ms   (3.596 ms .. 3.713 ms)
                     0.998 R²   (0.997 R² .. 0.999 R²)
mean                 3.601 ms   (3.555 ms .. 3.645 ms)
std dev              144.5 μs   (117.5 μs .. 184.1 μs)
variance introduced by outliers: 25% (moderately inflated)

benchmarking mempool/mempoolInsert
time                 2.351 ms   (2.319 ms .. 2.377 ms)
                     0.999 R²   (0.998 R² .. 0.999 R²)
mean                 2.321 ms   (2.295 ms .. 2.350 ms)
std dev              100.1 μs   (76.24 μs .. 132.7 μs)
variance introduced by outliers: 30% (moderately inflated)

benchmarking mempool/mempoolAddToBadList
time                 615.5 μs   (605.8 μs .. 625.3 μs)
                     0.997 R²   (0.995 R² .. 0.999 R²)
mean                 617.6 μs   (610.3 μs .. 639.0 μs)
std dev              37.25 μs   (24.81 μs .. 61.12 μs)
variance introduced by outliers: 52% (severely inflated)

benchmarking mempool/mempoolPrune
time                 167.9 μs   (167.2 μs .. 168.5 μs)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 167.6 μs   (166.9 μs .. 168.5 μs)
std dev              1.903 μs   (1.303 μs .. 2.913 μs)

benchmarking mempool/mempoolPruneExpired
time                 149.9 μs   (149.1 μs .. 150.8 μs)
                     1.000 R²   (0.999 R² .. 1.000 R²)
mean                 149.7 μs   (149.0 μs .. 151.3 μs)
std dev              2.161 μs   (1.130 μs .. 3.241 μs)

1,074,688,622,368 bytes allocated in the heap
 113,081,523,512 bytes copied during GC
      18,448,744 bytes maximum residency (3282 sample(s))
         857,760 bytes maximum slop
              90 MiB total memory in use (0 MiB lost due to fragmentation)

                                     Tot time (elapsed)  Avg pause  Max pause
  Gen  0     1070086 colls, 1070086 par   65.350s  38.828s     0.0000s    0.0081s
  Gen  1      3282 colls,  3281 par   28.515s   8.528s     0.0026s    0.0148s

  Parallel GC work balance: 25.98% (serial 0%, perfect 100%)

  TASKS: 18 (1 bound, 17 peak workers (17 total), using -N8)

  SPARKS: 34 (34 converted, 0 overflowed, 0 dud, 0 GC'd, 0 fizzled)

  INIT    time    0.001s  (  0.001s elapsed)
  MUT     time  186.303s  (164.792s elapsed)
  GC      time   93.865s  ( 47.356s elapsed)
  EXIT    time    0.001s  (  0.000s elapsed)
  Total   time  280.170s  (212.150s elapsed)

  Alloc rate    5,768,499,947 bytes per MUT second

  Productivity  66.5% of total user, 77.7% of total elapsed
```

</details>

<details>

<summary>Benchmarks after</summary>

```
benchmarking mempool/mempoolGetBlock 1
time                 9.438 μs   (9.117 μs .. 9.935 μs)
                     0.990 R²   (0.983 R² .. 0.999 R²)
mean                 9.369 μs   (9.100 μs .. 10.00 μs)
std dev              811.2 ns   (235.4 ns .. 1.314 μs)
variance introduced by outliers: 80% (severely inflated)

benchmarking mempool/mempoolGetBlock 16
time                 105.9 μs   (105.0 μs .. 106.9 μs)
                     0.999 R²   (0.999 R² .. 1.000 R²)
mean                 105.0 μs   (104.3 μs .. 105.8 μs)
std dev              2.385 μs   (1.829 μs .. 3.090 μs)
variance introduced by outliers: 18% (moderately inflated)

benchmarking mempool/mempoolGetBlock 64
time                 410.8 μs   (408.9 μs .. 412.4 μs)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 407.9 μs   (406.0 μs .. 409.5 μs)
std dev              6.679 μs   (5.264 μs .. 8.068 μs)

benchmarking mempool/mempoolGetBlock 256
time                 1.883 ms   (1.854 ms .. 1.914 ms)
                     0.997 R²   (0.995 R² .. 0.998 R²)
mean                 1.883 ms   (1.858 ms .. 1.908 ms)
std dev              96.28 μs   (78.14 μs .. 129.9 μs)
variance introduced by outliers: 40% (moderately inflated)

benchmarking mempool/mempoolGetBlock 1024
time                 8.267 ms   (8.133 ms .. 8.407 ms)
                     0.998 R²   (0.996 R² .. 0.999 R²)
mean                 8.234 ms   (8.160 ms .. 8.297 ms)
std dev              208.7 μs   (174.6 μs .. 262.4 μs)

benchmarking mempool/mempoolGetBlock 4096
time                 32.66 ms   (32.17 ms .. 33.00 ms)
                     0.999 R²   (0.997 R² .. 1.000 R²)
mean                 33.24 ms   (32.92 ms .. 33.53 ms)
std dev              691.3 μs   (447.4 μs .. 998.9 μs)

benchmarking mempool/mempoolGetBlockHalfExcludedHashes 1
time                 9.954 μs   (9.603 μs .. 10.25 μs)
                     0.993 R²   (0.991 R² .. 0.997 R²)
mean                 9.812 μs   (9.493 μs .. 10.17 μs)
std dev              737.8 ns   (538.1 ns .. 911.1 ns)
variance introduced by outliers: 75% (severely inflated)

benchmarking mempool/mempoolGetBlockHalfExcludedHashes 16
time                 59.85 μs   (59.03 μs .. 60.68 μs)
                     0.999 R²   (0.998 R² .. 0.999 R²)
mean                 58.65 μs   (58.25 μs .. 59.22 μs)
std dev              1.444 μs   (1.100 μs .. 1.898 μs)
variance introduced by outliers: 22% (moderately inflated)

benchmarking mempool/mempoolGetBlockHalfExcludedHashes 64
time                 210.1 μs   (208.1 μs .. 211.7 μs)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 208.7 μs   (207.9 μs .. 209.5 μs)
std dev              2.779 μs   (2.102 μs .. 3.648 μs)

benchmarking mempool/mempoolGetBlockHalfExcludedHashes 256
time                 894.1 μs   (883.8 μs .. 906.4 μs)
                     0.999 R²   (0.999 R² .. 0.999 R²)
mean                 896.1 μs   (887.4 μs .. 904.2 μs)
std dev              31.82 μs   (23.36 μs .. 46.68 μs)
variance introduced by outliers: 27% (moderately inflated)

benchmarking mempool/mempoolGetBlockHalfExcludedHashes 1024
time                 4.196 ms   (4.125 ms .. 4.286 ms)
                     0.996 R²   (0.993 R² .. 0.998 R²)
mean                 4.222 ms   (4.168 ms .. 4.325 ms)
std dev              247.3 μs   (178.7 μs .. 366.8 μs)
variance introduced by outliers: 40% (moderately inflated)

benchmarking mempool/mempoolGetBlockHalfExcludedHashes 4096
time                 17.35 ms   (17.01 ms .. 17.70 ms)
                     0.994 R²   (0.988 R² .. 0.998 R²)
mean                 17.62 ms   (17.33 ms .. 18.01 ms)
std dev              904.3 μs   (660.6 μs .. 1.225 ms)
variance introduced by outliers: 21% (moderately inflated)

benchmarking mempool/mempoolInsertChecked
time                 3.655 ms   (3.587 ms .. 3.760 ms)
                     0.995 R²   (0.991 R² .. 0.998 R²)
mean                 3.707 ms   (3.639 ms .. 3.830 ms)
std dev              312.7 μs   (150.0 μs .. 595.5 μs)
variance introduced by outliers: 60% (severely inflated)

benchmarking mempool/mempoolInsert
time                 2.641 ms   (2.609 ms .. 2.693 ms)
                     0.998 R²   (0.995 R² .. 0.999 R²)
mean                 2.625 ms   (2.602 ms .. 2.655 ms)
std dev              94.88 μs   (73.77 μs .. 129.3 μs)
variance introduced by outliers: 23% (moderately inflated)

benchmarking mempool/mempoolAddToBadList
time                 385.6 μs   (379.9 μs .. 390.1 μs)
                     0.999 R²   (0.998 R² .. 0.999 R²)
mean                 383.4 μs   (379.5 μs .. 386.1 μs)
std dev              11.20 μs   (9.082 μs .. 13.99 μs)
variance introduced by outliers: 21% (moderately inflated)

benchmarking mempool/mempoolPrune
time                 136.4 μs   (136.0 μs .. 137.3 μs)
                     0.999 R²   (0.999 R² .. 1.000 R²)
mean                 137.2 μs   (136.6 μs .. 138.4 μs)
std dev              1.705 μs   (1.152 μs .. 2.240 μs)

benchmarking mempool/mempoolPruneExpired
time                 123.0 μs   (122.1 μs .. 123.8 μs)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 122.4 μs   (121.7 μs .. 123.0 μs)
std dev              1.619 μs   (1.010 μs .. 2.434 μs)

1,038,789,173,304 bytes allocated in the heap
 121,034,775,432 bytes copied during GC
      17,336,592 bytes maximum residency (3349 sample(s))
         832,712 bytes maximum slop
              87 MiB total memory in use (0 MiB lost due to fragmentation)

                                     Tot time (elapsed)  Avg pause  Max pause
  Gen  0     1199992 colls, 1199992 par   67.893s  38.501s     0.0000s    0.0072s
  Gen  1      3349 colls,  3348 par   28.359s   8.383s     0.0025s    0.0131s

  Parallel GC work balance: 25.31% (serial 0%, perfect 100%)

  TASKS: 18 (1 bound, 17 peak workers (17 total), using -N8)

  SPARKS: 34 (34 converted, 0 overflowed, 0 dud, 0 GC'd, 0 fizzled)

  INIT    time    0.001s  (  0.001s elapsed)
  MUT     time  205.082s  (178.018s elapsed)
  GC      time   96.252s  ( 46.884s elapsed)
  EXIT    time    0.001s  (  0.000s elapsed)
  Total   time  301.336s  (224.902s elapsed)

  Alloc rate    5,065,246,636 bytes per MUT second

  Productivity  68.1% of total user, 79.2% of total elapsed
```

</details>

Change-Id: Id0000000198ca7d8eaf77efc62f42dcbe180a9a4