### PR TITLE
Stop node after initial cut is reached, if it's configured

### DIFF
--- a/src/Chainweb/Chainweb.hs
+++ b/src/Chainweb/Chainweb.hs
@@ -88,7 +88,6 @@ module Chainweb.Chainweb
 , CutConfig(..)
 , cutFetchTimeout
 , cutInitialBlockHeightLimit
-, cutFastForwardBlockHeightLimit
 , defaultCutConfig
 
 ) where
@@ -228,11 +227,13 @@ withChainweb c logger rocksDb defaultPactDbDir backupDir inner =
             %~ (\x -> L.nub $ x <> _versionBootstraps (c ^. configChainwebVersion)) $ c
 
 data StartedChainweb logger where
-  StartedChainweb
-    :: (Logger logger)
-    => !(Chainweb logger)
-    -> StartedChainweb logger
-  Replayed :: !Cut -> !(Maybe Cut) -> StartedChainweb logger
+    StartedChainweb
+        :: (Logger logger)
+        => !(Chainweb logger)
+        -> StartedChainweb logger
+    RewoundToCut
+        :: !Cut
+        -> StartedChainweb logger
 
 data ChainwebStatus
     = ProcessStarted
@@ -328,8 +329,7 @@ withChainwebInternal conf logger peerRes serviceSock rocksDb defaultPactDbDir ba
         { _cutDbParamsLogLevel = Info
         , _cutDbParamsTelemetryLevel = Info
         , _cutDbParamsInitialHeightLimit = _cutInitialBlockHeightLimit cutConf
-        , _cutDbParamsFastForwardHeightLimit = _cutFastForwardBlockHeightLimit cutConf
-        , _cutDbParamsReadOnly = _configOnlySync conf || _configReadOnlyReplay conf
+        , _cutDbParamsReadOnly = _configReadOnlyReplay conf
         , _cutDbParamsInitialCutFile = _cutInitialCutFile cutConf
         }
       where
@@ -369,89 +369,76 @@ withChainwebInternal conf logger peerRes serviceSock rocksDb defaultPactDbDir ba
         liftIO $ logg Debug "start initializing cut resources"
         liftIO $ logFunctionJson logger Info InitializingCutResources
 
-        cuts <- withCutResources cutLogger cutDbParams p2pConfig myInfo peerDb rocksDb webchain providers mgr
-        liftIO $ do
-            logg Debug "finished initializing cut resources"
+        initialCutOrCutResources <- withCutResources cutLogger cutDbParams p2pConfig myInfo peerDb rocksDb webchain providers mgr
+        liftIO $ case initialCutOrCutResources of
+            Left initialCut -> do
+                logg Info "no cut resources, chainweb will not continue"
+                inner (RewoundToCut initialCut)
+            Right cutResources -> do
+                logg Debug "finished initializing cut resources"
 
-            let !mLogger = setComponent "miner" logger
-                !mConf = _configMining conf
-                !mCutDb = _cutResCutDb cuts
-                !throt  = _configThrottling conf
+                let !mLogger = setComponent "miner" logger
+                    !mConf = _configMining conf
+                    !mCutDb = _cutResCutDb cutResources
+                    !throt  = _configThrottling conf
 
-            -- initialize throttler
-            throttler <- mkGenericThrottler $ _throttlingRate throt
-            putPeerThrottler <- mkPutPeerThrottler $ _throttlingPeerRate throt
-            mempoolThrottler <- mkMempoolThrottler $ _throttlingMempoolRate throt
-            logg Debug "initialized throttlers"
+                -- initialize throttler
+                throttler <- mkGenericThrottler $ _throttlingRate throt
+                putPeerThrottler <- mkPutPeerThrottler $ _throttlingPeerRate throt
+                mempoolThrottler <- mkMempoolThrottler $ _throttlingMempoolRate throt
+                logg Debug "initialized throttlers"
 
-            -- synchronize pact dbs with latest cut before we start the server
-            -- and clients and begin mining.
-            --
-            -- This is a consistency check that validates the blocks in the
-            -- current cut. If it fails an exception is raised. Also, if it
-            -- takes long (for example, when doing a reset to a prior block
-            -- height) we want this to happen before we go online.
-            --
-            let
-                -- pactSyncChains =
-                --     case _configSyncPactChains conf of
-                --         Just syncChains
-                --             | _configOnlySyncPact conf || _configReadOnlyReplay conf
-                --             -> HM.filterWithKey (\k _ -> elem k syncChains) cs
-                --         _ -> cs
+                -- synchronize pact dbs with latest cut before we start the server
+                -- and clients and begin mining.
+                --
+                -- This is a consistency check that validates the blocks in the
+                -- current cut. If it fails an exception is raised. Also, if it
+                -- takes long (for example, when doing a reset to a prior block
+                -- height) we want this to happen before we go online.
+                --
+                let
+                    -- pactSyncChains =
+                    --     case _configSyncPactChains conf of
+                    --         Just syncChains
+                    --             | _configReadOnlyReplay conf
+                    --             -> HM.filterWithKey (\k _ -> elem k syncChains) cs
+                    --         _ -> cs
 
-            if _configReadOnlyReplay conf
-              then do
-                -- FIXME implement replay in payload provider
-                error "Chainweb.Chainweb.withChainwebInternal: pact replay is not supported"
-                -- logFunctionJson logger Info PactReplayInProgress
-                -- -- note that we don't use the "initial cut" from cutdb because its height depends on initialBlockHeightLimit.
-                -- highestCut <-
-                --     unsafeMkCut v <$> readHighestCutHeaders v (logFunctionText logger) webchain (cutHashesTable rocksDb)
-                -- lowerBoundCut <-
-                --     tryLimitCut webchain (fromMaybe 0 $ _cutInitialBlockHeightLimit $ _configCuts conf) highestCut
-                -- upperBoundCut <- forM (_cutFastForwardBlockHeightLimit $ _configCuts conf) $ \upperBound ->
-                --     tryLimitCut webchain upperBound highestCut
-                -- let
-                --     replayOneChain :: (ChainResources logger, (BlockHeader, Maybe BlockHeader)) -> IO ()
-                --     replayOneChain (cr, (l, u)) = do
-                --         let chainPact = _chainResPact cr
-                --         let logCr = logFunctionText
-                --                 $ addLabel ("component", "pact")
-                --                 $ addLabel ("sub-component", "init")
-                --                 $ _chainResLogger cr
-                --         void $ _pactReadOnlyReplay chainPact l u
-                --         logCr Info "pact db synchronized"
-                -- let bounds =
-                --         HM.intersectionWith (,)
-                --             pactSyncChains
-                --             (HM.mapWithKey
-                --                 (\cid bh ->
-                --                     (bh, (HM.! cid) . _cutMap <$> upperBoundCut))
-                --                 (_cutMap lowerBoundCut)
-                --             )
-                -- mapConcurrently_ replayOneChain bounds
-                -- logg Info "finished fast forward replay"
-                -- logFunctionJson logger Info PactReplaySuccessful
-                -- inner $ Replayed lowerBoundCut upperBoundCut
-              else
-                if _configOnlySync conf
-                  then do
+                if _configReadOnlyReplay conf
+                then do
+                    -- FIXME implement replay in payload provider
                     error "Chainweb.Chainweb.withChainwebInternal: pact replay is not supported"
-                    -- initialCut <- _cut mCutDb
-                    -- logg Info "start synchronizing Pact DBs to initial cut"
-                    -- logFunctionJson logger Info InitialSyncInProgress
-                    -- synchronizePactDb pactSyncChains initialCut
-                    -- logg Info "finished synchronizing Pact DBs to initial cut"
                     -- logFunctionJson logger Info PactReplayInProgress
-                    -- logg Info "start replaying Pact DBs to fast forward cut"
-                    -- fastForwardCutDb mCutDb
-                    -- newCut <- _cut mCutDb
-                    -- synchronizePactDb pactSyncChains newCut
-                    -- logg Info "finished replaying Pact DBs to fast forward cut"
+                    -- -- note that we don't use the "initial cut" from cutdb because its height depends on initialBlockHeightLimit.
+                    -- highestCut <-
+                    --     unsafeMkCut v <$> readHighestCutHeaders v (logFunctionText logger) webchain (cutHashesTable rocksDb)
+                    -- lowerBoundCut <-
+                    --     tryLimitCut webchain (fromMaybe 0 $ _cutInitialBlockHeightLimit $ _configCuts conf) highestCut
+                    -- upperBoundCut <- forM (_cutFastForwardBlockHeightLimit $ _configCuts conf) $ \upperBound ->
+                    --     tryLimitCut webchain upperBound highestCut
+                    -- let
+                    --     replayOneChain :: (ChainResources logger, (BlockHeader, Maybe BlockHeader)) -> IO ()
+                    --     replayOneChain (cr, (l, u)) = do
+                    --         let chainPact = _chainResPact cr
+                    --         let logCr = logFunctionText
+                    --                 $ addLabel ("component", "pact")
+                    --                 $ addLabel ("sub-component", "init")
+                    --                 $ _chainResLogger cr
+                    --         void $ _pactReadOnlyReplay chainPact l u
+                    --         logCr Info "pact db synchronized"
+                    -- let bounds =
+                    --         HM.intersectionWith (,)
+                    --             pactSyncChains
+                    --             (HM.mapWithKey
+                    --                 (\cid bh ->
+                    --                     (bh, (HM.! cid) . _cutMap <$> upperBoundCut))
+                    --                 (_cutMap lowerBoundCut)
+                    --             )
+                    -- mapConcurrently_ replayOneChain bounds
+                    -- logg Info "finished fast forward replay"
                     -- logFunctionJson logger Info PactReplaySuccessful
-                    -- inner $ Replayed initialCut (Just newCut)
-                  else do
+                    -- inner $ Replayed lowerBoundCut upperBoundCut
+                else do
                         logg Debug "start initializing miner resources"
                         logFunctionJson logger Info InitializingMinerResources
 
@@ -468,7 +455,7 @@ withChainwebInternal conf logger peerRes serviceSock rocksDb defaultPactDbDir ba
                                 inner $ StartedChainweb Chainweb
                                     { _chainwebHostAddress = haddr
                                     , _chainwebChains = cs
-                                    , _chainwebCutResources = cuts
+                                    , _chainwebCutResources = cutResources
                                     , _chainwebMiner = m
                                     , _chainwebCoordinator = mc
                                     , _chainwebLogger = logger

--- a/test/lib/Chainweb/Test/Utils.hs
+++ b/test/lib/Chainweb/Test/Utils.hs
@@ -1015,7 +1015,7 @@ node rdb rawLogger nowServingRef peerInfoVar conf pactDbDir backupDir nid = do
                 logFunctionText logger Info "write sample data"
                 logFunctionText logger Info "shutdown node"
             return ()
-        Replayed _ _ -> error "node: should not be a replay"
+        RewoundToCut _ -> error "node: should not be a replay"
   where
     logger = addLabel ("node", sshow nid) rawLogger
 

--- a/test/unit/Chainweb/Test/CutDB.hs
+++ b/test/unit/Chainweb/Test/CutDB.hs
@@ -142,7 +142,7 @@ withTestCutDb rdb conf n providers logger = do
     webDb <- liftIO $ initWebBlockHeaderDb rocksDb
     mgr <- liftIO $ HTTP.newManager HTTP.defaultManagerSettings
     headerStore <- withLocalWebBlockHeaderStore mgr webDb
-    cutDb <- withCutDb (conf $ defaultCutDbParams cutFetchTimeout) logger headerStore providers cutHashesDb
+    Right cutDb <- withCutDb (conf $ defaultCutDbParams cutFetchTimeout) logger headerStore providers cutHashesDb
     liftIO $ synchronizeProviders webDb genesisCut
 
     liftIO $ logFunctionText logger Debug "GOING TO MINE AT THE START"
@@ -299,7 +299,7 @@ startTestPayload rdb logger n = do
     mgr <- HTTP.newManager HTTP.defaultManagerSettings
     (hserver, hstore) <- startLocalWebBlockHeaderStore mgr webDb
     let disabledPayloadProviders = onAllChains DisabledPayloadProvider
-    cutDb <- startCutDb (defaultCutDbParams cutFetchTimeout) logger hstore disabledPayloadProviders cutHashesDb
+    Right cutDb <- startCutDb (defaultCutDbParams cutFetchTimeout) logger hstore disabledPayloadProviders cutHashesDb
     foldM_ (\c _ -> view _1 <$> mine logger cutDb c) genesisCut [0..n]
     return (hserver, cutDb)
 


### PR DESCRIPTION
Initial cut configuration is essentially a recovery mode, so the node should not continue as usual after it's been reset to. 

Change-Id: Id00000005392c4e5d45fb6bf9d6299a02f2ef733