### PR TITLE
Improve cut fetching for larger graphs during catchup

### DIFF
--- a/src/Chainweb/CutDB/Sync.hs
+++ b/src/Chainweb/CutDB/Sync.hs
@@ -82,7 +82,7 @@ getCut (CutClientEnv env) h = runClientThrowM (cutGetClientLimit (int h)) env
 -- times the number of chains.
 --
 catchupStepSize :: CutHeight
-catchupStepSize = 100
+catchupStepSize = 500
 
 syncSession
     :: HasVersion


### PR DESCRIPTION
Currently the cut validation code fetches the headers of a new cut sequentially. Fetching of dependencies for cut headers is done concurrently. This PR parallelizes fetching of the top-level headers of the cut itself, too.

For small numbers of chains and comparatively large catchup step sizes, this change makes only a small difference. However, for larger numbers of chains and comparatively small catchup step sizes this change can result in larger performance gains.

For caught up nodes, that only new to fetch a small number of blocks for each new cut, this change also only makes a small difference.

Additionally, the PR increases the catchup step size somewhat, experiments showed that this moderate increase result can result in substantial performance improvements.