### PR TITLE
Turn CutClientEnv into a newtype

### DIFF
--- a/src/Chainweb/CutDB/Sync.hs
+++ b/src/Chainweb/CutDB/Sync.hs
@@ -48,9 +48,7 @@ import P2P.Session
 -- -------------------------------------------------------------------------- --
 -- Client Env
 
-data CutClientEnv = CutClientEnv
-    { _envClientEnv :: !ClientEnv
-    }
+newtype CutClientEnv = CutClientEnv { _envClientEnv :: ClientEnv }
     deriving (Generic)
 
 runClientThrowM :: ClientM a -> ClientEnv -> IO a


### PR DESCRIPTION
`CutClientEnv` has only a single constructor and should be a `newtype`