### PR TITLE
Cleanup some import lists

### DIFF
--- a/chainweb.cabal
+++ b/chainweb.cabal
@@ -544,7 +544,6 @@ library chainweb-test-utils
         , bytestring >= 0.10.12
         , case-insensitive >= 1.2
         , chainweb-storage >= 0.1
-        , chronos >= 1.1
         , containers >= 0.5
         , crypton-connection >=0.4
         , data-dword >= 0.3
@@ -553,8 +552,6 @@ library chainweb-test-utils
         , directory >= 1.2
         , exceptions
         , filepath >= 1.4
-        , hashable
-        , hashes >=0.2.2.0
         , http-client >= 0.5
         , http-types >= 0.12
         , lens >= 4.17
@@ -701,7 +698,6 @@ test-suite chainweb-tests
         , crypton-connection >=0.4
         , data-dword >= 0.3
         , data-ordlist >= 0.4.7
-        , deepseq >= 1.4
         , direct-sqlite >= 2.3.27
         , ethereum
         , exceptions
@@ -726,10 +722,8 @@ test-suite chainweb-tests
         , pact-tng:pact-request-api
         , pact-tng:test-utils
         , pact-tng:pact-repl
-        , patience >= 0.3
         , prettyprinter
         , property-matchers ^>= 0.7
-        , pretty-show
         , quickcheck-instances >= 0.3
         , random >= 1.3
         , raw-strings-qq >=1.1
@@ -739,10 +733,8 @@ test-suite chainweb-tests
         , scheduler >= 1.4
         , servant-client >= 0.18.2
         , sha-validation >=0.1
-        , statistics >= 0.15
         , stm
         , streaming >= 0.2.2
-        , strict-concurrency >= 0.2
         , tasty >= 1.0
         , tasty-hedgehog >= 1.4.0.2
         , tasty-hunit >= 0.9
@@ -757,12 +749,12 @@ test-suite chainweb-tests
         , wai >= 3.2
         , warp >= 3.3.6
         , warp-tls >= 3.4
-        , yaml >= 0.11
     if flag(ed25519)
         cpp-options: -DWITH_ED25519=1
 
 test-suite compaction-tests
     import: warning-flags, debugging-flags
+    buildable: False
     default-language: Haskell2010
     type: exitcode-stdio-1.0
     ghc-options:

--- a/src/Chainweb/BlockHeaderDB/Internal.hs
+++ b/src/Chainweb/BlockHeaderDB/Internal.hs
@@ -48,7 +48,6 @@ import Control.Exception.Safe
 import Control.DeepSeq
 import Control.Lens hiding (children)
 import Control.Monad
-import Control.Monad.Trans.Maybe
 import Control.Monad.Trans.Resource hiding (throwM)
 
 import Data.Aeson

--- a/src/Chainweb/BlockHeaderDB/RemoteDB.hs
+++ b/src/Chainweb/BlockHeaderDB/RemoteDB.hs
@@ -21,7 +21,6 @@ module Chainweb.BlockHeaderDB.RemoteDB
   , remoteDb
   ) where
 
-import Control.Error.Util (hush)
 import Control.Lens
 import Control.Monad.Catch (handle, throwM)
 

--- a/src/Chainweb/BlockHeaderDB/RestAPI/Server.hs
+++ b/src/Chainweb/BlockHeaderDB/RestAPI/Server.hs
@@ -45,7 +45,6 @@ import Data.Foldable
 import Data.Function
 import Data.Functor.Of
 import Data.IORef
-import qualified Data.Map.Strict as Map
 import Data.Proxy
 import Data.Text.Encoding (decodeUtf8)
 import Numeric.Natural(Natural)
@@ -73,7 +72,6 @@ import Chainweb.RestAPI.Utils
 import Chainweb.TreeDB
 import Chainweb.Utils.Paging
 import Chainweb.Version
-import qualified Data.Text as Text
 
 -- -------------------------------------------------------------------------- --
 -- Handler Tools

--- a/src/Chainweb/BlockHeaderDB/RestAPI/Server.hs
+++ b/src/Chainweb/BlockHeaderDB/RestAPI/Server.hs
@@ -46,6 +46,7 @@ import Data.Function
 import Data.Functor.Of
 import Data.IORef
 import Data.Proxy
+import qualified Data.Text as Text
 import Data.Text.Encoding (decodeUtf8)
 import Numeric.Natural(Natural)
 

--- a/src/Chainweb/Chainweb/ChainResources.hs
+++ b/src/Chainweb/Chainweb/ChainResources.hs
@@ -88,7 +88,6 @@ import Chainweb.Logger
 import Chainweb.Pact.Mempool.InMem qualified as Mempool
 import Chainweb.Pact.Mempool.InMem.ValidatingConfig qualified as Mempool
 import Chainweb.Pact.PactService qualified as Pact
-import Chainweb.Pact.RestAPI qualified as Pact.RestAPI
 import Chainweb.Pact.RestAPI.Server qualified as Pact.RestAPI.Server
 import Chainweb.Pact.Types
 import qualified Chainweb.Pact.Payload.PayloadStore as Pact.Payload.PayloadStore

--- a/src/Chainweb/Chainweb/MempoolSyncClient.hs
+++ b/src/Chainweb/Chainweb/MempoolSyncClient.hs
@@ -19,36 +19,19 @@ module Chainweb.Chainweb.MempoolSyncClient
 
 import Chainweb.Time
 
-import Control.Lens hiding ((.=), (<.>))
-import Control.Monad
-import Control.Monad.Catch
-
-import qualified Data.Text as T
-
 import qualified Network.HTTP.Client as HTTP
 
 import Prelude hiding (log)
 
-import System.LogLevel
-
 -- internal modules
 
-import Chainweb.ChainId
 import Chainweb.Chainweb.ChainResources
 import Chainweb.Chainweb.PeerResources
 import Chainweb.Logger
-import qualified Chainweb.Pact.Mempool.Mempool as Mempool
 import Chainweb.Pact.Mempool.P2pConfig
-import qualified Chainweb.Pact.Mempool.RestAPI.Client as MPC
-import Chainweb.RestAPI.NetworkID
-import Chainweb.Utils
 import Chainweb.Version
 
-import P2P.Node.Configuration
 import P2P.Session
-import P2P.Node
-
-import qualified Servant.Client as Sv
 
 -- -------------------------------------------------------------------------- --
 -- Mempool sync.

--- a/src/Chainweb/Cut/Create.hs
+++ b/src/Chainweb/Cut/Create.hs
@@ -113,7 +113,6 @@ import Data.These
 import GHC.Generics (Generic)
 import GHC.Stack
 import Numeric.Natural
-
 import Chainweb.BlockCreationTime
 import Chainweb.BlockHash
 import Chainweb.BlockHeader
@@ -131,19 +130,17 @@ import Chainweb.Utils.Serialization
 import Chainweb.Version
 import Chainweb.Version.Utils
 import Chainweb.WebBlockHeaderDB
-import Data.Monoid
-import Chainweb.TreeDB hiding (parent)
-import Data.Function
-import qualified Streaming.Prelude as S
-import Data.Foldable
-import Data.Maybe
-import qualified Data.List as List
-import Data.List.NonEmpty (NonEmpty)
-import qualified Data.List.NonEmpty as NE
-import Data.Map.Strict (Map)
-import qualified Data.Map.Strict as Map
-import qualified Streaming as S
 import Chainweb.Ranked (Ranked(_rankedHeight))
+import Chainweb.TreeDB hiding (parent)
+import Data.Foldable
+import Data.Function
+import Data.List qualified as List
+import Data.List.NonEmpty (NonEmpty)
+import Data.List.NonEmpty qualified as NE
+import Data.Maybe
+import Data.Monoid
+import Streaming qualified as S
+import Streaming.Prelude qualified as S
 
 -- -------------------------------------------------------------------------- --
 -- Adjacent Parent Hashes

--- a/src/Chainweb/CutDB.hs
+++ b/src/Chainweb/CutDB.hs
@@ -101,7 +101,7 @@ import Control.Monad.Morph
 import Control.Monad.STM
 import Control.Monad.Trans.Resource hiding (throwM)
 
-import Data.Aeson (ToJSON, decodeStrict')
+import Data.Aeson (ToJSON)
 import Data.Foldable
 import Data.Function
 import Data.Functor.Of

--- a/src/Chainweb/Miner/Coordinator.hs
+++ b/src/Chainweb/Miner/Coordinator.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE BlockArguments #-}
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
@@ -14,14 +15,13 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE PatternGuards #-}
 {-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TupleSections #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE ViewPatterns #-}
-{-# LANGUAGE BlockArguments #-}
-{-# LANGUAGE RecordWildCards #-}
 
 -- |
 -- Module: Chainweb.Miner.Coordinator
@@ -65,7 +65,7 @@ import Chainweb.BlockHeader
 import Chainweb.BlockHeight
 import Chainweb.ChainValue
 import Chainweb.Core.Brief
-import Chainweb.Cut hiding (join)
+import Chainweb.Cut
 import Chainweb.Cut.Create
 import Chainweb.Cut.CutHashes
 import Chainweb.CutDB
@@ -79,37 +79,30 @@ import Chainweb.Storage.Table
 import Chainweb.Time (Micros(..), getCurrentTimeIntegral)
 import Chainweb.Utils hiding (check)
 import Chainweb.Version
-import Chainweb.Version.Utils
 import Chainweb.WebBlockHeaderDB
 import Control.Applicative
-import Control.Concurrent.Async
 import Control.Concurrent.STM (atomically, STM, retry)
 import Control.Concurrent.STM.TVar
-import Control.Concurrent.STM.TMVar
 import Control.Exception.Safe
 import Control.Lens
 import Control.Monad
 import Control.Monad.Except
 import Control.Monad.IO.Class
 import Control.Monad.Trans.Class
-import Data.Foldable
 import Data.HashMap.Strict qualified as HM
 import Data.HashSet qualified as HS
 import Data.Hashable
+import Data.List qualified as List
 import Data.LogMessage (JsonLog(..), LogFunction, LogFunctionText)
-import Data.Map.Strict qualified as M
 import Data.Maybe
 import Data.Text qualified as T
 import Data.Vector qualified as V
 import GHC.Generics (Generic)
-import GHC.Stack
 import Numeric.Natural
+import Pact.JSON.Encode qualified as J
 import Streaming.Prelude qualified as S
 import System.LogLevel (LogLevel(..))
 import System.Random (randomRIO)
-import qualified Data.Aeson as Aeson
-import qualified Data.List as List
-import qualified Pact.JSON.Encode as J
 
 -- -------------------------------------------------------------------------- --
 -- Utils

--- a/src/Chainweb/Pact/Backend/ChainwebPactDb.hs
+++ b/src/Chainweb/Pact/Backend/ChainwebPactDb.hs
@@ -1,26 +1,26 @@
 {-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE BlockArguments #-}
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE EmptyCase #-}
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE ImportQualifiedPost #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE PartialTypeSignatures #-}
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TemplateHaskell #-}
-{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE TupleSections #-}
+{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE BlockArguments #-}
+{-# LANGUAGE ViewPatterns #-}
 
 -- TODO pact5: fix the orphan PactDbFor instance
 {-# OPTIONS_GHC -Wno-orphans #-}
-{-# LANGUAGE TupleSections #-}
-{-# LANGUAGE ViewPatterns #-}
-{-# LANGUAGE RecordWildCards #-}
-{-# LANGUAGE EmptyCase #-}
 
 -- | The database operations that manipulate and read the Pact state.
 

--- a/src/Chainweb/Pact/PactService.hs
+++ b/src/Chainweb/Pact/PactService.hs
@@ -68,7 +68,6 @@ import Chainweb.Pact.Payload
 import Chainweb.Pact.Payload.PayloadStore
 import Chainweb.PayloadProvider
 import Chainweb.PayloadProvider.P2P
-import Chainweb.PayloadProvider.P2P.RestAPI.Client qualified as Rest
 import Chainweb.Ranked
 import Chainweb.Storage.Table
 import Chainweb.Storage.Table.Map qualified as MapTable

--- a/src/Chainweb/Pact/PactService/Checkpointer.hs
+++ b/src/Chainweb/Pact/PactService/Checkpointer.hs
@@ -1,27 +1,27 @@
 {-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE BlockArguments #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveFoldable #-}
+{-# LANGUAGE DeriveFunctor #-}
+{-# LANGUAGE DeriveTraversable #-}
+{-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE EmptyCase #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE ImportQualifiedPost #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MultiWayIf #-}
 {-# LANGUAGE NumericUnderscores #-}
+{-# LANGUAGE OverloadedRecordDot #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TupleSections #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE DataKinds #-}
-{-# LANGUAGE GADTs #-}
-{-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE RecordWildCards #-}
-{-# LANGUAGE OverloadedRecordDot #-}
-{-# LANGUAGE TupleSections #-}
-{-# LANGUAGE BlockArguments #-}
-{-# LANGUAGE DeriveFunctor #-}
-{-# LANGUAGE DeriveFoldable #-}
-{-# LANGUAGE DeriveTraversable #-}
-{-# LANGUAGE ImportQualifiedPost #-}
 
 -- |
 -- Module: Chainweb.Pact.PactService.Checkpointer
@@ -62,19 +62,17 @@ import Data.Maybe
 import Data.Monoid hiding (Product (..))
 import GHC.Stack
 import Prelude hiding (lookup)
-
-import qualified Pact.Core.Persistence.Types as Pact
-
+import Pact.Core.Persistence.Types qualified as Pact
 import Chainweb.BlockCreationTime
 import Chainweb.BlockHash
 import Chainweb.BlockHeader
 import Chainweb.BlockHeight
 import Chainweb.Logger
 import Chainweb.MinerReward
-import qualified Chainweb.Pact.Backend.ChainwebPactDb as ChainwebPactDb
+import Chainweb.Pact.Backend.ChainwebPactDb qualified as ChainwebPactDb
 import Chainweb.Pact.Backend.Types
 import Chainweb.Pact.Backend.Utils
-import qualified Chainweb.Pact.Backend.Utils as PactDb
+import Chainweb.Pact.Backend.Utils qualified as PactDb
 import Chainweb.Pact.Types
 import Chainweb.Parent
 import Chainweb.PayloadProvider
@@ -85,21 +83,19 @@ import Chainweb.Version
 import Chainweb.Version.Guards (pact5)
 import Control.Exception.Safe (MonadMask)
 import Data.List.NonEmpty (NonEmpty)
-import qualified Data.List.NonEmpty as NE
 import Chainweb.Pact.Backend.ChainwebPactDb (lookupRankedBlockHash)
 import Control.Monad.State.Strict
 import System.LogLevel
-import qualified Chainweb.Pact4.Backend.ChainwebPactDb as Pact4
+import Chainweb.Pact4.Backend.ChainwebPactDb qualified as Pact4
 import Control.Concurrent.MVar
-import qualified Pact.Types.Persistence as Pact4
+import Pact.Types.Persistence qualified as Pact4
 import Chainweb.Pact.Backend.DbCache (defaultModuleCacheLimit)
-import qualified Pact.Interpreter as Pact4
-import qualified Data.ByteString.Short as BS
+import Pact.Interpreter qualified as Pact4
+import Data.ByteString.Short qualified as BS
 import Data.Coerce
-import qualified Data.HashMap.Strict as HashMap
-import qualified Pact.Types.Command as Pact4
-import qualified Pact.Types.Hash as Pact4
-import Data.Foldable (foldlM)
+import Data.HashMap.Strict qualified as HashMap
+import Pact.Types.Command qualified as Pact4
+import Pact.Types.Hash qualified as Pact4
 import Data.Foldable1 (foldlMapM1)
 
 -- readFrom demands to know this context in case it's mining a block.

--- a/src/Chainweb/Pact/PactService/ExecBlock.hs
+++ b/src/Chainweb/Pact/PactService/ExecBlock.hs
@@ -24,62 +24,59 @@ module Chainweb.Pact.PactService.ExecBlock
     ) where
 
 import Chainweb.Logger
-import Chainweb.Pact.Mempool.Mempool(BlockFill (..), pactRequestKeyToTransactionHash, InsertError (..))
 import Chainweb.Miner.Pact
-import Chainweb.Pact.Types
-import Chainweb.Pact.Transaction
-import Chainweb.Pact.TransactionExec
+import Chainweb.Pact.Backend.ChainwebPactDb qualified as Pact
+import Chainweb.Pact.Backend.Types
+import Chainweb.Pact.Mempool.Mempool(BlockFill (..), pactRequestKeyToTransactionHash, InsertError (..))
+import Chainweb.Pact.NoCoinbase
 import Chainweb.Pact.Payload
+import Chainweb.Pact.Payload qualified as Chainweb
 import Chainweb.Pact.Payload.PayloadStore
+import Chainweb.Pact.Transaction
+import Chainweb.Pact.Transaction qualified as Pact
+import Chainweb.Pact.TransactionExec
+import Chainweb.Pact.Types
+import Chainweb.Pact.Types qualified as Pact
+import Chainweb.Pact.Validations qualified as Pact
 import Chainweb.Time
 import Chainweb.Utils
 import Chainweb.Version
 import Chainweb.Version.Guards
 import Chronos qualified
-import Control.DeepSeq
-import Control.Exception (evaluate)
 import Control.Lens
 import Control.Monad
 import Control.Monad.Except
 import Control.Monad.IO.Class
-import Control.Monad.Reader
 import Control.Monad.State.Strict
+import Data.Aeson qualified as Aeson
 import Data.ByteString (ByteString)
+import Data.ByteString.Short qualified as SB
 import Data.Coerce
 import Data.Either (partitionEithers)
 import Data.Foldable
+import Data.HashMap.Strict qualified as HashMap
+import Data.List.NonEmpty qualified as NEL
 import Data.Maybe
+import Data.Set qualified as S
 import Data.Text qualified as T
+import Data.Text.Encoding qualified as T
 import Data.Vector (Vector)
 import Data.Vector qualified as V
 import Data.Void
 import Pact.Core.ChainData hiding (ChainId)
+import Pact.Core.ChainData qualified as Pact
 import Pact.Core.Command.Types qualified as Pact
-import Pact.Core.Persistence qualified as Pact
+import Pact.Core.Errors qualified as Pact
+import Pact.Core.Evaluate qualified as Pact
+import Pact.Core.Gas qualified as P
+import Pact.Core.Gas qualified as Pact
 import Pact.Core.Hash
-import qualified Pact.Core.Gas as Pact
-import qualified Pact.JSON.Encode as J
+import Pact.Core.Hash qualified as Pact
+import Pact.Core.Persistence qualified as Pact
+import Pact.JSON.Encode qualified as J
+import System.LogLevel
 import System.Timeout
 import Utils.Logging.Trace
-import qualified Data.Set as S
-import qualified Pact.Core.Gas as P
-import qualified Data.Text.Encoding as T
-import qualified Data.HashMap.Strict as HashMap
-import qualified Chainweb.Pact.Backend.ChainwebPactDb as Pact
-import qualified Chainweb.Pact.Transaction as Pact
-import qualified Chainweb.Pact.Validations as Pact
-import Chainweb.Pact.NoCoinbase
-import Chainweb.Pact.Backend.Types
-import qualified Data.ByteString.Short as SB
-import qualified Pact.Core.Hash as Pact
-import System.LogLevel
-import qualified Data.Aeson as Aeson
-import qualified Data.List.NonEmpty as NEL
-import qualified Pact.Core.Errors as Pact
-import qualified Pact.Core.Evaluate as Pact
-import qualified Pact.Core.ChainData as Pact
-import qualified Chainweb.Pact.Payload as Chainweb
-import qualified Chainweb.Pact.Types as Pact
 
 runCoinbase
     :: (Logger logger)

--- a/src/Chainweb/Pact/Payload/PayloadStore.hs
+++ b/src/Chainweb/Pact/Payload/PayloadStore.hs
@@ -5,6 +5,7 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE InstanceSigs #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE PolyKinds #-}
@@ -14,7 +15,6 @@
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
-{-# LANGUAGE InstanceSigs #-}
 
 -- |
 -- Module: Chainweb.Pact.Payload.PayloadStore
@@ -72,31 +72,20 @@ module Chainweb.Pact.Payload.PayloadStore
 ) where
 
 import Control.Applicative
+import Chainweb.BlockHeight
+import Chainweb.Crypto.MerkleLog
+import Chainweb.MerkleUniverse
+import Chainweb.Pact.Payload
+import Chainweb.Ranked
+import Chainweb.Storage.Table
 import Control.DeepSeq
 import Control.Exception
 import Control.Lens
 import Control.Monad.IO.Class
 import Control.Monad.Trans.Maybe
-
 import Data.Hashable
-import Data.Foldable
-
-import GHC.Generics
-
--- internal modules
-
-import Chainweb.ChainId
-import Chainweb.Crypto.MerkleLog
-import Chainweb.MerkleUniverse
-import Chainweb.Pact.Payload
-import Chainweb.Version
-
-import Chainweb.Storage.Table
-import Chainweb.BlockHeight
-import Chainweb.PayloadProvider.Pact.Genesis
-import Chainweb.BlockPayloadHash (RankedBlockPayloadHash)
-import Chainweb.Ranked
 import Data.Maybe (isJust)
+import GHC.Generics
 
 -- -------------------------------------------------------------------------- --
 -- Exceptions

--- a/src/Chainweb/Pact/SPV.hs
+++ b/src/Chainweb/Pact/SPV.hs
@@ -12,8 +12,7 @@ module Chainweb.Pact.SPV (pactSPV) where
 
 import Control.Lens
 import Control.Monad (when)
-import Control.Monad.Except (ExceptT, runExceptT, throwError)
-import Control.Monad.IO.Class (liftIO)
+import Control.Monad.Except (runExceptT, throwError)
 import Data.Aeson qualified as Aeson
 import Data.Text (Text)
 import Data.Text.Encoding qualified as Text
@@ -24,14 +23,12 @@ import Pact.Core.PactValue (ObjectData(..), PactValue(..))
 import Pact.Core.SPV (SPVSupport(..), ContProof (..))
 import Pact.Core.StableEncoding (encodeStable)
 
-import Chainweb.Crypto.MerkleLog
 import Chainweb.MerkleUniverse
 import Chainweb.Pact.Backend.Types
-import Chainweb.Parent
 import Chainweb.Pact.Payload(TransactionOutput(..))
 import Chainweb.SPV (TransactionOutputProof(..), outputProofChainId)
-import Chainweb.SPV.VerifyProof (runTransactionOutputProof, checkProofAndExtractOutput)
-import Chainweb.Utils (decodeB64UrlNoPaddingText, unlessM)
+import Chainweb.SPV.VerifyProof (checkProofAndExtractOutput)
+import Chainweb.Utils (decodeB64UrlNoPaddingText)
 import Chainweb.Version qualified as CW
 
 pactSPV :: HeaderOracle -> SPVSupport

--- a/src/Chainweb/Pact/Types.hs
+++ b/src/Chainweb/Pact/Types.hs
@@ -137,7 +137,6 @@ import Control.Applicative ((<|>))
 import Control.DeepSeq
 import Control.Lens
 import Control.Monad.IO.Class
-import Control.Monad.State.Strict
 import Data.Aeson hiding (Error, (.=))
 import Data.Bool
 import Data.ByteString (ByteString)
@@ -155,14 +154,12 @@ import GHC.Generics (Generic)
 import Pact.Core.Builtin qualified as Pact
 import Pact.Core.Capabilities qualified as Pact
 import Pact.Core.ChainData qualified as Pact
-import Pact.Core.Command.Types (RequestKey)
 import Pact.Core.Errors qualified as Pact
 import Pact.Core.Evaluate qualified as Pact
 import Pact.Core.Gas.Types qualified as Pact
 import Pact.Core.Hash qualified as Pact
 import Pact.Core.Info qualified as Pact
 import Pact.Core.Literal qualified as Pact
-import Pact.Core.Persistence
 import Pact.Core.StableEncoding qualified as Pact
 import Pact.JSON.Encode qualified as J
 import System.LogLevel
@@ -187,7 +184,6 @@ import Chainweb.Version
 
 import Pact.Core.Command.Types qualified as Pact
 import Pact.Core.Persistence qualified as Pact
-import Pact.Core.SPV qualified as Pact
 import Servant.API
 import Data.List.NonEmpty (NonEmpty)
 import Chainweb.PayloadProvider

--- a/src/Chainweb/Pact/Validations.hs
+++ b/src/Chainweb/Pact/Validations.hs
@@ -59,7 +59,6 @@ import qualified Pact.Core.Hash as Pact
 import qualified Chainweb.Pact.Transaction as Pact
 import Chainweb.Utils (ebool_, int)
 import Chainweb.Version.Guards (maxBlockGasLimit)
-import Control.Monad (forM)
 import Numeric.Natural
 
 

--- a/src/Chainweb/Pact4/SPV.hs
+++ b/src/Chainweb/Pact4/SPV.hs
@@ -47,8 +47,6 @@ import qualified Data.Text as Text
 import qualified Data.Text.Encoding as Text
 import Text.Read (readMaybe)
 
-import Crypto.Hash.Algorithms
-
 import qualified Ethereum.Header as EthHeader
 import Ethereum.Misc
 import Ethereum.Receipt

--- a/src/Chainweb/Pact4/Types.hs
+++ b/src/Chainweb/Pact4/Types.hs
@@ -1,14 +1,15 @@
 {-# LANGUAGE BangPatterns #-}
-{-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE DataKinds #-}
-{-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE LambdaCase #-}
-{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE ImportQualifiedPost #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TemplateHaskell #-}
 
 module Chainweb.Pact4.Types
@@ -49,60 +50,42 @@ module Chainweb.Pact4.Types
   , getGasModel
   ) where
 
+import Chainweb.Logger
+import Chainweb.Miner.Pact
+import Chainweb.Pact.Payload(PayloadWithOutputs, newBlockOutputs, blockPayload, payloadData, payloadWithOutputs, newBlockTransactions, Transaction (..), TransactionOutput (..), CoinbaseOutput (..))
+import Chainweb.Pact.Types (Transactions(..), BlockCtx, guardCtx)
+import Chainweb.Pact4.Transaction qualified as Pact
+import Chainweb.Utils
+import Chainweb.Version
+import Chainweb.Version.Guards
 import Control.Exception.Safe
 import Control.Lens
 import Control.Monad.Reader
-
 import Data.Aeson hiding (Error,(.=))
-import qualified Data.Map.Strict as M
-import Data.Text (Text)
-
--- internal pact modules
-
-import qualified Pact.JSON.Encode as J
-import Pact.Parse (ParsedDecimal)
-import Pact.Types.Command
-import Pact.Types.ChainMeta
-import Pact.Types.Gas
-import Pact.Types.Info
-import Pact.Types.Pretty (viaShow)
-import Pact.Types.Runtime (PactError(..), PactErrorType(..))
-import Pact.Types.Term
-
--- internal chainweb modules
-
-import Chainweb.BlockCreationTime
-import Chainweb.BlockHash
-import Chainweb.BlockHeader
-import Chainweb.BlockHeight
-import Chainweb.ChainId
-import Chainweb.Miner.Pact
-import Chainweb.Logger
-import Chainweb.Time
-import Chainweb.Utils
-import Chainweb.Version
-
-import Pact.Gas.Table
--- import Chainweb.Pact.Types
-import Chainweb.Pact4.ModuleCache
-import qualified Chainweb.Pact4.Transaction as Pact
-import Chainweb.Version.Guards
-import qualified Pact.Types.Persistence as Pact
-import GHC.Stack (CallStack, HasCallStack, callStack)
-import GHC.Generics
+import Data.ByteString (ByteString)
+import Data.ByteString.Short qualified as SB
+import Data.DList (DList)
 import Data.HashMap.Strict (HashMap)
 import Data.HashSet (HashSet)
-import Data.ByteString (ByteString)
-import qualified Pact.Types.Runtime as Pact
-import Data.DList (DList)
 import Data.List.NonEmpty (NonEmpty)
-import Chainweb.Parent
+import Data.Map.Strict qualified as M
+import Data.Text (Text)
+import Data.Text qualified as T
+import Data.Text.Encoding qualified as T
+import GHC.Generics
+import GHC.Stack (CallStack, HasCallStack, callStack)
+import Pact.Gas.Table
+import Pact.JSON.Encode qualified as J
+import Pact.Parse (ParsedDecimal)
+import Pact.Types.Command
+import Pact.Types.Gas
+import Pact.Types.Info
+import Pact.Types.Persistence qualified as Pact
+import Pact.Types.Pretty (viaShow)
+import Pact.Types.Runtime (PactError(..), PactErrorType(..))
+import Pact.Types.Runtime qualified as Pact
+import Pact.Types.Term
 import System.LogLevel
-import qualified Data.Text as T
-import qualified Data.Text.Encoding as T
-import Chainweb.Pact.Payload(PayloadWithOutputs, newBlockOutputs, blockPayload, payloadData, payloadWithOutputs, newBlockTransactions, Transaction (..), TransactionOutput (..), CoinbaseOutput (..))
-import Chainweb.Pact.Types (Transactions(..), BlockCtx, guardCtx)
-import qualified Data.ByteString.Short as SB
 
 
 -- | Indicates a computed gas charge (gas amount * gas price)

--- a/src/Chainweb/Pact4/Validations.hs
+++ b/src/Chainweb/Pact4/Validations.hs
@@ -56,10 +56,8 @@ import Data.Word (Word8)
 
 -- internal modules
 
-import Chainweb.BlockHeader
 import Chainweb.BlockCreationTime (BlockCreationTime(..))
 import Chainweb.Pact.Types
-import Chainweb.Pact.Utils (fromPactChainId)
 import Chainweb.Time (Seconds(..), Time(..), secondsToTimeSpan, scaleTimeSpan, second, add)
 import Chainweb.Pact4.Transaction
 import Chainweb.Version
@@ -72,7 +70,6 @@ import qualified Pact.Types.Command as P
 import qualified Pact.Types.ChainMeta as P
 import qualified Pact.Types.KeySet as P
 import qualified Pact.Parse as P
-import Chainweb.Pact4.Types
 import Chainweb.Utils (ebool_, int)
 import Chainweb.Parent
 import qualified Pact.Core.Gas.Types as Pact5

--- a/src/Chainweb/PayloadProvider/EVM.hs
+++ b/src/Chainweb/PayloadProvider/EVM.hs
@@ -67,9 +67,9 @@ import Chainweb.PayloadProvider.EVM.EngineAPI
 import Chainweb.PayloadProvider.EVM.EthRpcAPI
 import Chainweb.PayloadProvider.EVM.ExecutionPayload
 import Chainweb.PayloadProvider.EVM.Header qualified as EVM
-import Chainweb.PayloadProvider.EVM.PayloadDB qualified as EvmDB
 import Chainweb.PayloadProvider.EVM.JsonRPC (JsonRpcHttpCtx, callMethodHttp)
 import Chainweb.PayloadProvider.EVM.JsonRPC qualified as RPC
+import Chainweb.PayloadProvider.EVM.PayloadDB qualified as EvmDB
 import Chainweb.PayloadProvider.EVM.SPV
 import Chainweb.PayloadProvider.EVM.Utils (decodeRlpM)
 import Chainweb.PayloadProvider.EVM.Utils qualified as EVM
@@ -92,7 +92,6 @@ import Control.Lens hiding ((.=))
 import Control.Monad
 import Control.Monad.Trans.Resource hiding (throwM)
 import Control.Monad.Writer
-import Data.Aeson qualified as Aeson
 import Data.ByteString.Short qualified as BS
 import Data.List qualified as L
 import Data.LogMessage

--- a/src/Chainweb/PayloadProvider/Minimal.hs
+++ b/src/Chainweb/PayloadProvider/Minimal.hs
@@ -85,25 +85,6 @@ module Chainweb.PayloadProvider.Minimal
 ) where
 
 import Configuration.Utils
-import Control.Concurrent
-import Control.Concurrent.Async
-import Control.Concurrent.STM
-import Control.Lens hiding ((.=))
-import Control.Monad
-import Control.Monad.Catch
-import Control.Monad.Except (throwError)
-import Data.ByteString qualified as B
-import Data.HashSet qualified as HS
-import Data.LogMessage (LogFunction, LogFunctionText)
-import Data.PQueue (PQueue)
-import Data.Text qualified as T
-import GHC.Generics (Generic)
-import Network.HTTP.Client qualified as HTTP
-import Numeric.Natural
-import P2P.TaskQueue
-import Servant.Client
-import System.LogLevel
-
 import Chainweb.BlockHeader
 import Chainweb.BlockHeight
 import Chainweb.BlockPayloadHash
@@ -123,6 +104,23 @@ import Chainweb.Storage.Table.RocksDB
 import Chainweb.Utils
 import Chainweb.Utils.Serialization
 import Chainweb.Version
+import Control.Concurrent.Async
+import Control.Concurrent.STM
+import Control.Lens hiding ((.=))
+import Control.Monad
+import Control.Monad.Catch
+import Control.Monad.Except (throwError)
+import Data.ByteString qualified as B
+import Data.HashSet qualified as HS
+import Data.LogMessage (LogFunction, LogFunctionText)
+import Data.PQueue (PQueue)
+import Data.Text qualified as T
+import GHC.Generics (Generic)
+import Network.HTTP.Client qualified as HTTP
+import Numeric.Natural
+import P2P.TaskQueue
+import Servant.Client
+import System.LogLevel
 
 -- -------------------------------------------------------------------------- --
 

--- a/src/Chainweb/PayloadProvider/Minimal/Payload.hs
+++ b/src/Chainweb/PayloadProvider/Minimal/Payload.hs
@@ -53,7 +53,6 @@ import Chainweb.Storage.Table
 import Chainweb.Utils
 import Chainweb.Utils.Serialization
 import Chainweb.Version
-import Chainweb.Version.Registry
 import Control.Lens (Getter)
 import Control.Lens.Getter (to)
 import Control.Monad

--- a/src/Chainweb/PayloadProvider/Pact.hs
+++ b/src/Chainweb/PayloadProvider/Pact.hs
@@ -1,22 +1,23 @@
-{-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE ImportQualifiedPost #-}
 {-# LANGUAGE InstanceSigs #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE TemplateHaskell #-}
-{-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE UndecidableInstances #-}
 
 module Chainweb.PayloadProvider.Pact
-    ( PactPayloadProvider(..)
-    , withPactPayloadProvider
-    , pactMemPoolAccess
-    , decodeNewPayload
-    ) where
+( PactPayloadProvider(..)
+, withPactPayloadProvider
+, pactMemPoolAccess
+, decodeNewPayload
+) where
 
 import Control.Concurrent.STM
 import Control.Exception.Safe
@@ -24,27 +25,25 @@ import Data.LogMessage
 import Data.Vector (Vector)
 import System.LogLevel
 import Control.Lens
-import qualified Network.HTTP.Client as HTTP
-import qualified Data.Vector as V
-
+import Network.HTTP.Client qualified as HTTP
+import Data.Vector qualified as V
 import Chainweb.ChainId
 import Chainweb.Counter
 import Chainweb.Logger
 import Chainweb.Pact.Mempool.Mempool
 import Chainweb.MerkleUniverse
-import qualified Chainweb.MinerReward as MinerReward
+import Chainweb.MinerReward qualified as MinerReward
 import Chainweb.Pact.Backend.Utils
-import qualified Chainweb.Pact.PactService as PactService
-import qualified Chainweb.Pact.Transaction as Pact
-import Chainweb.Pact.Types
+import Chainweb.Pact.PactService qualified as PactService
+import Chainweb.Pact.Transaction qualified as Pact
+import Chainweb.Core.Brief
 import Chainweb.Pact.Payload
 import Chainweb.Pact.Payload.PayloadStore
+import Chainweb.Pact.Types
 import Chainweb.PayloadProvider
 import Chainweb.Utils
 import Chainweb.Version
-import qualified Data.Pool as Pool
-import Control.Monad.Trans.Resource (ResourceT, allocate)
-import Chainweb.Core.Brief
+import Control.Monad.Trans.Resource (ResourceT)
 
 data PactPayloadProvider logger tbl = PactPayloadProvider
     { pactPayloadProviderLogger :: logger

--- a/src/Chainweb/PayloadProvider/Pact/Configuration.hs
+++ b/src/Chainweb/PayloadProvider/Pact/Configuration.hs
@@ -44,7 +44,6 @@ import Control.Monad
 import Data.Maybe
 import Data.Set qualified as Set
 import GHC.Generics hiding (from, to)
-import Numeric.Natural (Natural)
 import Pact.Core.Gas qualified as Pact
 import Pact.Core.Guards qualified as Pact
 import Pact.Core.StableEncoding

--- a/src/Chainweb/PayloadProvider/Pact/Genesis.hs
+++ b/src/Chainweb/PayloadProvider/Pact/Genesis.hs
@@ -11,36 +11,34 @@ module Chainweb.PayloadProvider.Pact.Genesis
 ( genesisPayload
 ) where
 
+import Chainweb.BlockHeader.Genesis.Development0Payload qualified as DN0
+import Chainweb.BlockHeader.Genesis.Development1to19Payload qualified as DNN
+import Chainweb.BlockHeader.Genesis.Mainnet0Payload qualified as MN0
+import Chainweb.BlockHeader.Genesis.Mainnet10to19Payload qualified as MNKAD
+import Chainweb.BlockHeader.Genesis.Mainnet1Payload qualified as MN1
+import Chainweb.BlockHeader.Genesis.Mainnet2Payload qualified as MN2
+import Chainweb.BlockHeader.Genesis.Mainnet3Payload qualified as MN3
+import Chainweb.BlockHeader.Genesis.Mainnet4Payload qualified as MN4
+import Chainweb.BlockHeader.Genesis.Mainnet5Payload qualified as MN5
+import Chainweb.BlockHeader.Genesis.Mainnet6Payload qualified as MN6
+import Chainweb.BlockHeader.Genesis.Mainnet7Payload qualified as MN7
+import Chainweb.BlockHeader.Genesis.Mainnet8Payload qualified as MN8
+import Chainweb.BlockHeader.Genesis.Mainnet9Payload qualified as MN9
+import Chainweb.BlockHeader.Genesis.RecapDevelopment0Payload qualified as RDN0
+import Chainweb.BlockHeader.Genesis.RecapDevelopment10to19Payload qualified as RDNKAD
+import Chainweb.BlockHeader.Genesis.RecapDevelopment1to9Payload qualified as RDNN
+import Chainweb.BlockHeader.Genesis.Testnet040Payload qualified as T04N0
+import Chainweb.BlockHeader.Genesis.Testnet041to19Payload qualified as T04NN
+import Chainweb.Pact.Payload
 import Chainweb.Version
 import Chainweb.Version.Development
 import Chainweb.Version.EvmDevelopment
 import Chainweb.Version.Mainnet
 import Chainweb.Version.RecapDevelopment
 import Chainweb.Version.Testnet04
-import Chainweb.Pact.Payload
 import Control.Lens
 import Data.HashMap.Strict qualified as HM
 import GHC.Stack
-
-import qualified Chainweb.BlockHeader.Genesis.Mainnet0Payload as MN0
-import qualified Chainweb.BlockHeader.Genesis.Mainnet1Payload as MN1
-import qualified Chainweb.BlockHeader.Genesis.Mainnet2Payload as MN2
-import qualified Chainweb.BlockHeader.Genesis.Mainnet3Payload as MN3
-import qualified Chainweb.BlockHeader.Genesis.Mainnet4Payload as MN4
-import qualified Chainweb.BlockHeader.Genesis.Mainnet5Payload as MN5
-import qualified Chainweb.BlockHeader.Genesis.Mainnet6Payload as MN6
-import qualified Chainweb.BlockHeader.Genesis.Mainnet7Payload as MN7
-import qualified Chainweb.BlockHeader.Genesis.Mainnet8Payload as MN8
-import qualified Chainweb.BlockHeader.Genesis.Mainnet9Payload as MN9
-import qualified Chainweb.BlockHeader.Genesis.Mainnet10to19Payload as MNKAD
-import qualified Chainweb.BlockHeader.Genesis.Development0Payload as DN0
-import qualified Chainweb.BlockHeader.Genesis.Development1to19Payload as DNN
-import qualified Chainweb.BlockHeader.Genesis.Testnet040Payload as T04N0
-import qualified Chainweb.BlockHeader.Genesis.Testnet041to19Payload as T04NN
-import qualified Chainweb.BlockHeader.Genesis.RecapDevelopment0Payload as RDN0
-import qualified Chainweb.BlockHeader.Genesis.RecapDevelopment1to9Payload as RDNN
-import qualified Chainweb.BlockHeader.Genesis.RecapDevelopment10to19Payload as RDNKAD
-import Chainweb.Utils
 
 genesisPayload
     :: (HasCallStack, HasVersion)

--- a/src/Chainweb/RestAPI.hs
+++ b/src/Chainweb/RestAPI.hs
@@ -84,8 +84,6 @@ import Chainweb.Logger (Logger)
 import Chainweb.Pact.Mempool.Mempool (MempoolBackend)
 import qualified Chainweb.Pact.Mempool.RestAPI.Server as Mempool
 import qualified Chainweb.Miner.RestAPI.Server as Mining
--- import qualified Chainweb.Pact.RestAPI.Server as PactAPI
-import qualified Chainweb.Pact.Transaction as Pact
 import Chainweb.Pact.Payload.RestAPI
 import Chainweb.RestAPI.Backup
 import Chainweb.RestAPI.Config

--- a/src/Chainweb/RestAPI/Orphans.hs
+++ b/src/Chainweb/RestAPI/Orphans.hs
@@ -32,7 +32,6 @@ module Chainweb.RestAPI.Orphans () where
 
 import Control.Monad
 
-import Data.Bool
 import Data.Bifunctor
 import Data.Proxy
 import Data.Semigroup (Max(..), Min(..))

--- a/src/Chainweb/SPV/CreateProof.hs
+++ b/src/Chainweb/SPV/CreateProof.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE ImportQualifiedPost #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
@@ -24,17 +25,9 @@ import Control.Applicative
 import Control.Lens hiding ((.=))
 import Control.Monad
 import Control.Monad.Catch
-
-import qualified Data.List.NonEmpty as N
+import Data.List.NonEmpty qualified as N
 import Data.MerkleLog.Common
-import qualified Data.MerkleLog.V1 as V1
-
-import GHC.Stack
-
-import Prelude hiding (lookup)
-
--- internal modules
-
+import Data.MerkleLog.V1 qualified as V1
 import Chainweb.BlockHash
 import Chainweb.BlockHeader
 import Chainweb.BlockHeight
@@ -44,14 +37,14 @@ import Chainweb.CutDB
 import Chainweb.Graph
 import Chainweb.MerkleUniverse
 import Chainweb.Parent
-import Chainweb.Pact.Payload
-import Chainweb.Pact.Payload.PayloadStore
+import Chainweb.PayloadProvider
 import Chainweb.SPV
 import Chainweb.TreeDB
 import Chainweb.Utils
 import Chainweb.Version
 import Chainweb.WebBlockHeaderDB
-import Chainweb.PayloadProvider
+import GHC.Stack
+import Prelude hiding (lookup)
 
 -- -------------------------------------------------------------------------- --
 -- FIXME

--- a/src/Chainweb/SPV/VerifyProof.hs
+++ b/src/Chainweb/SPV/VerifyProof.hs
@@ -27,14 +27,11 @@ import Data.MerkleLog.V1 qualified as V1
 -- internal modules
 
 import Chainweb.BlockHash
-import Chainweb.BlockHeaderDB
 import Chainweb.Crypto.MerkleLog (proofSubject)
-import Chainweb.CutDB
 import Chainweb.MerkleLogHash
 import Chainweb.MerkleUniverse
 import Chainweb.Pact.Payload
 import Chainweb.SPV
-import Chainweb.Version
 import Chainweb.Pact.Backend.Types (HeaderOracle (..))
 import Chainweb.Parent
 import Chainweb.Utils (unlessM)

--- a/src/Chainweb/Sync/WebBlockHeaderStore.hs
+++ b/src/Chainweb/Sync/WebBlockHeaderStore.hs
@@ -70,7 +70,6 @@ import Control.Monad
 import Control.Monad.Catch
 import Data.Foldable
 import Data.Hashable
-import Data.HashSet qualified as HS
 import Data.LogMessage
 import Data.PQueue
 import Data.TaskMap

--- a/src/Chainweb/VerifierPlugin/Hyperlane/Message.hs
+++ b/src/Chainweb/VerifierPlugin/Hyperlane/Message.hs
@@ -1,8 +1,9 @@
 {-# LANGUAGE DuplicateRecordFields #-}
+{-# LANGUAGE ImportQualifiedPost #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ViewPatterns #-}
-{-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE LambdaCase #-}
 
 -- |
 -- Chainweb.VerifierPlugin.Hyperlane.Message
@@ -14,9 +15,8 @@
 --
 module Chainweb.VerifierPlugin.Hyperlane.Message (plugin) where
 
-import Chainweb.Version.Guards
 import Chainweb.VerifierPlugin
-import qualified Chainweb.VerifierPlugin.Hyperlane.Message.After225 as After225
+import Chainweb.VerifierPlugin.Hyperlane.Message.After225 qualified as After225
 
 plugin :: VerifierPlugin
 plugin = VerifierPlugin $ \(cid, bh) proof caps gasRef ->

--- a/src/Chainweb/Version/RecapDevelopment.hs
+++ b/src/Chainweb/Version/RecapDevelopment.hs
@@ -21,9 +21,9 @@ import Chainweb.Utils.Rule
 import Chainweb.Version
 
 import Pact.Core.Names
-import qualified Chainweb.BlockHeader.Genesis.RecapDevelopment0Payload as RDN0
-import qualified Chainweb.BlockHeader.Genesis.RecapDevelopment1to9Payload as RDNN
-import qualified Chainweb.BlockHeader.Genesis.RecapDevelopment10to19Payload as RDNKAD
+-- import qualified Chainweb.BlockHeader.Genesis.RecapDevelopment0Payload as RDN0
+-- import qualified Chainweb.BlockHeader.Genesis.RecapDevelopment1to9Payload as RDNN
+-- import qualified Chainweb.BlockHeader.Genesis.RecapDevelopment10to19Payload as RDNKAD
 import qualified Chainweb.Pact.Transactions.RecapDevelopmentTransactions as RecapDevnet
 import qualified Chainweb.Pact.Transactions.CoinV3Transactions as CoinV3
 import qualified Chainweb.Pact.Transactions.CoinV4Transactions as CoinV4

--- a/test/lib/Chainweb/Test/MultiNode.hs
+++ b/test/lib/Chainweb/Test/MultiNode.hs
@@ -56,10 +56,12 @@ import Chainweb.Chainweb.Configuration
 import Chainweb.Chainweb.CutResources
 import Chainweb.Chainweb.PeerResources
 import Chainweb.Cut
+import Chainweb.Cut.CutHashes
 import Chainweb.CutDB
 import Chainweb.Graph
 import Chainweb.Logger
 import Chainweb.Miner.Config
+import Chainweb.Miner.Pact
 import Chainweb.Pact.Backend.PactState (allChains, getLatestBlockHeight, getLatestPactStateAtDiffable, TableDiffable(..), addChainIdLabel)
 import Chainweb.Pact.Backend.PactState.EmbeddedSnapshot (Snapshot(..))
 import Chainweb.Pact.Backend.PactState.GrandHash.Algorithm (ChainGrandHash(..))
@@ -67,6 +69,7 @@ import Chainweb.Pact.Backend.PactState.GrandHash.Calc qualified as GrandHash.Cal
 import Chainweb.Pact.Backend.PactState.GrandHash.Import qualified as GrandHash.Import
 import Chainweb.Pact.Backend.PactState.GrandHash.Utils qualified as GrandHash.Utils
 import Chainweb.PayloadProvider.Pact.Configuration (defaultPactProviderConfig, PactProviderConfig (_pactConfigGenesisPayload), _pactConfigMiner)
+import Chainweb.Storage.Table (IterableTable(withTableIterator), Casify)
 import Chainweb.Storage.Table.RocksDB
 import Chainweb.Test.P2P.Peer.BootstrapConfig
 import Chainweb.Test.Utils
@@ -78,12 +81,13 @@ import Chainweb.WebBlockHeaderDB
 import Control.Concurrent.Async
 import Control.DeepSeq
 import Control.Exception
-import Control.Lens (set, view, (^?!), ix, (^.))
+import Control.Lens (set, view, (^?!), ix)
 import Control.Monad
 import Data.Aeson (ToJSON, object, (.=))
 import Data.ByteString (ByteString)
 import Data.ByteString.Base16 qualified as Base16
 import Data.Foldable
+import Data.Function
 import Data.HashMap.Strict qualified as HM
 import Data.HashSet qualified as HS
 import Data.IORef
@@ -109,10 +113,6 @@ import System.IO.Temp
 import System.LogLevel
 import System.Timeout
 import Test.Tasty.HUnit
-import Chainweb.Miner.Pact
-import Chainweb.Storage.Table (IterableTable(withTableIterator), Casify)
-import Chainweb.Cut.CutHashes
-import Data.Function
 
 -- -------------------------------------------------------------------------- --
 -- * Configuration

--- a/test/lib/Chainweb/Test/Pact/Utils.hs
+++ b/test/lib/Chainweb/Test/Pact/Utils.hs
@@ -1,81 +1,60 @@
-{-# language
-    FlexibleContexts
-  , ImportQualifiedPost
-  , LambdaCase
-  , NumericUnderscores
-  , OverloadedStrings
-  , PackageImports
-  , TypeApplications
-#-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE ImportQualifiedPost #-}
+{-# LANGUAGE ImportQualifiedPost #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE NumericUnderscores #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE PackageImports #-}
+{-# LANGUAGE TypeApplications #-}
 
 module Chainweb.Test.Pact.Utils
-    -- ( initCheckpointer
-    -- , pactTxFrom4To5
+(
+-- * Logging
+  getTestLogLevel
+, testLogFn
+, getTestLogger
 
-        -- * Logging
-    ( getTestLogLevel
-    , testLogFn
-    , getTestLogger
+-- * Resources
+, withMempool
+, withBlockDbs
 
-        -- * Resources
-    , withMempool
-    , withBlockDbs
+-- * Properties
+, event
+, successfulTx
 
-        -- * Properties
-    , event
-    , successfulTx
-        -- * Utilities
-    , coinModuleName
-    )
-    where
+-- * Utilities
+, coinModuleName
+)
+where
 
 import Chainweb.Chainweb (validatingMempoolConfig)
 import Chainweb.ChainId
 import Chainweb.Logger
 import Chainweb.Pact.Mempool.InMem
 import Chainweb.Pact.Mempool.Mempool (MempoolBackend (..))
---import Chainweb.Pact.Backend.RelationalCheckpointer
-import Chainweb.Pact.Backend.Types (SQLiteEnv)
-import Chainweb.Pact.Backend.Utils (openSQLiteConnection, closeSQLiteConnection, chainwebPragmas)
 import Chainweb.Pact.PactService
-import Chainweb.Pact.Types
-import Chainweb.Pact.Transaction qualified as Pact
 import Chainweb.Pact.Payload.PayloadStore
 import Chainweb.Pact.Payload.PayloadStore.RocksDB
+import Chainweb.Pact.Transaction qualified as Pact
+import Chainweb.Pact.Types
 import Chainweb.Storage.Table.RocksDB
--- import Chainweb.Utils
 import Chainweb.Version
 import Chainweb.WebBlockHeaderDB
--- import Control.Concurrent hiding (throwTo)
--- import Control.Exception (AsyncException (..), throwTo)
--- import Control.Lens hiding (elements, only)
--- import Control.Monad
 import Control.Monad.IO.Class
-import Control.Monad.Trans.Resource (ResourceT, allocate)
--- import Control.Monad.Trans.Resource qualified as Resource
--- import Data.Aeson qualified as Aeson
--- import Data.ByteString.Short qualified as SBS
--- import Data.HashSet (HashSet)
--- import Data.HashSet qualified as HashSet
+import Control.Monad.Trans.Resource (ResourceT)
 import Data.Maybe (fromMaybe)
 import Data.Text (Text)
 import Data.Text qualified as Text
--- import Data.Text.Encoding qualified as Text
 import Data.Text.IO qualified as Text
--- import Data.Vector (Vector)
--- import Data.Vector qualified as Vector
+import Pact.Core.Capabilities
 import Pact.Core.Command.Types qualified as Pact
--- import Pact.Core.Hash qualified as Pact
--- import Pact.Core.Pretty qualified as Pact
 import Pact.Core.Gas qualified as Pact
--- import Pact.JSON.Encode qualified as J
-import System.Environment (lookupEnv)
-import System.LogLevel
+import Pact.Core.Names
+import Pact.Core.PactValue
 import PropertyMatchers ((?))
 import PropertyMatchers qualified as P
-import Pact.Core.PactValue
-import Pact.Core.Capabilities
-import Pact.Core.Names
+import System.Environment (lookupEnv)
+import System.LogLevel
 
 withBlockDbs :: HasVersion => RocksDb -> ResourceT IO (PayloadDb RocksDbTable, WebBlockHeaderDb)
 withBlockDbs rdb = do

--- a/test/lib/Chainweb/Test/Pact4/Utils.hs
+++ b/test/lib/Chainweb/Test/Pact4/Utils.hs
@@ -1,22 +1,21 @@
-{-# LANGUAGE LambdaCase #-}
-{-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE ImportQualifiedPost #-}
-{-# LANGUAGE RecordWildCards #-}
-{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GADTs #-}
+{-# LANGUAGE ImportQualifiedPost #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE NumericUnderscores #-}
 {-# LANGUAGE OverloadedRecordDot #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE ImportQualifiedPost #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TupleSections #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE ViewPatterns #-}
-{-# LANGUAGE DataKinds #-}
 
 {-# OPTIONS_GHC -fno-warn-incomplete-uni-patterns #-}
 -- |
@@ -112,48 +111,33 @@ module Chainweb.Test.Pact4.Utils
 
 ) where
 
-import Control.Arrow ((&&&))
-import Control.Concurrent.Async
-import Control.Concurrent.MVar
+
 import Control.Lens hiding ((.=))
 import Control.Monad
 import Control.Monad.Catch
 import Control.Monad.IO.Class
-
 import Data.Aeson (Value(..), object, (.=), Key)
 import Data.ByteString (ByteString)
-import qualified Data.ByteString.Short as BS
+import Data.ByteString.Short qualified as BS
 import Data.Decimal
-import Data.Foldable
-import qualified Data.HashMap.Strict as HM
-import Data.IORef
 import Data.List qualified as List
 import Data.Map (Map)
-import qualified Data.Map.Strict as M
+import Data.Map.Strict qualified as M
 import Data.Maybe
 import Data.Text (Text)
-import qualified Data.Text as T
-import qualified Data.Text.Encoding as T
+import Data.Text qualified as T
+import Data.Text.Encoding qualified as T
 import Data.String
-import qualified Data.Vector as V
-
+import Data.Vector qualified as V
 import Database.SQLite3.Direct (Database)
-
 import GHC.Generics
-
 import Streaming.Prelude qualified as S
 import System.LogLevel
-
 import Test.Tasty
-import Test.Tasty.HUnit(assertFailure)
-
--- internal pact modules
-
 import Pact.ApiReq (ApiKeyPair(..), mkKeyPairs)
-import Pact.Gas
 import Pact.JSON.Legacy.Value
 import Pact.Types.Capability
-import qualified Pact.Types.ChainId as P
+import Pact.Types.ChainId qualified as P
 import Pact.Types.ChainMeta
 import Pact.Types.Command
 import Pact.Types.Crypto
@@ -162,7 +146,7 @@ import Pact.Types.Gas
 import Pact.Types.Hash
 import Pact.Types.Info (noInfo)
 import Pact.Types.KeySet
-import qualified Pact.Types.Logger as P
+import Pact.Types.Logger qualified as P
 import Pact.Types.Names
 import Pact.Types.PactValue
 import Pact.Types.RPC
@@ -170,44 +154,31 @@ import Pact.Types.Runtime (PactEvent(..))
 import Pact.Types.Term
 import Pact.Types.Util (parseB16TextOnly)
 import Pact.Types.Verifier
-
--- internal modules
-
 import Chainweb.BlockHeader
 import Chainweb.BlockHeaderDB hiding (withBlockHeaderDb)
 import Chainweb.BlockHeight
 import Chainweb.ChainId
 import Chainweb.Graph
 import Chainweb.Logger
-import Chainweb.Miner.Pact
 import Chainweb.Pact.Backend.Compaction qualified as Sigma
 import Chainweb.Pact.Backend.PactState qualified as PactState
 import Chainweb.Pact.Backend.PactState (TableDiffable(..), Table(..), PactRow(..))
 import Chainweb.Pact.Backend.SQLite.DirectV2
-
 import Chainweb.Pact.Backend.Utils hiding (tbl, withSqliteDb)
-import Chainweb.Pact.PactService
-import Chainweb.Pact.RestAPI.Server (validateCommand)
-import Chainweb.Pact.Types
 import Chainweb.Pact4.Types
 import Chainweb.Pact.Payload
 import Chainweb.Pact.Payload.PayloadStore
-import Chainweb.Test.Cut
 import Chainweb.Test.Cut.TestBlockDb
 import Chainweb.Test.Utils
 import Chainweb.Test.Utils.BlockHeader
 import Chainweb.Test.TestVersions
 import Chainweb.Time
-import qualified Chainweb.Pact4.Transaction as Pact4
 import Chainweb.Utils
-import Chainweb.Version (ChainwebVersion(..), chainIds)
-import qualified Chainweb.Version as Version
-import Chainweb.Version.Utils (someChainId)
-import Chainweb.WebBlockHeaderDB
-
-import Chainweb.Storage.Table.RocksDB
+import Chainweb.Version (ChainwebVersion(..))
+import Chainweb.Version qualified as Version
 import Chainweb.Pact.Backend.Types
 import Chainweb.Parent
+import Chainweb.Storage.Table.RocksDB
 
 -- ----------------------------------------------------------------------- --
 -- Keys

--- a/test/lib/Chainweb/Test/TestVersions.hs
+++ b/test/lib/Chainweb/Test/TestVersions.hs
@@ -26,23 +26,19 @@ module Chainweb.Test.TestVersions
     ) where
 
 import Control.Lens hiding (elements)
-import Data.HashMap.Strict (HashMap)
 import qualified Data.HashMap.Strict as HM
 import qualified Data.HashSet as HS
-import qualified Data.List as List
 import qualified Data.Set as Set
 import qualified Chainweb.BlockHeader.Genesis.InstantTimedCPM0Payload as IN0
 import qualified Chainweb.BlockHeader.Genesis.InstantTimedCPM1to9Payload as INN
-import qualified Chainweb.BlockHeader.Genesis.Pact5InstantTimedCPM0Payload as PIN0
-import qualified Chainweb.BlockHeader.Genesis.Pact5InstantTimedCPM1to9Payload as PINN
+-- import qualified Chainweb.BlockHeader.Genesis.Pact5InstantTimedCPM0Payload as PIN0
+-- import qualified Chainweb.BlockHeader.Genesis.Pact5InstantTimedCPM1to9Payload as PINN
 import qualified Chainweb.BlockHeader.Genesis.Pact53TransitionTimedCPM0Payload as PIT0
 import qualified Chainweb.BlockHeader.Genesis.Pact53TransitionTimedCPM1to9Payload as PITN
-import qualified Chainweb.BlockHeader.Genesis.QuirkedGasPact5InstantTimedCPM0Payload as QPIN0
-import qualified Chainweb.BlockHeader.Genesis.QuirkedGasPact5InstantTimedCPM1to9Payload as QPINN
 -- import qualified Chainweb.BlockHeader.Genesis.QuirkedGasPact5InstantTimedCPM0Payload as QPIN0
 -- import qualified Chainweb.BlockHeader.Genesis.QuirkedGasPact5InstantTimedCPM1to9Payload as QPINN
-
-import System.IO.Unsafe
+-- import qualified Chainweb.BlockHeader.Genesis.QuirkedGasPact5InstantTimedCPM0Payload as QPIN0
+-- import qualified Chainweb.BlockHeader.Genesis.QuirkedGasPact5InstantTimedCPM1to9Payload as QPINN
 
 -- internal modules
 
@@ -56,10 +52,9 @@ import Chainweb.Time
 import Chainweb.Utils
 import Chainweb.Utils.Rule
 import Chainweb.Version
-import Chainweb.Version.Registry
 import P2P.Peer
 
-import Chainweb.Pact.Payload(PayloadWithOutputs_(_payloadWithOutputsPayloadHash), PayloadWithOutputs)
+import Chainweb.Pact.Payload(PayloadWithOutputs_(_payloadWithOutputsPayloadHash))
 import qualified Pact.Core.Names as Pact
 import qualified Pact.Core.Gas as Pact
 import qualified Data.List as L

--- a/test/lib/Chainweb/Test/Utils.hs
+++ b/test/lib/Chainweb/Test/Utils.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE ImportQualifiedPost #-}
+{-# LANGUAGE ImportQualifiedPost #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MultiWayIf #-}
 {-# LANGUAGE NumericUnderscores #-}
@@ -134,47 +135,41 @@ import Control.Concurrent
 import Control.Concurrent.STM
 import Control.Lens
 import Control.Monad
-import Control.Monad.Catch (finally, bracket)
+import Control.Monad.Catch (finally)
 import Control.Monad.IO.Class
 import Control.Monad.Trans.Resource
 import Control.Retry
-
 import Data.Aeson (FromJSON, ToJSON)
 import Data.Bifunctor hiding (second)
-import qualified Data.ByteString as B
-import qualified Data.ByteString.Lazy as BL
+import Data.ByteString qualified as B
+import Data.ByteString.Lazy qualified as BL
 import Data.Coerce (coerce)
 import Data.Foldable
 import Data.IORef
 import Data.List (sortOn, isInfixOf)
 import Data.Pool (Pool)
-import qualified Data.Text as T
-import qualified Data.Text.IO as T
+import Data.Text qualified as T
+import Data.Text.IO qualified as T
 import Data.Tree
-import qualified Data.Tree.Lens as LT
+import Data.Tree.Lens qualified as LT
 import Data.Word
-
-import qualified Network.Connection as HTTP
-import qualified Network.HTTP.Client as HTTP
-import qualified Network.HTTP.Client.TLS as HTTP
-import qualified Network.HTTP.Types as HTTP
+import Network.Connection qualified as HTTP
+import Network.HTTP.Client qualified as HTTP
+import Network.HTTP.Client.TLS qualified as HTTP
+import Network.HTTP.Types qualified as HTTP
 import Network.Socket (close)
-import qualified Network.TLS as HTTP
-import qualified Network.Wai as W
-import qualified Network.Wai.Handler.Warp as W
+import Network.TLS qualified as HTTP
+import Network.Wai qualified as W
+import Network.Wai.Handler.Warp qualified as W
 import Network.Wai.Handler.WarpTLS as W (runTLSSocket)
-
 import Numeric.Natural
-
 import Servant.Client (BaseUrl(..), ClientEnv, Scheme(..), mkClientEnv, runClientM)
-
 import System.Directory (removeDirectoryRecursive, removeFile)
 import System.Environment (withArgs)
 import System.IO
 import System.IO.Temp qualified as Temp
 import System.LogLevel
 import System.Random (randomIO)
-
 import Test.QuickCheck.Arbitrary
 import Test.QuickCheck.Gen
 import Test.QuickCheck.Property (Property, (===))
@@ -183,13 +178,8 @@ import Test.Tasty
 import Test.Tasty.Golden
 import Test.Tasty.HUnit
 import Test.Tasty.QuickCheck (property, discard, (.&&.))
-
 import Text.Printf (printf)
-
 import UnliftIO.Async
-
--- internal modules
-
 import Chainweb.BlockCreationTime
 import Chainweb.BlockHeader
 import Chainweb.BlockHeaderDB
@@ -208,7 +198,7 @@ import Chainweb.Difficulty (targetToDifficulty)
 import Chainweb.Graph
 import Chainweb.HostAddress
 import Chainweb.Logger
-import Chainweb.Pact.Mempool.Mempool (MempoolBackend(..), TransactionHash(..), BlockFill(..), mockBlockGasLimit)
+import Chainweb.Pact.Mempool.Mempool (TransactionHash(..), BlockFill(..), mockBlockGasLimit)
 import Chainweb.MerkleUniverse
 import Chainweb.Miner.Config
 import Chainweb.Pact.Backend.Types(SQLiteEnv)
@@ -218,8 +208,7 @@ import Chainweb.PayloadProvider.Pact.Configuration
 import Chainweb.RestAPI
 import Chainweb.RestAPI.NetworkID
 import Chainweb.Test.Pact.Utils (getTestLogLevel, getTestLogger)
-import Chainweb.Test.P2P.Peer.BootstrapConfig
-    (testBootstrapCertificate, testBootstrapKey, testBootstrapPeerConfig)
+import Chainweb.Test.P2P.Peer.BootstrapConfig (testBootstrapCertificate, testBootstrapKey, testBootstrapPeerConfig)
 import Chainweb.Test.Utils.BlockHeader
 import Chainweb.Time
 import Chainweb.TreeDB
@@ -228,24 +217,19 @@ import Chainweb.Utils.Serialization
 import Chainweb.Test.TestVersions
 import Chainweb.Version
 import Chainweb.Version.Utils
-
 import Chainweb.Storage.Table
 import Chainweb.Storage.Table.RocksDB
-
-import qualified Database.RocksDB.Internal as R
-
+import Database.RocksDB.Internal qualified as R
 import Network.X509.SelfSigned
-
 import P2P.Node.Configuration
-import qualified P2P.Node.PeerDB as P2P
+import P2P.Node.PeerDB qualified as P2P
 import P2P.Peer
-
 import Chainweb.Test.Utils.APIValidation
 import Data.Semigroup
-import qualified Pact.Core.Command.Types as Pact5
-import qualified Pact.Core.Errors as Pact5
-import qualified Pact.Core.Hash as Pact5
-import qualified Pact.Core.Gas as Pact
+import Pact.Core.Command.Types qualified as Pact5
+import Pact.Core.Errors qualified as Pact5
+import Pact.Core.Hash qualified as Pact5
+import Pact.Core.Gas qualified as Pact
 import Chainweb.Ranked (Ranked(_rankedHeight))
 
 -- -------------------------------------------------------------------------- --

--- a/test/unit/Chainweb/Test/Mempool.hs
+++ b/test/unit/Chainweb/Test/Mempool.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE ExistentialQuantification #-}
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE ImportQualifiedPost #-}
 {-# LANGUAGE NumericUnderscores #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RankNTypes #-}
@@ -29,13 +30,13 @@ import Control.Monad.Trans.Except
 import Data.Bifunctor (bimap)
 import Data.Decimal (Decimal, DecimalRaw(..))
 import Data.Function (on)
-import qualified Data.HashSet as HashSet
+import Data.HashSet qualified as HashSet
 import Data.IORef
 import Data.List (sort, sortBy)
-import qualified Data.List.Ordered as OL
+import Data.List.Ordered qualified as OL
 import Data.Ord (Down(..))
 import Data.Vector (Vector)
-import qualified Data.Vector as V
+import Data.Vector qualified as V
 import GHC.Stack
 import Prelude hiding (lookup)
 import System.Timeout (timeout)
@@ -44,22 +45,17 @@ import Test.QuickCheck.Monadic
 import Test.Tasty
 import Test.Tasty.HUnit
 import Test.Tasty.QuickCheck hiding ((.&.))
-
--- internal modules
-
-import Pact.Parse (ParsedDecimal(..))
 import Pact.Core.Gas.Types
-
 import Chainweb.BlockHash
 import Chainweb.Pact.Mempool.Mempool
 import Chainweb.Test.Utils
-import qualified Chainweb.Time as Time
-import Chainweb.Utils (T2(..))
-import Chainweb.PayloadProvider
+import Chainweb.Time qualified as Time
+import Chainweb.BlockCreationTime
 import Chainweb.MinerReward
 import Chainweb.Parent
-import Chainweb.BlockCreationTime
-import Control.Lens (from, view)
+import Chainweb.PayloadProvider
+import Chainweb.Utils (T2(..))
+import Control.Lens (view)
 
 ------------------------------------------------------------------------------
 -- | Several operations (reintroduce, validate, confirm) can only be performed

--- a/test/unit/Chainweb/Test/Mempool/RestAPI.hs
+++ b/test/unit/Chainweb/Test/Mempool/RestAPI.hs
@@ -1,45 +1,36 @@
 {-# LANGUAGE NumericUnderscores #-}
+{-# LANGUAGE ImportQualifiedPost #-}
+
 module Chainweb.Test.Mempool.RestAPI (tests) where
 
 import Control.Concurrent
-import Control.Concurrent.STM
-import Control.Exception
 import Control.Monad.IO.Class
 import Control.Monad.Trans.Resource
-
-import qualified Data.Pool as Pool
-import qualified Data.Vector as V
-
-import qualified Network.HTTP.Client as HTTP
+import Data.Pool qualified as Pool
+import Data.Vector qualified as V
+import Network.HTTP.Client qualified as HTTP
 import Network.Wai (Application)
-
 import Servant.Client (BaseUrl(..), ClientEnv, Scheme(..), mkClientEnv)
-
 import Test.Tasty
-
--- internal modules
-
 import Chainweb.Chainweb.Configuration
 import Chainweb.Graph
-import qualified Chainweb.Pact.Mempool.InMem as InMem
+import Chainweb.Pact.Mempool.InMem qualified as InMem
 import Chainweb.Pact.Mempool.InMemTypes (InMemConfig(..))
 import Chainweb.Pact.Mempool.Mempool
-import qualified Chainweb.Pact.Mempool.RestAPI.Client as MClient
+import Chainweb.Pact.Mempool.RestAPI.Client qualified as MClient
 import Chainweb.RestAPI
 import Chainweb.Test.Mempool (InsertCheck, MempoolWithFunc(..))
-import qualified Chainweb.Test.Mempool
-import Chainweb.Test.Utils (withTestAppServer)
+import Chainweb.Test.Mempool qualified
 import Chainweb.Test.TestVersions
+import Chainweb.Test.Utils (withTestAppServer)
 import Chainweb.Utils (Codec(..), withAsyncR, resourceToBracket)
 import Chainweb.Version
 import Chainweb.Version.Utils
-
-import Chainweb.Storage.Table.RocksDB
-
-import Network.X509.SelfSigned
 import Control.Monad
+import Network.X509.SelfSigned
 
 ------------------------------------------------------------------------------
+
 tests :: TestTree
 tests = withResource newPool Pool.destroyAllResources $
         \poolIO -> testGroup "Chainweb.Pact.Mempool.RestAPI"

--- a/test/unit/Chainweb/Test/Mining.hs
+++ b/test/unit/Chainweb/Test/Mining.hs
@@ -17,36 +17,8 @@ module Chainweb.Test.Mining
 ( tests
 ) where
 
-import Control.Concurrent
-import Control.Concurrent.Async
-import Control.Concurrent.STM.TVar
-import Control.Lens
-
-import Data.Foldable
-import qualified Data.HashMap.Strict as HM
-import Data.Maybe
-import qualified Data.Text as T
-
-import GHC.Stack
-
-import System.LogLevel
-
-import Test.Tasty
-import Test.Tasty.HUnit
-
--- internal modules
-
-import Chainweb.Chainweb.MinerResources
-import Chainweb.Graph
-import Chainweb.Logger
-import Chainweb.Miner.Config
-import Chainweb.Miner.Coordinator
-import Chainweb.Miner.Pact
-import Chainweb.Test.CutDB hiding (tests)
-import Chainweb.Test.TestVersions (barebonesTestVersion)
-
 import Chainweb.Storage.Table.RocksDB
-import Chainweb.Version (withVersion)
+import Test.Tasty
 
 -- -------------------------------------------------------------------------- --
 --

--- a/test/unit/Chainweb/Test/Misc.hs
+++ b/test/unit/Chainweb/Test/Misc.hs
@@ -1,5 +1,5 @@
-{-# LANGUAGE NumericUnderscores #-}
 {-# LANGUAGE ImportQualifiedPost #-}
+{-# LANGUAGE NumericUnderscores #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TypeApplications #-}
 
@@ -13,35 +13,25 @@
 -- Miscellaneous tests.
 --
 module Chainweb.Test.Misc
-  ( tests
-  ) where
+( tests
+) where
 
 import Chainweb.Pact.Payload
+import Chainweb.BlockHash
+import Chainweb.ChainId
+import Chainweb.MerkleUniverse
+import Chainweb.Parent
 import Chainweb.Test.Orphans.Internal ()
-
+import Chainweb.Utils (HasTextRepresentation(..))
+import Chainweb.Utils.Serialization
 import Control.Concurrent (threadDelay)
+import Control.Lens
 import Control.Scheduler (Comp(..), scheduleWork, terminateWith, withScheduler)
-
+import Data.HashMap.Strict qualified as HM
+import PropertyMatchers qualified as P
 import Test.Tasty
 import Test.Tasty.HUnit
 import Test.Tasty.QuickCheck
-import Chainweb.BlockHash
-import Data.HashMap.Strict qualified as HM
-import Chainweb.ChainId
-
-import PropertyMatchers ((?))
-import PropertyMatchers qualified as P
--- import Chainweb.MerkleLogHash (unsafeMerkleLogHash)
-import Data.Function ((&))
--- import qualified Data.ByteString as BS
-import Chainweb.Utils (HasTextRepresentation(..))
-import Chainweb.MerkleLogHash (unsafeMerkleLogHash)
-import qualified Data.ByteString as BS
-import Control.Lens
-import Control.Monad
-import Chainweb.Parent
-import Chainweb.Utils.Serialization
-import Chainweb.MerkleUniverse
 
 ---
 

--- a/test/unit/Chainweb/Test/Pact/CheckpointerTest.hs
+++ b/test/unit/Chainweb/Test/Pact/CheckpointerTest.hs
@@ -1,17 +1,17 @@
-{-# LANGUAGE LambdaCase #-}
-{-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE GADTs #-}
-{-# LANGUAGE TypeApplications #-}
-{-# LANGUAGE TupleSections #-}
-{-# LANGUAGE RankNTypes #-}
-{-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE QuantifiedConstraints #-}
-{-# LANGUAGE UndecidableInstances #-}
-{-# LANGUAGE NumericUnderscores #-}
-{-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE DataKinds #-}
-{-# LANGUAGE ViewPatterns #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GADTs #-}
 {-# LANGUAGE ImportQualifiedPost #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE NumericUnderscores #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE QuantifiedConstraints #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TupleSections #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE ViewPatterns #-}
 
 module Chainweb.Test.Pact.CheckpointerTest (tests) where
 
@@ -41,7 +41,6 @@ import PropertyMatchers qualified as P
 import Test.Tasty
 import Test.Tasty.HUnit (assertEqual, testCase)
 import Test.Tasty.Hedgehog
-
 import Chainweb.BlockHash
 import Chainweb.BlockHeader
 import Chainweb.Graph (singletonChainGraph)
@@ -55,13 +54,13 @@ import Chainweb.Parent
 import Chainweb.PayloadProvider
 import Chainweb.Test.Pact.Utils
 import Chainweb.Test.TestVersions
-import Chainweb.Test.Utils hiding (withTempSQLiteResource)
+import Chainweb.Test.Utils
 import Chainweb.Utils
 import Chainweb.Utils.Serialization (runGetS, runPutS)
 import Chainweb.Version
 import Chainweb.MinerReward
 import Control.Monad.State.Strict
-import qualified Chainweb.Pact.Payload as Chainweb
+import Chainweb.Pact.Payload qualified as Chainweb
 import Chainweb.Pact.Utils (emptyPayload)
 
 -- | A @DbAction f@ is a description of some action on the database together with an f-full of results for it.

--- a/test/unit/Chainweb/Test/Roundtrips.hs
+++ b/test/unit/Chainweb/Test/Roundtrips.hs
@@ -1,6 +1,8 @@
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE ImportQualifiedPost #-}
+
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 -- |
@@ -17,77 +19,57 @@ module Chainweb.Test.Roundtrips
 ) where
 
 import Chainweb.Pact.RestAPI.SPV
-
 import Control.Monad.Catch
-
-import Crypto.Hash.Algorithms
-
 import Data.Aeson
 import Data.Aeson.Encoding
 import Data.Bifunctor
-import qualified Data.ByteString.Lazy as BL
-import qualified Data.HashMap.Strict as HM
+import Data.ByteString.Lazy qualified as BL
+import Data.HashMap.Strict qualified as HM
 import Data.Int
-import qualified Data.Text as T
-
-import qualified Pact.JSON.Encode as J
-import Pact.Parse
-
-import Test.QuickCheck
-import Test.QuickCheck.Instances ()
-import Test.Tasty
-import Test.Tasty.QuickCheck
-
--- internal modules
-
+import Data.Text qualified as T
+import Pact.JSON.Encode qualified as J
 import Chainweb.BlockHash
 import Chainweb.BlockHeader
-import Chainweb.BlockHeaderDB.RestAPI
 import Chainweb.BlockHeight
 import Chainweb.BlockWeight
 import Chainweb.ChainId
-import Chainweb.Chainweb
 import Chainweb.Chainweb.Configuration
 import Chainweb.Cut.Create
 import Chainweb.Cut.CutHashes
 import Chainweb.Difficulty
 import Chainweb.HostAddress
-import Chainweb.Pact.Mempool.Mempool
-import Chainweb.Pact.Mempool.RestAPI
 import Chainweb.MerkleLogHash
 import Chainweb.MerkleUniverse
 import Chainweb.Miner.Config
 import Chainweb.Miner.Pact
 import Chainweb.NodeVersion
-import Chainweb.Pact.Types
+import Chainweb.Pact.Mempool.Mempool
+import Chainweb.Pact.Mempool.RestAPI
 import Chainweb.Pact.Payload
 import Chainweb.PowHash
+import Chainweb.Ranked
 import Chainweb.RestAPI.NetworkID
 import Chainweb.RestAPI.NodeInfo
-import Chainweb.SPV
 import Chainweb.SPV.EventProof
-import Chainweb.SPV.PayloadProof
--- import Chainweb.Test.Orphans.Internal (EventPactValue(..), ProofPactEvent(..), arbitraryBlockHeaderVersion, arbitraryBlockHeaderVersionHeight, arbitraryBlockHashRecordVersionHeightChain, arbitraryBlockHeaderVersionHeightChain)
-import Chainweb.Test.Orphans.Internal (arbitraryBlockHeaderVersion, arbitraryBlockHeaderVersionHeight, arbitraryBlockHashRecordVersionHeightChain, arbitraryBlockHeaderVersionHeightChain)
--- import Chainweb.Test.SPV.EventProof hiding (tests)
+import Chainweb.Test.Orphans.Internal ()
 import Chainweb.Test.Utils
 import Chainweb.Time
 import Chainweb.Utils
 import Chainweb.Utils.Paging
 import Chainweb.Version
-
+import Chainweb.Version.Mainnet (mainnet)
 import Network.X509.SelfSigned
-
 import P2P.Node
 import P2P.Node.Configuration
 import P2P.Peer
 import P2P.Test.Orphans ()
-
-import Utils.Logging
-import Control.Lens (view)
-import Chainweb.Version.Mainnet (mainnet)
 import Pact.Core.Gas
-import Chainweb.Ranked
+import Pact.Parse
+import Test.QuickCheck
+import Test.QuickCheck.Instances ()
+import Test.Tasty
+import Test.Tasty.QuickCheck
+import Utils.Logging
 
 -- -------------------------------------------------------------------------- --
 -- Roundrip Tests

--- a/test/unit/ChainwebTests.hs
+++ b/test/unit/ChainwebTests.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE NumericUnderscores #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ImportQualifiedPost #-}
 
 -- |
 -- Module: Main
@@ -14,74 +15,55 @@
 
 module Main ( main, setTestLogLevel ) where
 
+-- import qualified Chainweb.Test.BlockHeaderDB.PruneForks (tests)
+-- import qualified Chainweb.Test.Mempool.Consensus (tests)
+-- import qualified Chainweb.Test.Pact.SPVTest
+-- import qualified Chainweb.Test.SPV (tests)
+-- import qualified Chainweb.Test.SPV.EventProof (properties)
+import Chainweb.Storage.Table.RocksDB
+import Chainweb.Test.BlockHeader.Genesis qualified (tests)
+import Chainweb.Test.BlockHeader.Validation qualified (tests)
+import Chainweb.Test.BlockHeaderDB qualified (tests)
+import Chainweb.Test.Chainweb.Utils.Paging qualified (properties)
+import Chainweb.Test.Cut qualified (properties)
+import Chainweb.Test.CutDB qualified (tests)
+import Chainweb.Test.Difficulty qualified (properties)
+import Chainweb.Test.HostAddress qualified (properties)
+import Chainweb.Test.Mempool.InMem qualified (tests)
+import Chainweb.Test.Mempool.RestAPI qualified (tests)
+import Chainweb.Test.Mempool.Sync qualified (tests)
+import Chainweb.Test.MinerReward qualified (tests)
+import Chainweb.Test.Mining qualified (tests)
+import Chainweb.Test.Misc qualified (tests)
+import Chainweb.Test.Pact.CheckpointerTest qualified
+import Chainweb.Test.Pact.HyperlanePluginTests qualified
+import Chainweb.Test.Pact.PactServiceTest qualified
+import Chainweb.Test.Pact.RemotePactTest qualified
+import Chainweb.Test.Pact.TransactionExecTest qualified
+import Chainweb.Test.Pact.TransactionTests qualified
+import Chainweb.Test.Pact4.NoCoinbase qualified
+import Chainweb.Test.Pact4.RewardsTest qualified
+import Chainweb.Test.Pact4.SQLite qualified
+import Chainweb.Test.Pact4.TransactionTests qualified
+import Chainweb.Test.Pact4.VerifierPluginTest qualified
+import Chainweb.Test.RestAPI qualified (tests)
+import Chainweb.Test.Roundtrips qualified (tests)
+import Chainweb.Test.Sync.WebBlockHeaderStore qualified (properties)
+import Chainweb.Test.TreeDB qualified (properties)
+import Chainweb.Test.TreeDB.RemoteDB qualified
+import Chainweb.Test.Version qualified (tests)
 import Control.Monad.IO.Class
 import Control.Monad.Trans.Resource
-
+import Data.Test.PQueue qualified (properties)
+import Data.Test.Word.Encoding qualified (properties)
+import P2P.Test.Node qualified (properties)
+import P2P.Test.TaskQueue qualified (properties)
 import System.Environment
 import System.LogLevel
-
+import Test.Chainweb.SPV.Argument qualified
 import Test.Tasty
 import Test.Tasty.JsonReporter
 import Test.Tasty.QuickCheck
-
--- chainweb modules
-
-import Chainweb.BlockHeader
-import Chainweb.BlockHeaderDB
-import Chainweb.Storage.Table.RocksDB
-import Chainweb.Version.Development
-import Chainweb.Version.RecapDevelopment
-import Chainweb.Version.Registry
-
--- chainweb-test-tools modules
-
-import Chainweb.Test.Utils
-    (independentSequentialTestGroup, toyChainId, withToyDB, toyVersion)
-
--- internal modules
-
-import qualified Chainweb.Test.BlockHeader.Genesis (tests)
-import qualified Chainweb.Test.BlockHeader.Validation (tests)
-import qualified Chainweb.Test.BlockHeaderDB (tests)
--- import qualified Chainweb.Test.BlockHeaderDB.PruneForks (tests)
-import qualified Chainweb.Test.Chainweb.Utils.Paging (properties)
-import qualified Chainweb.Test.Cut (properties)
-import qualified Chainweb.Test.CutDB (tests)
-import qualified Chainweb.Test.Difficulty (properties)
-import qualified Chainweb.Test.HostAddress (properties)
--- import qualified Chainweb.Test.Mempool.Consensus (tests)
-import qualified Chainweb.Test.Mempool.InMem (tests)
-import qualified Chainweb.Test.Mempool.RestAPI (tests)
-import qualified Chainweb.Test.Mempool.Sync (tests)
-import qualified Chainweb.Test.MinerReward (tests)
-import qualified Chainweb.Test.Mining (tests)
-import qualified Chainweb.Test.Misc (tests)
-import qualified Chainweb.Test.Pact.CheckpointerTest
-import qualified Chainweb.Test.Pact.HyperlanePluginTests
-import qualified Chainweb.Test.Pact.PactServiceTest
-import qualified Chainweb.Test.Pact.RemotePactTest
--- import qualified Chainweb.Test.Pact.SPVTest
-import qualified Chainweb.Test.Pact.TransactionExecTest
-import qualified Chainweb.Test.Pact.TransactionTests
-import qualified Chainweb.Test.Pact4.NoCoinbase
-import qualified Chainweb.Test.Pact4.RewardsTest
-import qualified Chainweb.Test.Pact4.SQLite
-import qualified Chainweb.Test.Pact4.VerifierPluginTest
-import qualified Chainweb.Test.Pact4.TransactionTests
-import qualified Chainweb.Test.RestAPI (tests)
-import qualified Chainweb.Test.Roundtrips (tests)
--- import qualified Chainweb.Test.SPV (tests)
--- import qualified Chainweb.Test.SPV.EventProof (properties)
-import qualified Chainweb.Test.Sync.WebBlockHeaderStore (properties)
-import qualified Chainweb.Test.TreeDB (properties)
-import qualified Chainweb.Test.TreeDB.RemoteDB
-import qualified Chainweb.Test.Version (tests)
-import qualified Data.Test.PQueue (properties)
-import qualified Data.Test.Word.Encoding (properties)
-import qualified P2P.Test.Node (properties)
-import qualified P2P.Test.TaskQueue (properties)
-import Chainweb.Version (withVersion)
-import qualified Test.Chainweb.SPV.Argument
 
 setTestLogLevel :: LogLevel -> IO ()
 setTestLogLevel l = setEnv "CHAINWEB_TEST_LOG_LEVEL" (show l)


### PR DESCRIPTION
This PR is a step in the direction of bringing back sanity to the formatting of module imports and language pragmas.

## Background

Historically, module import lists were in a particular that put external and internal modules in different sections. This format predates the Haskell-language-server (hls).

With the widespread use of hls it becomes more convenient to add new import automatically. However, this often results in redundant important statements and also leafs the import list unsorted, which make merges and code maintenance more difficult.

Similar statements apply to language pragmas.

As discussed in the team we are transitioning the code base to a new layout, with the following rules. The guiding principle is
to establish a compromise between the use of hls and code readability and maintainability and reducing merge overhead.

## Module Imports

1. No redundant module imports.
2. Qualified module imports use `ImportPostQualified` notation (which makes sorting and reading easier).
3. Each import is on a single line (even if lines get long).
4. module imports are organized in a list without interspersed empty lines.
5. the list of module imports is lexicographically sorted.
6. Modules can be imported qualified or unqualified, with or without explicit symbol lists or hiding directive, as long as each import starts at the start of a line with `module <Qualified Module Name>` (the only exception are "package" imports). 

## Language Pragmas

1. Language pragmas appear at the very top of a module.
1. Each pragma enables a single language extension.
2. Each pragma appears on a separate line.
3. There are no newlines in-between language pragmas.
4. Any other pragmatic appears in the module *after* the language pragmas (separated by at least one empty line).
5. Redundant language pragmas are acceptable but should be avoided.
7. The list of language pragmas is lexicographically sorted.

An example for formatting a single language pragmatic is `{-# LANGUAGE OverloadedStrings #-}`.