### PR TITLE
remove `errors` package

### DIFF
--- a/chainweb.cabal
+++ b/chainweb.cabal
@@ -408,7 +408,6 @@ library
         , direct-sqlite >= 2.3.27
         , directory >= 1.3
         , dlist >= 0.8
-        , errors >= 2.3
         , ethereum:{ethereum, secp256k1} >= 0.1
         , exceptions >= 0.8
         , file-embed >= 0.0

--- a/src/Chainweb/BlockHeaderDB/RemoteDB.hs
+++ b/src/Chainweb/BlockHeaderDB/RemoteDB.hs
@@ -21,7 +21,6 @@ module Chainweb.BlockHeaderDB.RemoteDB
   , remoteDb
   ) where
 
-import Control.Error.Util (hush)
 import Control.Lens
 import Control.Monad.Catch (handle, throwM)
 

--- a/src/Chainweb/Pact/Mempool/InMem.hs
+++ b/src/Chainweb/Pact/Mempool/InMem.hs
@@ -33,7 +33,6 @@ import Control.Applicative ((<|>))
 import Control.Concurrent.Async
 import Control.Concurrent.MVar
 import Control.DeepSeq
-import Control.Error.Util (hush)
 import Control.Exception (evaluate, mask_)
 import Control.Monad
 import Control.Monad.IO.Class
@@ -493,6 +492,7 @@ insertCheckInMem' cfg lock txs
     now <- getCurrentTimeIntegral
     badmap <- withMVarMasked lock $ readIORef . _inmemBadMap
     curTxIdx <- withMVarMasked lock $ readIORef . _inmemCurrentTxs
+    let hush = either (const Nothing) Just
 
     let withHashes :: Vector (T2 TransactionHash t)
         withHashes = flip V.mapMaybe txs $ \tx ->

--- a/src/Chainweb/Pact4/SPV.hs
+++ b/src/Chainweb/Pact4/SPV.hs
@@ -30,7 +30,6 @@ module Chainweb.Pact4.SPV
 
 import GHC.Stack
 
-import Control.Error
 import Control.Lens hiding (index)
 import Control.Monad
 import Control.Monad.Catch
@@ -414,7 +413,7 @@ getTxIdx headerOracle pdb bh th = do
           & S.mapM toTxHash
           & sindex (== th)
 
-        r & note "unable to find transaction at the given block height"
+        r & maybe (Left "unable to find transaction at the given block height") Right
           & fmap int
           & return
   where

--- a/src/Chainweb/VerifierPlugin/Hyperlane/Message/After225.hs
+++ b/src/Chainweb/VerifierPlugin/Hyperlane/Message/After225.hs
@@ -18,7 +18,6 @@
 module Chainweb.VerifierPlugin.Hyperlane.Message.After225 (runPlugin) where
 
 import Control.Lens
-import Control.Error
 import Control.Exception (evaluate)
 import Control.Monad (unless)
 import Control.Monad.Except


### PR DESCRIPTION
This PR removes the `errors` package. We rely on two helpers:
- `hush`
- `note`

which can be easily integrated into our codebase.