### PR TITLE
add blockhistory migration

### DIFF
--- a/chainweb.cabal
+++ b/chainweb.cabal
@@ -246,6 +246,7 @@ library
         , Chainweb.PayloadProvider.Pact
         , Chainweb.PayloadProvider.Pact.Configuration
         , Chainweb.PayloadProvider.Pact.Genesis
+        , Chainweb.PayloadProvider.Pact.BlockHistoryMigration
         , Chainweb.PayloadProvider.P2P
         , Chainweb.PayloadProvider.P2P.RestAPI
         , Chainweb.PayloadProvider.P2P.RestAPI.Client
@@ -642,6 +643,7 @@ test-suite chainweb-tests
         Chainweb.Test.Mining
         Chainweb.Test.Misc
         Chainweb.Test.Pact.CheckpointerTest
+        Chainweb.Test.Pact.BlockHistoryMigrationTest
         Chainweb.Test.Pact.CutFixture
         Chainweb.Test.Pact.HyperlanePluginTests
         Chainweb.Test.Pact.PactServiceTest
@@ -748,6 +750,37 @@ test-suite chainweb-tests
         , wai >= 3.2
         , warp >= 3.3.6
         , warp-tls >= 3.4
+    if flag(ed25519)
+        cpp-options: -DWITH_ED25519=1
+
+test-suite blockhistory-migration-tests
+    default-language: Haskell2010
+    type: exitcode-stdio-1.0
+    hs-source-dirs: test/blockhistory-migration
+    main-is: BlockHistoryMigrationTests.hs
+
+    build-depends:
+        -- internal
+        , chainweb
+        , chainweb:chainweb-test-utils
+
+        -- external
+        , base >= 4.12 && < 5
+        , chainweb-storage >= 0.1
+        , loglevel >= 0.1
+        , tasty >= 1.0
+        , tasty-hunit >= 0.9
+        , temporary >= 1.3
+        , filepath
+        , directory
+        , mtl
+        , bytestring
+        , direct-sqlite
+        , resourcet
+        , streaming
+        , HUnit
+        , lens
+
     if flag(ed25519)
         cpp-options: -DWITH_ED25519=1
 

--- a/src/Chainweb/BlockHeader/Internal.hs
+++ b/src/Chainweb/BlockHeader/Internal.hs
@@ -62,6 +62,7 @@ module Chainweb.BlockHeader.Internal
 , encodeEpochStartTime
 , decodeEpochStartTime
 , epochStart
+, makeGenesisBlockHeader
 
 -- * FeatureFlags
 , FeatureFlags

--- a/src/Chainweb/Chainweb/ChainResources.hs
+++ b/src/Chainweb/Chainweb/ChainResources.hs
@@ -374,6 +374,7 @@ withPayloadProviderResources logger cid serviceApiConfig peerStuff rdb rewindLim
                     pp <-
                         withPactPayloadProvider
                             cid
+                            rdb
                             (view _4 <$> peerStuff)
                             logger
                             Nothing

--- a/src/Chainweb/Pact/Backend/PactState.hs
+++ b/src/Chainweb/Pact/Backend/PactState.hs
@@ -93,20 +93,20 @@ import Control.Monad.Trans.Resource
 excludedTables :: [Utf8]
 excludedTables = checkpointerTables ++ compactionTables
   where
-    checkpointerTables = ["BlockHistory", "VersionedTableCreation", "VersionedTableMutation", "TransactionIndex"]
+    checkpointerTables = ["BlockHistory2", "VersionedTableCreation", "VersionedTableMutation", "TransactionIndex"]
     compactionTables = ["CompactGrandHash", "CompactActiveRow"]
 
 -- | Get the latest blockheight on chain.
 getLatestBlockHeight :: Database -> IO BlockHeight
 getLatestBlockHeight db = do
-  let qryText = "SELECT MAX(blockheight) FROM BlockHistory"
+  let qryText = "SELECT MAX(blockheight) FROM BlockHistory2"
   throwOnDbError $ qry db qryText [] [RInt] >>= \case
     [[SInt bh]] -> pure (BlockHeight (int bh))
     _ -> error "getLatestBlockHeight: expected int"
 
 getEarliestBlockHeight :: Database -> IO BlockHeight
 getEarliestBlockHeight db = do
-  let qryText = "SELECT MIN(blockheight) FROM BlockHistory"
+  let qryText = "SELECT MIN(blockheight) FROM BlockHistory2"
   throwOnDbError $ qry db qryText [] [RInt] >>= \case
     [[SInt bh]] -> pure (BlockHeight (int bh))
     _ -> error "getEarliestBlockHeight: expected int"
@@ -116,13 +116,13 @@ getEarliestBlockHeight db = do
 --   Throws an exception if it doesn't.
 ensureBlockHeightExists :: Database -> BlockHeight -> IO ()
 ensureBlockHeightExists db bh = do
-  r <- throwOnDbError $ qry db "SELECT blockheight FROM BlockHistory WHERE blockheight = ?1" [SInt (fromIntegral bh)] [RInt]
+  r <- throwOnDbError $ qry db "SELECT blockheight FROM BlockHistory2 WHERE blockheight = ?1" [SInt (fromIntegral bh)] [RInt]
   case r of
     [[SInt rBH]] -> do
       when (fromIntegral bh /= rBH) $ do
         error "ensureBlockHeightExists: malformed query"
     _ -> do
-      error $ "ensureBlockHeightExists: empty BlockHistory: height=" ++ show bh
+      error $ "ensureBlockHeightExists: empty BlockHistory2: height=" ++ show bh
 
 getLatestCommonBlockHeight :: (Logger logger)
   => logger
@@ -251,7 +251,7 @@ getEndingTxId :: ()
   -> IO Int64
 getEndingTxId db bh = do
   r <- throwOnDbError $ qry db
-         "SELECT endingtxid FROM BlockHistory WHERE blockheight=?"
+         "SELECT endingtxid FROM BlockHistory2 WHERE blockheight=?"
          [SInt (int bh)]
          [RInt]
   case r of

--- a/src/Chainweb/Pact4/Backend/ChainwebPactDb.hs
+++ b/src/Chainweb/Pact4/Backend/ChainwebPactDb.hs
@@ -854,7 +854,7 @@ commitBlockStateToDatabase db blockHash payloadHash bh blockState = do
             ]
       where
         stmt =
-          "INSERT INTO BlockHistory ('blockheight','hash','payloadhash','endingtxid') VALUES (?,?,?,?);"
+          "INSERT INTO BlockHistory2 ('blockheight','hash','payloadhash','endingtxid') VALUES (?,?,?,?);"
 
     createUserTable :: Text -> IO ()
     createUserTable (toUtf8 -> tablename) = do
@@ -911,7 +911,7 @@ lookupBlockHash db hash = do
         [] -> return $ Nothing
         res -> error $ "Invalid result, " <> sshow res
     where
-    qtext = "SELECT blockheight FROM BlockHistory WHERE hash = ?;"
+    qtext = "SELECT blockheight FROM BlockHistory2 WHERE hash = ?;"
 
 headerOracleForBlock :: BlockHandlerEnv logger -> HeaderOracle
 headerOracleForBlock env = HeaderOracle

--- a/src/Chainweb/PayloadProvider/Pact/BlockHistoryMigration.hs
+++ b/src/Chainweb/PayloadProvider/Pact/BlockHistoryMigration.hs
@@ -1,0 +1,144 @@
+{-# LANGUAGE BlockArguments #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE ImportQualifiedPost #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE NumericUnderscores #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+
+module Chainweb.PayloadProvider.Pact.BlockHistoryMigration where
+
+import Chainweb.BlockHash
+import Chainweb.BlockHeader
+import Chainweb.BlockHeaderDB (BlockHeaderDb)
+import Chainweb.Logger
+import Chainweb.Pact.Backend.Types (SQLiteEnv)
+import Chainweb.TreeDB
+import Chainweb.Version (HasVersion)
+import Control.Lens
+import Control.Monad.IO.Class
+import System.Logger qualified as L
+import System.LogLevel
+import Chainweb.Pact.Backend.Utils
+import Chainweb.Pact.Backend.PactState (qryStream)
+import Streaming qualified as S
+import Streaming.Prelude qualified as S
+import Chainweb.Utils (sshow, whenM)
+import Control.Exception.Safe
+import Chainweb.Utils.Serialization (runPutS, runGetS)
+import Data.IORef (newIORef, readIORef, modifyIORef')
+import Control.Monad
+import Data.Time.Clock (getCurrentTime, diffUTCTime)
+
+-- | Migrates the @BlockHistory@ table if it is outdated or missing required columns.
+--
+-- Due to SQLite limitations, we cannot simply add the missing column and migrate
+-- the data afterward. Specifically, constraints (such as the uniqueness of the
+-- @blockhash@ column) must be satisfied at the time the column is added, and
+-- SQLite does not allow adding columns with unique constraints via @ALTER TABLE@.
+-- See <https://www.sqlite.org/lang_altertable.html> for more details.
+--
+-- The migration is performed only if 'tableNeedsMigration' indicates it's necessary.
+-- It proceeds in a row-wise migration of existing data from the old @BlockHistory@ table and
+-- the 'BlockHeaderDb' (backed by RocksDb), performed in chunks of 10,000 entries.
+--
+-- Each chunk is committed in a transaction block.
+--
+-- NOTE: THIS Module can be deleted after migration !!!
+--
+migrateBlockHistoryTable
+  :: HasVersion
+  => Logger logger
+  => logger        -- ^ logger
+  -> SQLiteEnv     -- ^ sqlite database
+  -> BlockHeaderDb -- ^ block header database
+  -> Bool          -- ^ cleanup table after migration
+  -> IO ()
+migrateBlockHistoryTable logger sdb bhdb cleanup
+  = L.withLoggerLabel ("component", "migrateBlockHistoryTable") logger $ \lf ->
+    whenM (tableNeedsMigration lf sdb) $ do
+      let logf serv msg = liftIO $ logFunctionText lf serv msg
+
+      nBlockHistory2 <- nTableEntries "BlockHistory2"
+      nBlockHistory <- nTableEntries "BlockHistory"
+
+      when (nBlockHistory2 <= nBlockHistory) $ do
+        logf Info "Partial migration detected, cleaning up and restarting."
+        throwOnDbError $ exec_ sdb "DELETE FROM BlockHistory2"
+
+      let qstmt = "SELECT blockheight, endingtxid, hash from BlockHistory ORDER BY blockheight,endingtxid ASC"
+          rty = [RInt, RInt, RBlob]
+
+      start <- getCurrentTime
+
+      e <- qryStream sdb qstmt [] rty $ \rs -> do
+        remainingRowsRef <- newIORef nBlockHistory
+        rs
+          & S.chunksOf 10_000
+          & S.mapsM_ (\chunk -> do
+            remainingRows <- readIORef remainingRowsRef
+            let perc = (1.0 - fromIntegral @_ @Double remainingRows / fromIntegral @_ @Double nBlockHistory) * 100.0
+            logf Info $ "Table migration: Process remaining rows: " <> sshow remainingRows <> " ("<> sshow perc <> ")"
+            r <- tx $ flip S.mapM_ chunk $ \case
+              rr@[SInt bh, SInt _, SBlob h] -> do
+                let rowBlockHeight = fromIntegral bh
+                rowBlockHash <- runGetS decodeBlockHash h
+                blockHeader <- lookupRanked bhdb rowBlockHeight rowBlockHash >>= \case
+                    Nothing -> do
+                      error $ "BlockHeader Entry missing for "
+                        <> "blockHeight="
+                        <> sshow rowBlockHeight
+                        <> ", blockHash="
+                        <> sshow rowBlockHash
+                    Just blockHeader -> return blockHeader
+
+                let bph = view blockPayloadHash blockHeader
+                    enc = runPutS $ encodeBlockPayloadHash bph
+
+                throwOnDbError $ exec' sdb "INSERT INTO BlockHistory2 (blockheight, endingtxid, hash, payloadhash) VALUES (?, ?, ?, ?)"
+                  $ rr ++ [SBlob enc]
+              _ -> error "unexpected row shape"
+
+            modifyIORef' remainingRowsRef (\old -> max 0 (old - 10_000))
+            pure r)
+
+      case e of
+        Left e' -> error $ "Table migration failure: " <> sshow e'
+        Right () -> do
+          end <- getCurrentTime
+          logf Info $ "Elapsed Time: " <> sshow (diffUTCTime end start)
+
+          when cleanup $ do
+            logf Info "Data migration completed, cleaning up"
+            throwOnDbError $ exec_ sdb "DROP TABLE BlockHistory"
+
+          logf Info "Table migration successful"
+
+  where
+    tx = bracket_
+      (throwOnDbError $ exec_ sdb "BEGIN TRANSACTION")
+      (throwOnDbError $ exec_ sdb "COMMIT TRANSACTION")
+    nTableEntries tname = throwOnDbError $ qry_ sdb ("SELECT count(*) from " <> tname) [RInt] >>= \case
+        [[SInt n]] -> pure n
+        _ -> error "unexpected row shape"
+
+
+-- | Checks whether the @BlockHistory@ table is (still) existing
+--   and therefore requires a data migration step.
+tableNeedsMigration
+  :: Logger logger
+  => logger
+  -> SQLiteEnv
+  -> IO Bool
+tableNeedsMigration lf sqe = do
+  let logf serv msg = liftIO $ logFunctionText lf serv msg
+
+  r <- throwOnDbError $ qry sqe "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'BlockHistory';" [] [RInt]
+  case r of
+    [[SInt _]] -> do
+        logf Info "BlockHistory table exists, need to migrate data."
+        pure True
+    _ -> do
+      logf Info "BlockHistory table does not exists. No table migration required."
+      pure False

--- a/test/blockhistory-migration/BlockHistoryMigrationTests.hs
+++ b/test/blockhistory-migration/BlockHistoryMigrationTests.hs
@@ -1,0 +1,128 @@
+{-# LANGUAGE RankNTypes, OverloadedStrings #-}
+{-# LANGUAGE ImportQualifiedPost #-}
+{-# LANGUAGE LambdaCase #-}
+
+module Main
+( main
+) where
+
+import Chainweb.BlockHash
+import Chainweb.BlockHeader
+import Chainweb.BlockHeaderDB
+import Chainweb.Graph
+import Chainweb.Logger
+import Chainweb.Pact.Backend.ChainwebPactDb
+import Chainweb.Pact.Backend.ChainwebPactDb qualified as ChainwebPactDb
+import Chainweb.Pact.Backend.PactState (qryStream)
+import Chainweb.Pact.Backend.Types
+import Chainweb.Pact.Backend.Utils
+import Chainweb.PayloadProvider.Pact.BlockHistoryMigration (migrateBlockHistoryTable)
+import Chainweb.Storage.Table.RocksDB
+import Chainweb.Test.MultiNode qualified
+import Chainweb.Test.Pact.Utils
+import Chainweb.Test.TestVersions
+import Chainweb.Test.Utils
+import Chainweb.TreeDB (lookupRankedM)
+import Chainweb.Utils.Serialization
+import Chainweb.Version
+import Chainweb.Version.EvmTestnet (evmTestnet)
+import Chainweb.Version.Mainnet
+import Control.Lens
+import Control.Monad.Except
+import Control.Monad.IO.Class
+import Control.Monad.Trans.Resource
+import Data.ByteString qualified as BS
+import Data.Function
+import Database.SQLite3.Direct qualified as SQL
+import Streaming qualified as S
+import Streaming.Prelude qualified as S
+import System.Directory
+import System.Environment (lookupEnv)
+import System.FilePath
+import System.IO.Temp
+import System.LogLevel
+import Test.HUnit (assertFailure)
+import Test.Tasty
+import Test.Tasty.HUnit
+
+loglevel :: LogLevel
+loglevel = Warn
+
+cid :: ChainId
+cid = unsafeChainId 1
+
+prepareSQLite :: SQLiteEnv -> IO ()
+prepareSQLite sql = throwOnDbError $ do
+  exec_ sql
+    "CREATE TABLE IF NOT EXISTS BlockHistory \
+    \(blockheight UNSIGNED BIGINT NOT NULL, \
+    \ endingtxid UNSIGNED BIGINT NOT NULL, \
+    \ hash BLOB NOT NULL, \
+    \ CONSTRAINT blockHeightConstraint UNIQUE (blockheight), \
+    \ CONSTRAINT hashConstraint UNIQUE (hash));"
+
+  liftIO $ ChainwebPactDb.initSchema sql
+
+requireEnv :: String -> IO String
+requireEnv name =
+  lookupEnv name >>= maybe (fail $ name ++ " not set") pure
+
+main :: IO ()
+main = withSystemTempDirectory "sql-db" $ \dbDir -> do
+  logger <- getTestLogger
+
+  -- /Volumes/Extreme Pro/db-chainweb-node-mainnet/0/sqlite/pact-v1-chain-1.sqlite
+  dbpath <- requireEnv "SQLITE_CHAIN1_FILEPATH"
+  -- /Volumes/Extreme Pro/db-chainweb-node-mainnet/0/rocksDb
+  rocksdbPath <- requireEnv "ROCKSDB_DIRPATH"
+
+  copyFile dbpath (dbDir </> "pact-v1-chain-1.sqlite")
+
+  sql <- startSqliteDb cid logger dbDir False
+
+  prepareSQLite sql
+  n <- nTableEntries sql "BlockHistory"
+  n2 <- nTableEntries sql "BlockHistory2"
+
+  assert (n > 0) "BlockHistory Table is not empty"
+  assert (n2 == 0) "BlockHistory2 Table is empty"
+
+  withRocksDb rocksdbPath modernDefaultOptions $ \rocksdb -> do
+    withVersion Mainnet01 $ runResourceT $ do
+      bhdb <- withBlockHeaderDb rocksdb cid
+      liftIO $ do
+        migrateBlockHistoryTable logger sql bhdb False
+
+        let qstmt = "SELECT A.blockheight, A.endingtxid, \
+                    \ B.hash AS b_hash, B.payloadhash AS b_payload_hash, \
+                    \ A.hash AS a_hash \
+                    \ FROM BlockHistory AS A INNER JOIN BlockHistory2 AS B \
+                    \ ON A.blockheight = B.blockheight AND A.endingtxid = B.endingtxid \
+                    \ ORDER BY A.blockheight, A.endingtxid"
+            rty = [RInt, RInt, RBlob, RBlob, RBlob]
+
+        qryStream sql  qstmt [] rty $ \rs -> do
+          rs & flip S.mapM_ $ \[SInt a_bh, SInt a_etxid, SBlob b_hash, SBlob b_payload, SBlob a_hash] -> do
+
+            assert (a_hash == b_hash) $
+              "Hash mismatch at block " ++ show a_bh ++ " / txid " ++ show a_etxid
+
+            let rowBlockHeight = fromIntegral a_bh
+            rowBlockHash <- runGetS decodeBlockHash a_hash
+            blockHeader <- lookupRankedM bhdb rowBlockHeight rowBlockHash
+            let bph = view blockPayloadHash blockHeader
+                enc = runPutS $ encodeBlockPayloadHash bph
+
+            assert (b_payload == enc) $
+              "Payload Hash mismatch at block " ++ show a_bh ++ " / txid " ++ show a_etxid
+
+        n2' <- nTableEntries sql "BlockHistory2"
+        assert (n == n2') "BlockHistory2 has the same number of rows as BlockHistory"
+
+  where
+  assert p msg =
+      if p then pure () else Test.HUnit.assertFailure msg
+
+  nTableEntries sql tname = throwOnDbError $ qry_ sql ("SELECT count(*) from " <> tname) [RInt] >>= \case
+        [[SInt n]] -> pure n
+        _ -> error "unexpected row shape"

--- a/test/unit/Chainweb/Test/Pact/BlockHistoryMigrationTest.hs
+++ b/test/unit/Chainweb/Test/Pact/BlockHistoryMigrationTest.hs
@@ -1,0 +1,210 @@
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE ImportQualifiedPost #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RankNTypes #-}
+
+module Chainweb.Test.Pact.BlockHistoryMigrationTest
+  (tests)
+where
+
+import Chainweb.BlockHash
+import Chainweb.BlockHeader
+import Chainweb.BlockHeaderDB
+import Chainweb.BlockHeaderDB.Internal
+import Chainweb.Logger
+import Chainweb.Pact.Backend.ChainwebPactDb qualified as ChainwebPactDb
+import Chainweb.Pact.Backend.PactState
+import Chainweb.Pact.Backend.Types
+import Chainweb.Pact.Backend.Utils
+import Chainweb.PayloadProvider.Pact.BlockHistoryMigration (migrateBlockHistoryTable)
+import Chainweb.Storage.Table.RocksDB
+import Chainweb.Test.Pact.Utils
+import Chainweb.Test.Utils
+import Chainweb.TreeDB
+import Chainweb.Utils
+import Chainweb.Utils.Serialization
+import Chainweb.Version
+import Chainweb.Version.Mainnet
+import Control.Lens
+import Control.Monad.IO.Class
+import Control.Monad.Trans.Resource
+import Data.Aeson (throwDecodeStrict')
+import Data.ByteString qualified as BS
+import Data.ByteString.Base64 qualified as B64
+import Data.Foldable (traverse_)
+import Data.Int (Int64)
+import Data.Maybe (fromJust)
+import Database.SQLite3.Direct
+import Streaming.Prelude qualified as S
+import Test.Tasty
+import Test.Tasty.HUnit hiding (assert)
+
+cid :: ChainId
+cid = unsafeChainId 0
+
+createLegacyBlockHistoryTable :: SQLiteEnv -> IO ()
+createLegacyBlockHistoryTable sql = throwOnDbError $
+  exec_ sql
+    "CREATE TABLE IF NOT EXISTS BlockHistory \
+    \(blockheight UNSIGNED BIGINT NOT NULL, \
+    \ endingtxid UNSIGNED BIGINT NOT NULL, \
+    \ hash BLOB NOT NULL, \
+    \ CONSTRAINT blockHeightConstraint UNIQUE (blockheight), \
+    \ CONSTRAINT hashConstraint UNIQUE (hash));"
+
+
+initSchema :: SQLiteEnv -> IO ()
+initSchema sql = do
+  ChainwebPactDb.initSchema sql     -- create the BlockHistory2 table
+  createLegacyBlockHistoryTable sql -- create the legacy BlockHistory table
+
+withSetup
+  :: TestName
+  -> (SQLiteEnv -> IO ())
+  -> (HasVersion => GenericLogger -> SQLiteEnv -> BlockHeaderDb -> Bool -> IO ())
+  -> TestTree
+withSetup n setup action = withResourceT (withTempChainSqlite cid) $ \sqlIO -> do
+  testCase n $ do
+    logger <- getTestLogger
+    (sql, _sqlReadPool) <- sqlIO
+
+    _ <- setup sql
+
+    withTempRocksDb "chainweb-tests" $ \rdb -> do
+      withVersion Mainnet01 $ runResourceT $ do
+        bhdb <- withBlockHeaderDb rdb cid
+        liftIO $ action logger sql bhdb True
+
+tests :: HasCallStack => TestTree
+tests = testGroup "BlockHistory Table Migration" [
+     withSetup "test with empty BlockHistoryTable"
+        initSchema
+        migrateBlockHistoryTable
+    , withSetup "test successful migration cleanup"
+        initSchema
+        $ \lf sdb bhdb cleanup -> do
+            let qryIO = throwOnDbError $ qry sdb "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'BlockHistory'" [] [RInt]
+            [[SInt p]] <- qryIO
+            assertExpectation "Table should be present" (Expected 1) (Actual p)
+            migrateBlockHistoryTable lf sdb bhdb cleanup
+            post <- qryIO
+            assertExpectation "Table should not be present" (Expected []) (Actual post)
+    , withSetup "test migration"
+        initSchema
+        $ \lf sdb bhdb _cleanup -> do
+          traverse_ (unsafeInsertBlockHeaderDb bhdb) blockHeaders
+          traverse_ (unsafeInsertEntry sdb) sqliteData
+
+          -- Disable original table cleanup for migration verification.
+          migrateBlockHistoryTable lf sdb bhdb False
+
+          verifyMigration sdb bhdb
+
+          -- Re-run verification
+          migrateBlockHistoryTable lf sdb bhdb False
+
+          verifyMigration sdb bhdb
+    , withSetup "test migration with one missing row"
+        initSchema
+        $ \lf sdb bhdb _cleanup -> do
+          traverse_ (unsafeInsertBlockHeaderDb bhdb) blockHeaders
+          traverse_ (unsafeInsertEntry sdb) sqliteData
+
+          -- Disable original table cleanup for migration verification.
+          migrateBlockHistoryTable lf sdb bhdb False
+
+          verifyMigration sdb bhdb
+
+          -- remove single row from BlockHistory2 table
+          let (rbh,_,_) = head sqliteData
+          throwOnDbError $ exec' sdb "DELETE FROM BlockHistory2 where blockheight=?" [SInt rbh]
+
+          n <- nTableEntries sdb "BlockHistory2"
+          assert (n == 9) $ "BlockHistory2 should contain 9 entries, actual: " <> sshow n
+
+          -- Re-run verification
+          migrateBlockHistoryTable lf sdb bhdb False
+
+          verifyMigration sdb bhdb
+    ]
+
+
+-- | Blockheader from mainnet01 of chain 1
+--
+-- Obtained by curl -H 'https://api.chainweb.com/chainweb/0.0/mainnet01/chain/1/header?limit=10' | jq
+blockHeaders :: [BlockHeader]
+blockHeaders = fromJust $ traverse throwDecodeStrict'  [
+    "\"AAAAAAAAAAAAJ41tFZYFAMhy366rCocPqnIPH492fe3J_cMShzHQwiyBVMT5RnKFAwADAAAAUsNRCUkMKQBRDVIv0JLDfDllYNg2QO0EXaWcRfMQ6g0EAAAAOu6kxMXpuwpm9uiIVhiEFHSbTdhanjHyiEh2G0EZV_wGAAAABQeojaqG63-R_1bILrd0LI6kDkS74hNBB0Bs3Y211bD__________________________________________5Apaf08O5Hgi1zH2gsox_oE6ABpi70UKojUZoVlAm8bAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFAAAAACeNbRWWBQAAAAAAAAAAAGlRRahfD2xrvjGZFIW9TpOF4o4MVlGMQcYoAUIGZgxS\"",
+    "\"jw3vOXLHNX9X8Pf8F5YFAGlRRahfD2xrvjGZFIW9TpOF4o4MVlGMQcYoAUIGZgxSAwADAAAAtMyy7k6lrQOsGg2oXh20kOC3zudjwsaL9F5Ogx0XNBoEAAAAyeWKDE27xM45-LgdwpnVMM6E4pAoYryRrJJFgRiaKgQGAAAAOXehM2W5YuiV0iWlDGIPMdaRv721zMUbj3caJqZJNBX__________________________________________3CgdhATU9VNY_SB4Z9xQYmupqf0-0oZU5WKfk0I_SJJAQAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAFAAAAACeNbRWWBQAAAAAAAAAAABwrUPRfEh4gKXiQaLRVoqUK1aDCluIWbmZQzt9lUSDV\"",
+    "\"NSpftriT22gDWwz9F5YFABwrUPRfEh4gKXiQaLRVoqUK1aDCluIWbmZQzt9lUSDVAwADAAAAe0GGnclF0G2-_AMlCLGjKJVgzSBj1V9dTiqtsCC-IB4EAAAAuekHplt74MFfLHPsu7cJz9HbWNb_vBY-MR1y5RRDiYsGAAAA7OcrWyX2Gk7zrwmdI6HALWBvCihE6PwaS7TELscDGCH__________________________________________7sfFm8JbPK3qCTNeRvk4tzVrddPKuqFw-tI68WMfCvbAQAAAAIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgAAAAAAAAAFAAAAACeNbRWWBQAAAAAAAAAAALpshckMhpgcor3YL9kXfHzYpq1iMsbjLA-2QKABndRt\"",
+    "\"h1RefsOyecrGlGX9F5YFALpshckMhpgcor3YL9kXfHzYpq1iMsbjLA-2QKABndRtAwADAAAAUYQRTGxyJpPIvFxR8mRa-wtGsBD9ymVwuPv9ta90DCEEAAAAhcayV2lxaq0ExtZZAKbHGptweEhk44dh3rk_6QGEff8GAAAAxu26E8QHPhi3GfZjOtisZyzMuR6E4-ekdfO-eWd06YT__________________________________________-nZJfKtvRk1CPK-MEaEfWAy0WrGA5g7b0xFyq1LykpHAQAAAAMAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAwAAAAAAAAAFAAAAACeNbRWWBQAAAAAAAAAAALO4obrG733x3raJyCjCQKWTp9IxoVDXC00thjQhnq5Z\"",
+    "\"ApXp4xPFfLL6MHT9F5YFALO4obrG733x3raJyCjCQKWTp9IxoVDXC00thjQhnq5ZAwADAAAAKuCNwclDosE_LMTCJPR-m8cLSTlQodWupf1c7PacZMEEAAAAlO6bNRGAwyiMdOAcDBushxBQheVa6Ra7TAd6OECzVVUGAAAAY00AQMeyYamYt6RnqEmQkAJVSt_OyNTZPA8ySAbs1c___________________________________________7Rres8j0FBEYwtUcS5UBNQumgtf0PG6j7y4VRMafRdmAQAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAFAAAAACeNbRWWBQAAAAAAAAAAAJr-V0iWi6yBDNGqEU0oJLNUrVOACJmITKsOvRz4H90R\"",
+    "\"0t473zHYtI-uNbf9F5YFAJr-V0iWi6yBDNGqEU0oJLNUrVOACJmITKsOvRz4H90RAwADAAAAumaN584K3DrEDxwpyuETFMsQ6ECseJVda54NIeQn8TkEAAAAv9sZzSMjqRD_uVMGoM-5kVnNqkRTYGqH6O-C7dIqXJsGAAAAcsRGLYQHN1NIYa1sXlj0eFaYwDLG7Vg3zqps05VEvGj__________________________________________5-87RGWTTcz0_voXhENxoJO6YTSH0GpwPkzCAxBCSvwAQAAAAUAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABQAAAAAAAAAFAAAAACeNbRWWBQAAAAAAAAAAAERk0j0pZ1OduMRVwNDrexiPbxnTPTKIjwwNmsZ-gl6H\"",
+    "\"vhmHzX6Tuzdm--H9F5YFAERk0j0pZ1OduMRVwNDrexiPbxnTPTKIjwwNmsZ-gl6HAwADAAAA7mB5gbJFX_TnYhstzsiLBEhe0kT5nhh_JpPHfe7gMMEEAAAAxC3P3K1B1gDjwyLJPABbGt2qLuF93Y7QyiTNctqm94cGAAAA8JQk7mo7jCppLZnaHG6Doz6dOxrrKLXypB8CdzuAKHX__________________________________________65nMrh2AwrQTKIvl7YVg3ulCXikvFzPX4dVpPT9-s6cAQAAAAYAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABgAAAAAAAAAFAAAAACeNbRWWBQAAAAAAAAAAAMpV6GV2nJeFmSVBjo7QzWvF5W2LPS9uKFUCKJfU29Qr\"",
+    "\"XDW_QcCklR_DbUD-F5YFAMpV6GV2nJeFmSVBjo7QzWvF5W2LPS9uKFUCKJfU29QrAwADAAAAlk-iO8laTJ5Gy-U7pE-P3EDr548IUL1sWOfZv9DGHn0EAAAAhFuMKuqHuk4fA2BOBCTvTEFrOZEs691JLXuINP3BSu4GAAAA85F8Vdy_NKXopcOdG4pcEpAw8G2Xk4wWfp29d_T5xk7__________________________________________7g-M1b3FLNbXKogETFOeA6w2xPeMWVODCbJl8PHDEGDAQAAAAcAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABwAAAAAAAAAFAAAAACeNbRWWBQAAAAAAAAAAAF8yBC9hIAHcsIUtgH5-RFdC2-QAmkmuB93qDIlXLWBB\"",
+    "\"415OTHBmkcV-oJn-F5YFAF8yBC9hIAHcsIUtgH5-RFdC2-QAmkmuB93qDIlXLWBBAwADAAAAPT37vtcbWdrZUi21FIrCyeUl4rU6g4W6syR3iM-mSyUEAAAAUcfuhJG94kMymAtpftR3Vbv3dNuCCpIOaf2PZULHemwGAAAAumhex2eCzZTd9mVjd8QBug13FN2Y_65X68Guel01bLb__________________________________________9lYTtyLATglm7r7WHyqgYL3tqtOdVjaYqlv2w6JpDmmAQAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACAAAAAAAAAAFAAAAACeNbRWWBQAAAAAAAAAAAE8hMzYm6jX5iR2HwqCIreHN4eHJNBwlAxdUp0A4wEJ1\"",
+    "\"uD82CpEfylAigrn-F5YFAE8hMzYm6jX5iR2HwqCIreHN4eHJNBwlAxdUp0A4wEJ1AwADAAAAB4vWZj8UZzuvPJkCq3-_32I8pCkdePIRlYz3UIudbowEAAAAFYSAHoaThaLUdIFRcFYSkNm3xk0s7nzDMfY-wB-hp5YGAAAAwT2FOsosNkjFLH4-l-WFevFkAnJiFU-8IpGqpYb0_tr__________________________________________18PgFBxcI7IqYgDsHrSRiwWiAcrodG0YQBKFQuhxxcZAQAAAAkAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACQAAAAAAAAAFAAAAACeNbRWWBQAAAAAAAAAAAO8gTCqlCDrGsVZkvavO_Cr6GX5y6iCcp7XvtXCSsyae\""
+  ]
+
+unsafeInsertEntry :: SQLiteEnv -> (Int64, BS.ByteString, Int64) -> IO ()
+unsafeInsertEntry sql (bh, h, txid) = case B64.decode h of
+  Right h' ->
+    throwOnDbError $ exec' sql "INSERT INTO BlockHistory (blockheight, endingtxid, hash) VALUES (?, ?, ?)"
+      [SInt bh, SInt txid, SBlob h' ]
+  Left _ -> error "error decoding hash"
+
+
+sqliteData :: [(Int64, BS.ByteString, Int64)]
+sqliteData = [
+  (0, "aVFFqF8PbGu+MZkUhb1Ok4XijgxWUYxBxigBQgZmDFI=", 6),
+  (1, "HCtQ9F8SHiApeJBotFWipQrVoMKW4hZuZlDO32VRINU=", 7),
+  (2, "umyFyQyGmByivdgv2Rd8fNimrWIyxuMsD7ZAoAGd1G0=", 8),
+  (3, "s7ihusbvffHetonIKMJApZOn0jGhUNcLTS2GNCGerlk=", 9),
+  (4, "mv5XSJaLrIEM0aoRTSgks1StU4AImYhMqw69HPgf3RE=", 10),
+  (5, "RGTSPSlnU524xFXA0Ot7GI9vGdM9MoiPDA2axn6CXoc=", 11),
+  (6, "ylXoZXacl4WZJUGOjtDNa8XlbYs9L24oVQIol9Tb1Cs=", 12),
+  (7, "XzIEL2EgAdywhS2Afn5EV0Lb5ACaSa4H3eoMiVctYEE=", 13),
+  (8, "TyEzNibqNfmJHYfCoIit4c3h4ck0HCUDF1SnQDjAQnU=", 14),
+  (9, "7yBMKqUIOsaxVmS9q878KvoZfnLqIJynte+1cJKzJp4=", 15)]
+
+
+verifyMigration :: HasVersion => SQLiteEnv -> BlockHeaderDb -> IO ()
+verifyMigration sql bhdb = do
+  let qstmt = "SELECT A.blockheight, A.endingtxid, \
+                    \ B.hash AS b_hash, B.payloadhash AS b_payload_hash, \
+                    \ A.hash AS a_hash \
+                    \ FROM BlockHistory AS A INNER JOIN BlockHistory2 AS B \
+                    \ ON A.blockheight = B.blockheight AND A.endingtxid = B.endingtxid \
+                    \ ORDER BY A.blockheight, A.endingtxid"
+      rty = [RInt, RInt, RBlob, RBlob, RBlob]
+
+  n <- nTableEntries sql "BlockHistory"
+
+  _ <- qryStream sql  qstmt [] rty $ \rs -> do
+    rs & flip S.mapM_ $ \case
+      [SInt a_bh, SInt a_etxid, SBlob b_hash, SBlob b_payload, SBlob a_hash] -> do
+        assert (a_hash == b_hash) $
+                "Hash mismatch at block " ++ show a_bh ++ " / txid " ++ show a_etxid
+
+        let rowBlockHeight = fromIntegral a_bh
+        rowBlockHash <- runGetS decodeBlockHash a_hash
+        blockHeader <- lookupRankedM bhdb rowBlockHeight rowBlockHash
+        let bph = view blockPayloadHash blockHeader
+            enc = runPutS $ encodeBlockPayloadHash bph
+
+        assert (b_payload == enc) $
+          "Payload Hash mismatch at block " ++ show a_bh ++ " / txid " ++ show a_etxid
+
+        n2' <- nTableEntries sql "BlockHistory2"
+        assert (n == n2') "BlockHistory2 has the same number of rows as BlockHistory"
+      _ -> error "unexpected result shape"
+  pure ()
+
+assert :: Bool -> String -> IO ()
+assert = flip assertBool
+
+nTableEntries :: SQLiteEnv -> Utf8 -> IO Int64
+nTableEntries sql tname = throwOnDbError $ qry_ sql ("SELECT count(*) from " <> tname) [RInt] >>= \case
+      [[SInt n]] -> pure n
+      _ -> error "unexpected row shape"

--- a/test/unit/ChainwebTests.hs
+++ b/test/unit/ChainwebTests.hs
@@ -35,6 +35,7 @@ import Chainweb.Test.Mempool.Sync qualified (tests)
 import Chainweb.Test.MinerReward qualified (tests)
 import Chainweb.Test.Mining qualified (tests)
 import Chainweb.Test.Misc qualified (tests)
+import Chainweb.Test.Pact.BlockHistoryMigrationTest qualified (tests)
 import Chainweb.Test.Pact.CheckpointerTest qualified
 import Chainweb.Test.Pact.HyperlanePluginTests qualified
 import Chainweb.Test.Pact.PactServiceTest qualified
@@ -100,6 +101,7 @@ suite rdb =
             ]
         , Chainweb.Test.CutDB.tests rdb
         , Chainweb.Test.Pact.CheckpointerTest.tests
+        , Chainweb.Test.Pact.BlockHistoryMigrationTest.tests
         , Chainweb.Test.Pact.TransactionExecTest.tests rdb
         , Chainweb.Test.Pact.PactServiceTest.tests rdb
         -- TODO: PP


### PR DESCRIPTION
Migrate BlockHistory table to add missing column for the new payload design.

Specifically:

- Constraints such as the uniqueness of the blockhash column must be satisfied at the time the column is added.
- SQLite does not allow adding columns with unique constraints via ALTER TABLE (see [SQLite docs](https://www.sqlite.org/lang_altertable.html)).

This PR introduces a migration that:
- Runs only if tableNeedsMigration indicates it’s required.
- Performs a row-wise migration of existing data from the old BlockHistory table and the BlockHeaderDb (backed by RocksDB).
- Migrates data in chunks of 10,000 entries, each chunk committed in its own transaction for safety and performance.

**Note**
The migration module is temporary and can be removed once all deployments have successfully migrated.