### PR TITLE
Multi-chain incremental pruning

### DIFF
--- a/.github/workflows/applications.yml
+++ b/.github/workflows/applications.yml
@@ -369,6 +369,7 @@ jobs:
           exe:ea \
           exe:genconf \
           exe:known-graphs \
+          exe:standalone-pruner \
           exe:pact-diff \
           test:chainweb-tests \
           test:multi-node-network-tests \
@@ -417,6 +418,7 @@ jobs:
         cp $(cabal list-bin multi-node-network-tests) artifacts/chainweb
         cp $(cabal list-bin pact-diff) artifacts/chainweb
         cp $(cabal list-bin remote-tests) artifacts/chainweb
+        cp $(cabal list-bin standalone-pruner) artifacts/chainweb
         cp README.md artifacts/chainweb
         cp CHANGELOG.md artifacts/chainweb
         cp LICENSE artifacts/chainweb

--- a/chainweb.cabal
+++ b/chainweb.cabal
@@ -113,6 +113,7 @@ common warning-flags
 
 library
     import: warning-flags, debugging-flags
+    ghc-options: -ddump-simpl -dsuppress-all -ddump-to-file -dno-suppress-type-signatures
     default-language: Haskell2010
     hs-source-dirs: src
     other-modules:
@@ -630,7 +631,7 @@ test-suite chainweb-tests
         Chainweb.Test.BlockHeader.Genesis
         Chainweb.Test.BlockHeader.Validation
         Chainweb.Test.BlockHeaderDB
-        -- Chainweb.Test.BlockHeaderDB.PruneForks
+        Chainweb.Test.BlockHeaderDB.PruneForks
         Chainweb.Test.Chainweb.Utils.Paging
         Chainweb.Test.CutDB
         Chainweb.Test.Difficulty
@@ -727,6 +728,7 @@ test-suite chainweb-tests
         , property-matchers ^>= 0.7
         , quickcheck-instances >= 0.3
         , random >= 1.3
+        , random-shuffle >= 0.0.4
         , raw-strings-qq >=1.1
         , resource-pool >= 0.4
         , resourcet >= 1.3

--- a/cwtools/cwtools.cabal
+++ b/cwtools/cwtools.cabal
@@ -87,6 +87,28 @@ executable b64
         , optparse-applicative
         , text
 
+executable standalone-pruner
+    import: warning-flags, debugging-flags
+    default-language: Haskell2010
+    ghc-options:
+        -threaded
+    hs-source-dirs: standalone-pruner
+    main-is: Main.hs
+    build-depends:
+        -- internal
+        , chainweb
+        , chainweb-storage
+
+        -- external
+        , base >= 4.12 && < 5
+        , lens
+        , lens-aeson
+        , loglevel
+        , optparse-applicative
+        , resourcet
+        , text
+        , time
+
 executable calculate-release
     import: warning-flags, debugging-flags
     default-language: Haskell2010

--- a/cwtools/standalone-pruner/Main.hs
+++ b/cwtools/standalone-pruner/Main.hs
@@ -1,0 +1,46 @@
+{-# LANGUAGE ImportQualifiedPost #-}
+{-# LANGUAGE ApplicativeDo #-}
+
+module Main where
+
+import Options.Applicative
+
+import Control.Monad
+import Data.Text.IO qualified as T
+import System.LogLevel
+
+import Chainweb.BlockHeaderDB.PruneForks qualified as PruneForks
+import Chainweb.Cut (unsafeMkCut)
+import Chainweb.CutDB (readHighestCutHeaders, cutHashesTable)
+import Chainweb.Logger
+import Chainweb.Storage.Table.RocksDB (withRocksDb, modernDefaultOptions)
+import Chainweb.Utils
+import Chainweb.Version
+import Chainweb.Version.Registry
+import Chainweb.WebBlockHeaderDB
+
+main :: IO ()
+main = join $
+    execParser $ info
+        (parser <**> helper)
+        (fullDesc
+            <> progDesc "Prune a chainweb-node block header database (rocksdb)"
+            <> header "standalone-pruner")
+
+parser :: Parser (IO ())
+parser = do
+    version <- option (findKnownVersion =<< textReader) (long "chainweb-version" <> short 'v')
+    dbDir <- textOption (long "rocksdb-path")
+    logLevel <- flag' Debug (long "verbose") <|> flag' Warn (long "quiet") <|> pure Info
+    doPrune <-
+        flag' PruneForks.ForcePrune (long "force")
+        <|> flag' PruneForks.PruneDryRun (long "dry-run")
+        <|> pure PruneForks.Prune
+    return $ withVersion version $ do
+        withRocksDb dbDir modernDefaultOptions $ \rdb -> do
+            let logger = genericLogger logLevel T.putStrLn
+            wbhdb <- initWebBlockHeaderDb rdb
+            let cutHashesStore = cutHashesTable rdb
+            initialCut <- unsafeMkCut <$> readHighestCutHeaders (logFunctionText logger) wbhdb cutHashesStore
+            PruneForks.pruneForks logger initialCut wbhdb doPrune (int PruneForks.safeDepth)
+            return ()

--- a/node/src/ChainwebNode.hs
+++ b/node/src/ChainwebNode.hs
@@ -79,6 +79,7 @@ import System.Mem
 -- internal modules
 
 import Chainweb.BlockHeader
+import Chainweb.BlockHeaderDB.PruneForks (PruneStats(..))
 import Chainweb.Chainweb
 import Chainweb.Chainweb.Configuration
 import Chainweb.Chainweb.CutResources
@@ -409,6 +410,8 @@ withNodeLogger logCfg chainwebCfg v f = runManaged $ do
         $ mkTelemetryLogger @P2pNodeStats mgr teleLogConfig
     topLevelStatusBackend <- managed
         $ mkTelemetryLogger @ChainwebStatus mgr teleLogConfig
+    pruneStatsBackend <- managed
+        $ mkTelemetryLogger @PruneStats mgr teleLogConfig
 
     logger <- managed
         $ L.withLogger (_logConfigLogger logCfg) $ logHandles
@@ -433,6 +436,7 @@ withNodeLogger logCfg chainwebCfg v f = runManaged $ do
                     , logHandler dbStatsBackend
                     , logHandler p2pNodeStatsBackend
                     , logHandler topLevelStatusBackend
+                    , logHandler pruneStatsBackend
                     ]
             ]) baseBackend
 

--- a/src/Chainweb/BlockHeaderDB/PruneForks.hs
+++ b/src/Chainweb/BlockHeaderDB/PruneForks.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE FlexibleContexts #-}
@@ -8,6 +9,12 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE PolyKinds #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE NumericUnderscores #-}
+{-# LANGUAGE ImportQualifiedPost #-}
+{-# LANGUAGE DerivingVia #-}
 
 -- |
 -- Module: Chainweb.BlockHeaderDB.PruneForks
@@ -19,19 +26,23 @@
 -- Prune old forks from BlockHeader DB
 --
 module Chainweb.BlockHeaderDB.PruneForks
-( pruneForksLogg
-, pruneForks
+( pruneForks
 , pruneForks_
+, safeDepth
+, pruneForksJob
+, DoPrune(..)
+, PruneStats(..)
 ) where
 
-import Control.DeepSeq
-import Control.Exception (evaluate)
-import Control.Lens (view)
+import Control.DeepSeq (NFData)
+import Control.Exception (evaluate, throw)
+import Control.Lens (ix, view, (^?!), iforM_, (%~))
 import Control.Monad
 import Control.Monad.Catch
 
 import Data.Function
-import qualified Data.List as L
+import Data.HashSet (HashSet)
+import Data.HashSet qualified as HashSet
 import Data.Maybe
 import Data.Semigroup
 import qualified Data.Text as T
@@ -43,7 +54,7 @@ import Numeric.Natural
 
 import Prelude hiding (lookup)
 
-import qualified Streaming.Prelude as S
+import Streaming.Prelude qualified as S
 
 import System.LogLevel
 
@@ -55,39 +66,71 @@ import Chainweb.BlockHeaderDB.Internal
 import Chainweb.BlockHeight
 import Chainweb.Logger
 import Chainweb.Parent
+import Chainweb.Ranked
 import Chainweb.TreeDB
 import Chainweb.Utils hiding (Codec)
 import Chainweb.Version
 
 import Chainweb.Storage.Table
 import Chainweb.Storage.Table.RocksDB
+import Chainweb.Time qualified
 import Data.LogMessage
+import Chainweb.WebBlockHeaderDB
+import Chainweb.Cut
+import Chainweb.CutDB
+import Control.Monad.Cont
+import Data.Void (Void)
+import Data.Foldable (toList)
+import Data.Functor ((<&>))
+import Data.Ord
+import Control.Concurrent
+import Chainweb.BlockHeader.Validation (validateIntrinsicM)
+import Data.Aeson (FromJSON, ToJSON)
 
 -- -------------------------------------------------------------------------- --
 -- Chain Database Pruning
 
-pruneForksLogg
+safeDepth :: BlockHeight
+safeDepth = 10000
+
+data PruneStats = PruneStats
+    { blocksPruned :: !Int
+    }
+    deriving stock Generic
+    deriving anyclass (NFData, ToJSON, FromJSON)
+    deriving LogMessage via (JsonLog PruneStats)
+
+-- | `ForcePrune` restarts from genesis. `PruneDryRun` does the prune without deleting
+-- anything, but it also records the prune as having happened.
+-- Prune
+data DoPrune = Prune | ForcePrune | PruneDryRun
+    deriving (Show, Eq, Ord)
+    deriving (ToJSON, FromJSON) via (JsonTextRepresentation "DoPrune" DoPrune)
+
+instance HasTextRepresentation DoPrune where
+    toText Prune = "prune"
+    toText ForcePrune = "force-prune"
+    toText PruneDryRun = "prune-dry-run"
+    fromText "prune"= return Prune
+    fromText "force-prune" = return ForcePrune
+    fromText "prune-dry-run" = return PruneDryRun
+    fromText t =
+        throwM $ TextFormatException $ "HasTextRepresentation DoPrune: invalid DoPrune value " <> sshow t
+
+pruneForksJob
     :: HasVersion
     => Logger logger
     => logger
-    -> BlockHeaderDb
+    -> IO Cut
+    -> WebBlockHeaderDb
+    -> DoPrune
     -> Natural
-        -- ^ The depth at which pruning starts. Block at this depth are used as
-        -- pivots and actual deletion starts at (depth - 1).
-        --
-        -- Note, that the max rank isn't necessarly included in the current best
-        -- cut. So one, should choose a depth for which one is confident that
-        -- all forks are resolved.
-
-    -> (Bool -> BlockHeader -> IO ())
-        -- ^ Deletion call back. This hook is called /after/ the entry is
-        -- deleted from the database. It's main purpose is to delete any
-        -- resources that were related to the deleted header and that are not
-        -- needed any more. The first parameter indicates whether the block
-        -- header got deleted from the chain database.
-
-    -> IO Int
-pruneForksLogg = pruneForks . logFunctionText
+    -> IO Void
+pruneForksJob logger getCut wbhdb doPrune depth = do
+    runForever (logFunction logger) "prune_forks" $ do
+        initialCut <- getCut
+        void $ pruneForks logger initialCut wbhdb doPrune depth
+        threadDelay (1_000_000 * 60 * 60)
 
 -- | Prunes most block headers from forks that are older than the given number
 -- of blocks.
@@ -98,55 +141,94 @@ pruneForksLogg = pruneForks . logFunctionText
 -- This function doesn't guarantee to delete all blocks on forks. A small number
 -- of fork blocks may not get deleted.
 --
--- The function takes a callback that are invoked on each block header in the
--- database starting from the given depth. The callback takes a parameter that
--- indicates whether the related block is pruned or not.
---
 pruneForks
     :: HasVersion
-    => LogFunctionText
-    -> BlockHeaderDb
+    => Logger logger
+    => logger
+    -> Cut
+    -> WebBlockHeaderDb
+    -> DoPrune
     -> Natural
         -- ^ The depth at which pruning starts. Block at this depth are used as
-        -- pivots and actual deletion starts at (depth - 1).
+        -- initial live set and actual deletion starts at (depth - 1).
         --
         -- Note, that the max rank isn't necessarly included in the current best
         -- cut. So one, should choose a depth for which one is confident that
         -- all forks are resolved.
 
-    -> (Bool -> BlockHeader -> IO ())
-        -- ^ Deletion call back. This hook is called /after/ the entry is
-        -- deleted from the database. It's main purpose is to delete any
-        -- resources that were related to the deleted header and that are not
-        -- needed any more. The first parameter indicates whether the block
-        -- header got deleted from the chain database.
-
     -> IO Int
-pruneForks logg cdb depth callback = do
-    hdr <- maxEntry cdb
-    if
-        | int (view blockHeight hdr) <= depth -> do
-            logg Info
+pruneForks logger initialCut wbhdb doPrune depth = do
+    let highestSafePruneTarget =
+            _cutMinHeight initialCut - min (int depth) (_cutMinHeight initialCut)
+
+    (resumptionPoint, startedFrom) <- tableLookup (_webCurrentPruneJob wbhdb) () >>= \case
+        Just j | doPrune /= ForcePrune -> return j
+        _ -> return (highestSafePruneTarget, highestSafePruneTarget)
+
+    -- the lower bound is different from the job start point because some
+    -- heights have already been pruned
+    lowerBound <- tableLookup (_webHighestPruned wbhdb) () >>= \case
+        Just highestPruned | doPrune /= ForcePrune -> return highestPruned
+        _ -> return 0
+
+    tableInsert (_webHighestPruned wbhdb) () lowerBound
+
+    numPruned <- if
+        | int (_cutMinHeight initialCut) <= depth -> do
+            logFunctionText logger Info
                 $ "Skipping database pruning because the maximum block height "
-                <> sshow (view blockHeight hdr) <> " is not larger than then requested depth "
+                <> sshow (_cutMinHeight initialCut) <> " is not larger than then requested depth "
                 <> sshow depth
             return 0
-        | int (view blockHeight hdr) <= int genHeight + depth -> do
-            logg Info $ "Skipping database pruning because there are not yet"
-                <> " enough block headers on the chain"
+        | lowerBound > resumptionPoint -> do
+            -- as far as I know, this can only happen if we write highestPruned
+            -- below and we stop before we can delete the current job.  if the
+            -- lower bound is already pruned, the prune job is done.
+            logFunctionText logger Info
+                $ "Skipping database pruning because the lower bound is already pruned"
             return 0
         | otherwise -> do
-            let mar = MaxRank $ Max $ int (view blockHeight hdr) - depth
-            pruneForks_ logg cdb mar (MinRank $ Min $ int genHeight) callback
-  where
-    cid = _chainId cdb
-    genHeight = genesisHeight cid
+            numPruned <-
+                pruneForks_ logger wbhdb doPrune PruneJob
+                    { resumptionPoint
+                    , startedFrom
+                    , lowerBound
+                    }
+            logFunctionText logger Info
+                $ "Pruned "
+                <> sshow numPruned
+                <> " blocks, now pruned up to "
+                <> sshow startedFrom
+
+            return numPruned
+
+    tableInsert (_webHighestPruned wbhdb) () startedFrom
+    tableDelete (_webCurrentPruneJob wbhdb) ()
+    return numPruned
 
 data PruneForksException
     = PruneForksDbInvariantViolation BlockHeight [BlockHeight] T.Text
     deriving (Show, Eq, Ord, Generic)
 
 instance Exception PruneForksException
+
+data PruneState = PruneState
+    { liveSet :: HashSet BlockHash
+    , prevHeight :: BlockHeight
+    , prevRecordedHeight :: BlockHeight
+    , numPruned :: Int
+    , pendingDeletes :: ChainMap [RankedBlockHash]
+    , pendingDeleteCount :: Int
+    } deriving Show
+
+data PruneJob = PruneJob
+    { resumptionPoint :: BlockHeight
+    , startedFrom :: BlockHeight
+    -- this is the lower bound we actually work down to; we know inductively
+    -- that the interval [genesis, lowerbound] is already pruned.
+    , lowerBound :: BlockHeight
+    }
+    deriving Show
 
 -- | Prune forks between the given min rank and max rank.
 --
@@ -160,75 +242,173 @@ instance Exception PruneForksException
 --
 pruneForks_
     :: (HasCallStack, HasVersion)
-    => LogFunctionText
-    -> BlockHeaderDb
-    -> MaxRank
-    -> MinRank
-    -> (Bool -> BlockHeader -> IO ())
+    => Logger logger
+    => logger
+    -> WebBlockHeaderDb
+    -> DoPrune
+    -> PruneJob
     -> IO Int
-pruneForks_ logg _ (MaxRank (Max mar)) _  _
-    | mar <= 1 = 0 <$ logg Warn ("Skipping database pruning for max bound of " <> sshow mar)
-pruneForks_ logg cdb mar mir callback = do
-    logg Debug $ "Pruning block header database for chain " <> sshow (_chainId cdb)
-        <> " with upper bound " <> sshow (_getMaxRank mar)
-        <> " and lower bound " <> sshow (_getMinRank mir)
+pruneForks_ logger wbhdb doPrune pruneJob = do
+    logFunctionText logger Info $ "Pruning block header database job "
+        <> sshow pruneJob
 
     -- parent hashes of all blocks at height max rank @mar@.
+    -- it's fine if we miss some chains here, because we never remove chains
+    -- from the chain graph.
     --
-    !pivots <- entries cdb Nothing Nothing (Just $ MinRank $ Min $ _getMaxRank mar) (Just mar)
-        $ fmap (force . L.nub) . S.toList_ . S.map (unwrapParent . view blockParent)
-            -- the set of pivots is expected to be very small. In fact it is
-            -- almost always a singleton set.
+    !initialLiveSet <- webEntries wbhdb (Just $ MinRank $ Min $ _getMaxRank mar) (Just mar)
+        $ S.foldMap_
+        $ \blk ->
+            HashSet.singleton (view (blockParent . _Parent) blk)
+            <> foldMap HashSet.singleton (getAdjs blk)
+            -- the initial live set is expected to be very small. In fact it is
+            -- almost always a singleton set on each chain.
+    logFunctionText logger Debug $
+        "Initial live set at " <> sshow mar <> ": " <> sshow initialLiveSet
 
-    if null pivots
-      then do
-        logg Warn
-            $ "Skipping database pruning because of an empty set of block headers at upper pruning bound " <> sshow mar
+    let initialPruneState = PruneState
+            { liveSet = initialLiveSet
+            , prevHeight = resumptionPoint pruneJob
+            , prevRecordedHeight = resumptionPoint pruneJob
+            , numPruned = 0
+            , pendingDeletes = noDeletes
+            , pendingDeleteCount = 0
+            }
+
+    now <- Chainweb.Time.getCurrentTimeIntegral
+
+    if null initialLiveSet
+    then do
+        logFunctionText logger Warn
+            $ "Skipping database pruning because of an empty set of headers at upper pruning bound "
+            <> sshow mar
         return 0
-      else
-        withReverseHeaderStream cdb (mar - 1) mir
-            $ S.foldM_ go (return (pivots, int (_getMaxRank mar), 0)) (\(_,_,!n) -> evaluate n)
-            . progress 200000 reportProgress
+    else do
+        withWebReverseHeaderStream wbhdb (max 1 mar - 1)
+            $ pruneBlocks now initialPruneState
 
   where
-    reportProgress i a = logg Info
-        $ "inspected " <> sshow i
-        <> " block headers. Current height "
-        <> sshow (view blockHeight a)
+    !noDeletes = onAllChains []
+    mar = MaxRank $ int $ resumptionPoint pruneJob
+    !action = case doPrune of
+        PruneDryRun -> "Would have pruned "
+        _ -> "Pruned "
+    getAdjs bh =
+        view _Parent <$> _getBlockHashRecord (view blockAdjacentHashes bh)
 
-    go :: ([BlockHash], BlockHeight, Int) -> BlockHeader -> IO ([BlockHash], BlockHeight, Int)
-    go ([], _, _) cur = throwM $ InternalInvariantViolation
-        $ "PruneForks.pruneForks_: no pivots left at block " <> encodeToText (ObjectEncoded cur)
-    go (!pivots, !prevHeight, !n) !cur
+    executePendingDeletes PruneState{..} = do
+        iforM_ pendingDeletes $ \cid pendingDeletesForCid -> do
+            let cdb = _webBlockHeaderDb wbhdb ^?! atChain cid
+            case doPrune of
+                PruneDryRun -> return ()
+                _ -> do
+                    tableDeleteBatch (_chainDbCas cdb) pendingDeletesForCid
+                    tableDeleteBatch (_chainDbRankTable cdb) (_ranked <$> pendingDeletesForCid)
+        logFunctionText logger Info $
+            action <> sshow pendingDeleteCount <> " block headers at height " <> sshow prevHeight
+        logFunctionText logger Debug $
+            action <> sshow pendingDeletes <> ", at height " <> sshow prevHeight
+        logFunction logger Info $
+            PruneStats pendingDeleteCount
 
-        -- This checks some structural consistency. It's not a comprehensive
-        -- check. Comprehensive checks on various levels are availabe through
-        -- callbacks that are offered in the module "Chainweb.Chainweb.PruneChainDatabase"
-        | prevHeight /= curHeight && prevHeight /= curHeight + 1 =
-            throwM $ InternalInvariantViolation
-                $ "PruneForks.pruneForks_: detected a corrupted database. Some block headers are missing"
-                <> ". Current pivots: " <> encodeToText pivots
-                <> ". Current header: " <> encodeToText (ObjectEncoded cur)
-                <> ". Previous height: " <> sshow prevHeight
-        | view blockHash cur `elem` pivots = do
-            callback False cur
-            let !pivots' = force $ L.nub $ unwrapParent (view blockParent cur) : L.delete (view blockHash cur) pivots
-            return (pivots', curHeight, n)
-        | otherwise = do
-            deleteHdr cur
-            callback True cur
-            return (pivots, curHeight, n+1)
-      where
-        curHeight = view blockHeight cur
+    deleteBatchSize = 1000
+    checkpointSize = 1000
 
-    deleteHdr k = do
-        -- TODO: make this atomic (create boilerplate to combine queries for
-        -- different tables)
-        casDelete (_chainDbCas cdb) (RankedBlockHeader k)
-        tableDelete (_chainDbRankTable cdb) (view blockHash k)
-        logg Debug
-            $ "pruned block header " <> encodeToText (view blockHash k)
-            <> " at height " <> sshow (view blockHeight k)
+    pruneBlocks now initialState =
+        go initialState
+        where
+        go state strm =
+            if pendingDeleteCount state >= deleteBatchSize
+                || prevRecordedHeight state - prevHeight state > checkpointSize
+            then do
+                -- first execute pending deletes, then record checkpoint. that
+                -- way we never miss deletes.
+                executePendingDeletes state
+                -- make a checkpoint of our progress. we want to resume a level
+                -- higher, because we really don't prune the first height, we
+                -- use it for the initial live set.
+                tableInsert (_webCurrentPruneJob wbhdb) ()
+                    (succ $ prevHeight state, startedFrom pruneJob)
+                go
+                    state
+                        { prevRecordedHeight = prevHeight state
+                        , pendingDeletes = noDeletes
+                        , pendingDeleteCount = 0
+                        }
+                    strm
+            else do
+                S.uncons strm >>= \case
+                    Nothing -> do
+                        executePendingDeletes state
+                        return $! numPruned state
+                    Just (block, strm') -> do
+                        pruneBlock state block strm'
+
+        pruneBlock :: PruneState -> BlockHeader -> S.Stream (S.Of BlockHeader) IO () -> IO Int
+        pruneBlock PruneState {liveSet, prevHeight} _ _ | HashSet.null liveSet =
+            throw $ InternalInvariantViolation
+                $ "PruneForks.pruneForks_: no live blocks left at height " <> sshow prevHeight
+        pruneBlock PruneState{..} cur strm
+            -- This checks some structural consistency. It's not a comprehensive
+            -- check. Comprehensive checks on various levels are available through
+            -- callbacks that are offered in the module "Chainweb.Chainweb.PruneChainDatabase"
+            | prevHeight /= curHeight && prevHeight /= curHeight + 1 =
+                throw $ InternalInvariantViolation
+                    $ "PruneForks.pruneForks_: detected a corrupted database. "
+                    <> "Some block headers are missing."
+                    <> "Current live set: " <> encodeToText liveSet
+                    <> ". Current header: " <> encodeToText (ObjectEncoded cur)
+                    <> ". Previous height: " <> sshow prevHeight
+            -- if we are at or beyond the lower bound,
+            -- and we have no more pending fork tips to prune,
+            -- we're done early.
+            | curHeight <= lowerBound pruneJob
+            , curHeight < prevHeight
+            = do
+                when (pendingDeleteCount > 0) $
+                    executePendingDeletes PruneState{..}
+                return numPruned
+            -- the current block is live.
+            -- its parents take its place as live blocks.
+            | curHash `elem` liveSet = do
+                let !liveSet' =
+                        flip (foldl' (flip HashSet.insert)) curAdjs $
+                        HashSet.insert curParent $
+                        HashSet.delete curHash liveSet
+
+                validateIntrinsicM now cur
+
+                go
+                    PruneState
+                        { liveSet = liveSet'
+                        , prevHeight = curHeight
+                        , prevRecordedHeight
+                        , numPruned
+                        , pendingDeletes
+                        , pendingDeleteCount
+                        } strm
+            -- the current block is not live, delete it.
+            | otherwise = do
+                let !newDelete = view rankedBlockHash cur
+                let !(!pendingDeletes', !pendingDeleteCount') =
+                        (pendingDeletes & ix cid %~ (newDelete :)
+                        , pendingDeleteCount + 1)
+                let !numPruned' = numPruned + 1
+                go
+                    PruneState
+                        { liveSet
+                        , prevHeight = curHeight
+                        , prevRecordedHeight
+                        , numPruned = numPruned'
+                        , pendingDeletes = pendingDeletes'
+                        , pendingDeleteCount = pendingDeleteCount'
+                        } strm
+            where
+            curParent = view (blockParent . _Parent) cur
+            curAdjs = getAdjs cur
+            !cid = view chainId cur
+            !curHeight = view blockHeight cur
+            !curHash = view blockHash cur
 
 -- -------------------------------------------------------------------------- --
 -- Utils
@@ -238,16 +418,24 @@ pruneForks_ logg cdb mar mir callback = do
 withReverseHeaderStream
     :: BlockHeaderDb
     -> MaxRank
-    -> MinRank
     -> (S.Stream (S.Of BlockHeader) IO () -> IO a)
     -> IO a
-withReverseHeaderStream db mar mir inner = withTableIterator headerTbl $ \it -> do
-    iterSeek it $ RankedBlockHash (BlockHeight $ int $ _getMaxRank mar + 1) nullBlockHash
+withReverseHeaderStream db mar inner = withTableIterator headerTbl $ \it -> do
+
+    iterSeek it $
+        RankedBlockHash (BlockHeight $ int $ _getMaxRank mar + 1) nullBlockHash
     iterPrev it
+
     inner $ iterToReverseValueStream it
         & S.map _getRankedBlockHeader
-        & S.takeWhile (\a -> int (view blockHeight a) >= mir)
   where
     headerTbl = _chainDbCas db
 
-{-# INLINE withReverseHeaderStream #-}
+withWebReverseHeaderStream
+    :: WebBlockHeaderDb
+    -> MaxRank
+    -> (S.Stream (S.Of BlockHeader) IO () -> IO a)
+    -> IO a
+withWebReverseHeaderStream wbhdb mar inner = do
+    runContT (forM (_webBlockHeaderDb wbhdb) (\db -> ContT $ withReverseHeaderStream db mar))
+        $ \streamPerChain -> inner $ mergeN (\bh -> (Down (view blockHeight bh), view chainId bh)) $ toList streamPerChain

--- a/src/Chainweb/Chainweb.hs
+++ b/src/Chainweb/Chainweb.hs
@@ -132,6 +132,7 @@ import System.LogLevel
 
 import Chainweb.Backup
 import Chainweb.BlockHeaderDB (BlockHeaderDb)
+import Chainweb.BlockHeaderDB.PruneForks qualified as PruneForks
 import Chainweb.ChainId
 import Chainweb.Chainweb.ChainResources
 import Chainweb.Chainweb.Configuration
@@ -361,7 +362,7 @@ withChainwebInternal conf logger peerRes serviceSock rocksDb defaultPactDbDir ba
         :: ChainMap (ChainResources logger)
         -> IO ()
     global cs = runResourceT $ do
-        let !webchain = mkWebBlockHeaderDb (fmap _chainResBlockHeaderDb cs)
+        let !webchain = mkWebBlockHeaderDb rocksDb (fmap _chainResBlockHeaderDb cs)
             -- !pact = mkWebPactExecutionService (HM.map _chainResPact cs)
             !providers = payloadProvidersForAllChains cs
             !cutLogger = setComponent "cut" logger
@@ -369,112 +370,118 @@ withChainwebInternal conf logger peerRes serviceSock rocksDb defaultPactDbDir ba
         liftIO $ logg Debug "start initializing cut resources"
         liftIO $ logFunctionJson logger Info InitializingCutResources
 
-        initialCutOrCutResources <- withCutResources cutLogger cutDbParams p2pConfig myInfo peerDb rocksDb webchain providers mgr
-        liftIO $ case initialCutOrCutResources of
-            Left initialCut -> do
+        withCutResources cutLogger cutDbParams p2pConfig myInfo peerDb rocksDb webchain providers mgr >>= \case
+            Left initialCut -> liftIO $ do
                 logg Info "no cut resources, chainweb will not continue"
                 inner (RewoundToCut initialCut)
             Right cutResources -> do
-                logg Debug "finished initializing cut resources"
+                _ <- withAsyncR $ PruneForks.pruneForksJob
+                    logger
+                    (cutResources ^. cutResCutDb . cut)
+                    (cutResources ^. cutResCutDb . cutDbWebBlockHeaderDb)
+                    (_configPruneCommand $ _configPrune conf)
+                    (int PruneForks.safeDepth)
+                liftIO $ do
+                    logg Debug "finished initializing cut resources"
 
-                let !mLogger = setComponent "miner" logger
-                    !mConf = _configMining conf
-                    !mCutDb = _cutResCutDb cutResources
-                    !throt  = _configThrottling conf
+                    let !mLogger = setComponent "miner" logger
+                        !mConf = _configMining conf
+                        !mCutDb = _cutResCutDb cutResources
+                        !throt  = _configThrottling conf
 
-                -- initialize throttler
-                throttler <- mkGenericThrottler $ _throttlingRate throt
-                putPeerThrottler <- mkPutPeerThrottler $ _throttlingPeerRate throt
-                mempoolThrottler <- mkMempoolThrottler $ _throttlingMempoolRate throt
-                logg Debug "initialized throttlers"
+                    -- initialize throttler
+                    throttler <- mkGenericThrottler $ _throttlingRate throt
+                    putPeerThrottler <- mkPutPeerThrottler $ _throttlingPeerRate throt
+                    mempoolThrottler <- mkMempoolThrottler $ _throttlingMempoolRate throt
+                    logg Debug "initialized throttlers"
 
-                -- synchronize pact dbs with latest cut before we start the server
-                -- and clients and begin mining.
-                --
-                -- This is a consistency check that validates the blocks in the
-                -- current cut. If it fails an exception is raised. Also, if it
-                -- takes long (for example, when doing a reset to a prior block
-                -- height) we want this to happen before we go online.
-                --
-                let
-                    -- pactSyncChains =
-                    --     case _configSyncPactChains conf of
-                    --         Just syncChains
-                    --             | _configReadOnlyReplay conf
-                    --             -> HM.filterWithKey (\k _ -> elem k syncChains) cs
-                    --         _ -> cs
+                    -- synchronize pact dbs with latest cut before we start the server
+                    -- and clients and begin mining.
+                    --
+                    -- This is a consistency check that validates the blocks in the
+                    -- current cut. If it fails an exception is raised. Also, if it
+                    -- takes long (for example, when doing a reset to a prior block
+                    -- height) we want this to happen before we go online.
+                    --
+                    let
+                        -- pactSyncChains =
+                        --     case _configSyncPactChains conf of
+                        --         Just syncChains
+                        --             | _configReadOnlyReplay conf
+                        --             -> HM.filterWithKey (\k _ -> elem k syncChains) cs
+                        --         _ -> cs
 
-                if _configReadOnlyReplay conf
-                then do
-                    -- FIXME implement replay in payload provider
-                    error "Chainweb.Chainweb.withChainwebInternal: pact replay is not supported"
-                    -- logFunctionJson logger Info PactReplayInProgress
-                    -- -- note that we don't use the "initial cut" from cutdb because its height depends on initialBlockHeightLimit.
-                    -- highestCut <-
-                    --     unsafeMkCut v <$> readHighestCutHeaders v (logFunctionText logger) webchain (cutHashesTable rocksDb)
-                    -- lowerBoundCut <-
-                    --     tryLimitCut webchain (fromMaybe 0 $ _cutInitialBlockHeightLimit $ _configCuts conf) highestCut
-                    -- upperBoundCut <- forM (_cutFastForwardBlockHeightLimit $ _configCuts conf) $ \upperBound ->
-                    --     tryLimitCut webchain upperBound highestCut
-                    -- let
-                    --     replayOneChain :: (ChainResources logger, (BlockHeader, Maybe BlockHeader)) -> IO ()
-                    --     replayOneChain (cr, (l, u)) = do
-                    --         let chainPact = _chainResPact cr
-                    --         let logCr = logFunctionText
-                    --                 $ addLabel ("component", "pact")
-                    --                 $ addLabel ("sub-component", "init")
-                    --                 $ _chainResLogger cr
-                    --         void $ _pactReadOnlyReplay chainPact l u
-                    --         logCr Info "pact db synchronized"
-                    -- let bounds =
-                    --         HM.intersectionWith (,)
-                    --             pactSyncChains
-                    --             (HM.mapWithKey
-                    --                 (\cid bh ->
-                    --                     (bh, (HM.! cid) . _cutMap <$> upperBoundCut))
-                    --                 (_cutMap lowerBoundCut)
-                    --             )
-                    -- mapConcurrently_ replayOneChain bounds
-                    -- logg Info "finished fast forward replay"
-                    -- logFunctionJson logger Info PactReplaySuccessful
-                    -- inner $ Replayed lowerBoundCut upperBoundCut
-                else do
-                        logg Debug "start initializing miner resources"
-                        logFunctionJson logger Info InitializingMinerResources
+                    if _configReadOnlyReplay conf
+                    then do
+                        -- FIXME implement replay in payload provider
+                        error "Chainweb.Chainweb.withChainwebInternal: pact replay is not supported"
+                        -- logFunctionJson logger Info PactReplayInProgress
+                        -- -- note that we don't use the "initial cut" from cutdb because its height depends on initialBlockHeightLimit.
+                        -- highestCut <-
+                        --     unsafeMkCut v <$> readHighestCutHeaders v (logFunctionText logger) webchain (cutHashesTable rocksDb)
+                        -- lowerBoundCut <-
+                        --     tryLimitCut webchain (fromMaybe 0 $ _cutInitialBlockHeightLimit $ _configCuts conf) highestCut
+                        -- upperBoundCut <- forM (_cutFastForwardBlockHeightLimit $ _configCuts conf) $ \upperBound ->
+                        --     tryLimitCut webchain upperBound highestCut
+                        -- let
+                        --     replayOneChain :: (ChainResources logger, (BlockHeader, Maybe BlockHeader)) -> IO ()
+                        --     replayOneChain (cr, (l, u)) = do
+                        --         let chainPact = _chainResPact cr
+                        --         let logCr = logFunctionText
+                        --                 $ addLabel ("component", "pact")
+                        --                 $ addLabel ("sub-component", "init")
+                        --                 $ _chainResLogger cr
+                        --         void $ _pactReadOnlyReplay chainPact l u
+                        --         logCr Info "pact db synchronized"
+                        -- let bounds =
+                        --         HM.intersectionWith (,)
+                        --             pactSyncChains
+                        --             (HM.mapWithKey
+                        --                 (\cid bh ->
+                        --                     (bh, (HM.! cid) . _cutMap <$> upperBoundCut))
+                        --                 (_cutMap lowerBoundCut)
+                        --             )
+                        -- mapConcurrently_ replayOneChain bounds
+                        -- logg Info "finished fast forward replay"
+                        -- logFunctionJson logger Info PactReplaySuccessful
+                        -- inner $ Replayed lowerBoundCut upperBoundCut
+                    else do
+                            logg Debug "start initializing miner resources"
+                            logFunctionJson logger Info InitializingMinerResources
 
-                        withMiningCoordination mLogger mConf mCutDb $ \mc ->
+                            withMiningCoordination mLogger mConf mCutDb $ \mc ->
 
-                            -- Miner resources are used by the test-miner when in-node
-                            -- mining is configured or by the mempool noop-miner (which
-                            -- keeps the mempool updated) in production setups.
-                            --
-                            withMinerResources mLogger (_miningInNode mConf) cs mCutDb mc $ \m -> do
-                                logFunctionJson logger Info ChainwebStarted
-                                logg Debug "finished initializing miner resources"
-                                let !haddr = _peerConfigAddr $ _p2pConfigPeer $ _configP2p conf
-                                inner $ StartedChainweb Chainweb
-                                    { _chainwebHostAddress = haddr
-                                    , _chainwebChains = cs
-                                    , _chainwebCutResources = cutResources
-                                    , _chainwebMiner = m
-                                    , _chainwebCoordinator = mc
-                                    , _chainwebLogger = logger
-                                    , _chainwebPeer = peerRes
-                                    , _chainwebManager = mgr
-                                    -- , _chainwebPactData = pactData
-                                    , _chainwebThrottler = throttler
-                                    , _chainwebPutPeerThrottler = putPeerThrottler
-                                    , _chainwebMempoolThrottler = mempoolThrottler
-                                    , _chainwebConfig = conf
-                                    , _chainwebServiceSocket = serviceSock
-                                    , _chainwebBackup = BackupEnv
-                                        { _backupRocksDb = rocksDb
-                                        , _backupDir = backupDir
-                                        , _backupPactDbDir = defaultPactDbDir
-                                        , _backupChainIds = cids
-                                        , _backupLogger = backupLogger
+                                -- Miner resources are used by the test-miner when in-node
+                                -- mining is configured or by the mempool noop-miner (which
+                                -- keeps the mempool updated) in production setups.
+                                --
+                                withMinerResources mLogger (_miningInNode mConf) cs mCutDb mc $ \m -> do
+                                    logFunctionJson logger Info ChainwebStarted
+                                    logg Debug "finished initializing miner resources"
+                                    let !haddr = _peerConfigAddr $ _p2pConfigPeer $ _configP2p conf
+                                    inner $ StartedChainweb Chainweb
+                                        { _chainwebHostAddress = haddr
+                                        , _chainwebChains = cs
+                                        , _chainwebCutResources = cutResources
+                                        , _chainwebMiner = m
+                                        , _chainwebCoordinator = mc
+                                        , _chainwebLogger = logger
+                                        , _chainwebPeer = peerRes
+                                        , _chainwebManager = mgr
+                                        -- , _chainwebPactData = pactData
+                                        , _chainwebThrottler = throttler
+                                        , _chainwebPutPeerThrottler = putPeerThrottler
+                                        , _chainwebMempoolThrottler = mempoolThrottler
+                                        , _chainwebConfig = conf
+                                        , _chainwebServiceSocket = serviceSock
+                                        , _chainwebBackup = BackupEnv
+                                            { _backupRocksDb = rocksDb
+                                            , _backupDir = backupDir
+                                            , _backupPactDbDir = defaultPactDbDir
+                                            , _backupChainIds = cids
+                                            , _backupLogger = backupLogger
+                                            }
                                         }
-                                    }
 
     -- synchronizePactDb :: HM.HashMap ChainId (ChainResources logger) -> Cut -> IO ()
     -- synchronizePactDb cs targetCut = do

--- a/src/Chainweb/Chainweb/CutResources.hs
+++ b/src/Chainweb/Chainweb/CutResources.hs
@@ -8,6 +8,7 @@
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE ImportQualifiedPost #-}
 
 -- |
 -- Module: Chainweb.Chainweb.CutResources
@@ -38,13 +39,13 @@ import Control.Monad.Trans.Resource
 
 import Prelude hiding (log)
 
-import qualified Network.HTTP.Client as HTTP
+import Network.HTTP.Client qualified as HTTP
 
 -- internal modules
 
 import Chainweb.Cut (Cut)
 import Chainweb.CutDB
-import qualified Chainweb.CutDB.Sync as C
+import Chainweb.CutDB.Sync qualified as C
 import Chainweb.Logger
 import Chainweb.RestAPI.NetworkID
 import Chainweb.Sync.WebBlockHeaderStore
@@ -58,9 +59,11 @@ import P2P.Node.Configuration
 import P2P.Peer
 import P2P.TaskQueue
 import Chainweb.PayloadProvider
-import qualified Data.Text as T
+import Data.Text qualified as T
 import P2P.Session (P2pSession)
 import P2P.Node.PeerDB (PeerDb)
+import Chainweb.Utils
+import Chainweb.BlockHeaderDB.PruneForks qualified as PruneForks
 
 -- -------------------------------------------------------------------------- --
 -- Cuts Resources

--- a/test/lib/Chainweb/Test/MultiNode.hs
+++ b/test/lib/Chainweb/Test/MultiNode.hs
@@ -689,7 +689,7 @@ sampleConsensusState
     -> IO ConsensusState
 sampleConsensusState nid bhdb cutdb ct s = do
     numStoredCuts <- withTableIterator ct $ \i -> iterToEntryStream i & S.length_
-    !hashes' <- webEntries bhdb
+    !hashes' <- webEntries bhdb Nothing Nothing
         $ S.fold_ (flip HS.insert) (_stateBlockHashes s) id
         . S.map (view blockHash)
     !c <- _cut cutdb

--- a/test/lib/Chainweb/Test/Utils.hs
+++ b/test/lib/Chainweb/Test/Utils.hs
@@ -47,7 +47,6 @@ module Chainweb.Test.Utils
 -- * Data Generation
 , toyBlockHeaderDb
 , toyChainId
-, toyGenesis
 , toyVersion
 , genesisBlockHeaderForChain
 , withToyDB
@@ -331,23 +330,20 @@ toyVersion = barebonesTestVersion singletonChainGraph
 toyChainId :: ChainId
 toyChainId = withVersion toyVersion someChainId
 
-toyGenesis :: ChainId -> BlockHeader
-toyGenesis cid = withVersion toyVersion genesisBlockHeader cid
-
 -- | Initialize an length-1 `BlockHeaderDb` for testing purposes.
 --
 -- Borrowed from TrivialSync.hs
 --
-toyBlockHeaderDb :: RocksDb -> ChainId -> IO (BlockHeader, BlockHeaderDb)
-toyBlockHeaderDb db cid = withVersion toyVersion $ (g,) <$> testBlockHeaderDb db g
+toyBlockHeaderDb :: HasVersion => RocksDb -> ChainId -> IO (BlockHeader, BlockHeaderDb)
+toyBlockHeaderDb db cid = (g,) <$> testBlockHeaderDb db g
   where
-    g = toyGenesis cid
+    g = genesisBlockHeader cid
 
 -- | Given a function that accepts a Genesis Block and
 -- an initialized `BlockHeaderDb`, perform some action
 -- and cleanly close the DB.
 --
-withToyDB :: RocksDb -> ChainId -> ResourceT IO (BlockHeader, BlockHeaderDb)
+withToyDB :: HasVersion => RocksDb -> ChainId -> ResourceT IO (BlockHeader, BlockHeaderDb)
 withToyDB db cid
     = snd <$> allocate (toyBlockHeaderDb db cid) (closeBlockHeaderDb . snd)
 

--- a/test/unit/Chainweb/Test/BlockHeaderDB/PruneForks.hs
+++ b/test/unit/Chainweb/Test/BlockHeaderDB/PruneForks.hs
@@ -1,0 +1,451 @@
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE ImportQualifiedPost #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE TupleSections #-}
+{-# LANGUAGE PartialTypeSignatures #-}
+
+-- |
+-- Module: Chainweb.Test.BlockHeaderDB.PruneForks
+-- Copyright: Copyright © 2020 Kadena LLC.
+-- License: MIT
+-- Maintainer: Lars Kuhtz <lars@kadena.io>
+-- Stability: experimental
+--
+-- TODO
+--
+module Chainweb.Test.BlockHeaderDB.PruneForks
+( tests
+) where
+
+import Control.Concurrent.STM
+import Control.Lens
+import Control.Monad
+import Control.Monad.Catch
+import Control.Monad.Trans.Resource
+import Control.Monad.IO.Class
+
+-- import Data.CAS
+-- import Data.CAS.RocksDB
+import Data.HashMap.Strict qualified as HM
+import Data.Text qualified as T
+import Data.Tree (Tree)
+import Data.Tree qualified as Tree
+
+import Numeric.Natural
+
+import System.LogLevel
+import System.Random
+
+import Test.Tasty
+import Test.Tasty.HUnit
+
+-- internal modules
+
+import Chainweb.BlockHash
+import Chainweb.BlockHeader
+import Chainweb.BlockHeader.Validation
+import Chainweb.BlockHeaderDB
+import Chainweb.BlockHeaderDB.Internal
+import Chainweb.BlockHeaderDB.PruneForks
+import Chainweb.Logger
+import Chainweb.Test.Utils
+import Chainweb.Test.Utils.BlockHeader
+import Chainweb.Utils
+import Chainweb.Version
+import Chainweb.Storage.Table.RocksDB
+import Chainweb.CutDB
+import Chainweb.Test.CutDB (withTestCutDb)
+import Chainweb.PayloadProvider (ConfiguredPayloadProvider(DisabledPayloadProvider))
+import Chainweb.Test.Pact.Utils
+import Chainweb.Storage.Table
+import Chainweb.Cut (unsafeMkCut, genesisCut)
+import Chainweb.Cut.CutHashes
+import Chainweb.Core.Brief
+import Chainweb.Test.TestVersions
+import Chainweb.Graph
+import Chainweb.WebBlockHeaderDB
+import Control.Monad.State.Strict
+import Chainweb.Parent
+import Data.HashMap.Strict (HashMap)
+import Data.Maybe (mapMaybe, catMaybes, fromMaybe)
+import Chainweb.Cut.Create
+import Hedgehog
+import Hedgehog.Gen (shuffle)
+import qualified Data.HashSet as HS
+import System.Random.Shuffle (shuffleM)
+import Streaming.Prelude qualified as S
+import Control.Monad.Except
+import Streaming qualified as S
+import PropertyMatchers qualified as P
+import Chainweb.ChainValue
+import qualified Chainweb.TreeDB as TreeDB
+import Chainweb.Ranked
+import Chainweb.Version.Utils (avgBlockHeightAtCutHeight, chainIdsAt)
+
+-- -------------------------------------------------------------------------- --
+-- Utils
+
+-- | Log level for the tests in this module. Set to 'Debug' for debugging any
+-- issues with the test.
+--
+testLogLevel :: LogLevel
+testLogLevel = Warn
+
+-- logg :: Show a => (String -> t) -> a -> T.Text -> t
+-- logg s l msg
+--     | l >= testLogLevel = s $ "[" <> sshow l <> "] " <> T.unpack msg
+--     | otherwise = return ()
+
+withDbs
+    :: HasVersion
+    => RocksDb
+    -> ResourceT IO CutDb
+withDbs rdb = do
+    -- create unique namespace for each test so that they so that test can
+    -- run in parallel.
+    -- x <- randomIO :: IO Int
+    -- rdb <- rio >>= testRocksDb (sshow x)
+    testLogger <- liftIO getTestLogger
+    (_, cutDb) <- withTestCutDb rdb id 0 (onAllChains DisabledPayloadProvider) testLogger
+    return cutDb
+
+selectHighCuts :: Casify RocksDbTable CutHashes -> Int -> Maybe (CasKeyType CutHashes) -> IO ([CutHashes], CasKeyType CutHashes)
+selectHighCuts cutTable candidateCount maybeMaxCutHeight = do
+    (highestCuts, nextCutHeight) <- withTableIterator cutTable $ \iter -> do
+        case maybeMaxCutHeight of
+            Nothing ->
+                iterLast iter
+            Just ch -> do
+                iterSeek iter ch
+                iterPrev iter
+
+        cuts <- fmap catMaybes $ replicateM candidateCount $ do
+            iterValue iter >>= \case
+                Just r -> do
+                    iterPrev iter
+                    return (Just r)
+                Nothing -> return Nothing
+        nextCutHeight <- iterKey iter >>= \case
+            Nothing -> iterNext iter >> fromJuste <$> iterKey iter
+            Just ch -> return ch
+        return (cuts, nextCutHeight)
+    (,nextCutHeight) <$> shuffleM highestCuts
+
+findM :: Monad m => [t] -> (t -> m (Maybe a)) -> m (Maybe a)
+findM (x:xs) f = do
+    y <- f x
+    case y of
+        Nothing -> findM xs f
+        Just u -> return $ Just u
+findM [] _ = return Nothing
+
+selectNewBlockParents
+    :: HasVersion
+    => Casify RocksDbTable CutHashes
+    -> WebBlockHeaderDb
+    -> Maybe (CasKeyType CutHashes)
+    -> Int
+    -> IO CutExtension
+selectNewBlockParents cutTable wbhdb maybeMaxCutHeight candCutCount = do
+    (candCutHashesList, newMaxCutHeight) <- selectHighCuts cutTable candCutCount maybeMaxCutHeight
+    shuffledChains <- shuffleM $ HS.toList $ chainIdsAt (round $ avgBlockHeightAtCutHeight $ maybe maxBound (view _1) maybeMaxCutHeight)
+    r <- findM candCutHashesList $ \candCutHashes -> do
+        candCutBlocks <- liftIO $
+            iforM (candCutHashes ^. cutHashes) (lookupRankedWebBlockHeaderDb wbhdb)
+        let candCut = unsafeMkCut candCutBlocks
+        let exts = mapMaybe (getCutExtension candCut) shuffledChains
+        case exts of
+            ext:_ -> return $ Just ext
+            [] -> return Nothing
+    case r of
+        Just r' -> return r'
+        Nothing -> selectNewBlockParents cutTable wbhdb (Just newMaxCutHeight) candCutCount
+
+progressArbitraryFork
+    :: (HasVersion, MonadIO m, MonadState Nonce m)
+    => Casify RocksDbTable CutHashes
+    -> WebBlockHeaderDb
+    -> Int
+    -> m ()
+progressArbitraryFork cutTable wbhdb candCutCount = do
+    cutExt <- liftIO $ selectNewBlockParents cutTable wbhdb Nothing candCutCount
+    let parent = _cutExtensionParent cutExt
+    let bhdb = wbhdb ^?! webBlockHeaderDb . ix (parent ^. chainId)
+    adjsForParent <- liftIO $ iforMOf (itraversed . _Parent)
+        (_getBlockHashRecord $ _cutExtensionAdjacentHashes cutExt)
+        (\c blk -> lookupRankedWebBlockHeaderDb wbhdb c
+            (Ranked (view (_Parent . blockHeight) parent) blk))
+    nextNonce <- get
+    let newBlock = testBlockHeader adjsForParent nextNonce parent
+    liftIO $ unsafeInsertBlockHeaderDb bhdb newBlock
+    newCut <- liftIO $ tryMonotonicCutExtension (_cutExtensionCut cutExt) newBlock
+    liftIO $ casInsert cutTable (cutToCutHashes Nothing $ fromJuste newCut)
+    put (succ nextNonce)
+    return ()
+
+pruneTestRandom :: (HasVersion, _) => _
+pruneTestRandom baseRdb f = runResourceT $ do
+    rdb <- withTestRocksDb "" baseRdb
+    liftIO $ do
+        let t = cutHashesTable rdb
+        wbhdb <- initWebBlockHeaderDb rdb
+        let lookupChainBlk (ChainValue c bhsh) = do
+                db <- getWebBlockHeaderDb wbhdb c
+                TreeDB.lookup db bhsh
+        let validateAllBlocks = do
+                void $ webEntries wbhdb Nothing Nothing $ \blks -> do
+                    blks
+                        & S.hoist liftIO
+                        & S.mapM_ (\blk ->
+                            validateAllParentsExist lookupChainBlk blk
+                                >>= \case
+                                Right r -> P.succeed r
+                                Left e -> P.fail "successful validation" (e, "failed on block: " <> sshow blk)
+                            )
+        casInsert t (cutToCutHashes Nothing genesisCut)
+        lgr <- getTestLogger
+        logFunctionText lgr Info "inserting blocks..."
+        (_, finalNonce) <- flip runStateT (Nonce 0) $ f t wbhdb
+        logFunctionText lgr Info $ "final nonce " <> sshow finalNonce
+        logFunctionText lgr Info "validating initial blocks..."
+        validateAllBlocks
+        highestCut <- readHighestCutHeaders (logFunctionText lgr) wbhdb t
+        numPruned <- pruneForks lgr (unsafeMkCut highestCut) wbhdb Prune 0
+        logFunctionText lgr Info "validating pruned blocks..."
+        validateAllBlocks
+        return numPruned
+
+pruneTestWithOnePivot :: _
+pruneTestWithOnePivot rdb = withVersion (barebonesTestVersion pairChainGraph) $ do
+    _ <- pruneTestRandom rdb $ \t wbhdb -> do
+        replicateM_ 4000 $ do
+            progressArbitraryFork t wbhdb 2
+        replicateM_ 10 $ do
+            progressArbitraryFork t wbhdb 1
+    return ()
+
+pruneTestWithLotsOfPivots :: _
+pruneTestWithLotsOfPivots rdb = withVersion (barebonesTestVersion pairChainGraph) $ do
+    _ <- pruneTestRandom rdb $ \t wbhdb -> do
+        replicateM_ 4000 $ do
+            progressArbitraryFork t wbhdb 16
+    return ()
+
+pruneTestWithManyForks :: _
+pruneTestWithManyForks rdb = withVersion (barebonesTestVersion pairChainGraph) $ do
+    _ <- pruneTestRandom rdb $ \t wbhdb -> do
+        replicateM_ 4000 $ do
+            progressArbitraryFork t wbhdb 16
+    return ()
+
+pruneTestWithManyChains :: _
+pruneTestWithManyChains rdb = withVersion (barebonesTestVersion petersenChainGraph) $ do
+    _ <- pruneTestRandom rdb $ \t wbhdb -> do
+        replicateM_ 1000 $ do
+            progressArbitraryFork t wbhdb 14
+    return ()
+
+pruneTestWithManyManyChains :: _
+pruneTestWithManyManyChains rdb = withVersion (barebonesTestVersion d4k4ChainGraph) $ do
+    _ <- pruneTestRandom rdb $ \t wbhdb -> do
+        replicateM_ 200 $ do
+            progressArbitraryFork t wbhdb 1
+        replicateM_ 400 $ do
+            progressArbitraryFork t wbhdb 140
+        replicateM_ 400 $ do
+            progressArbitraryFork t wbhdb 1
+    return ()
+
+pruneTestSmall :: _
+pruneTestSmall rdb = withVersion (barebonesTestVersion petersenChainGraph) $ do
+    _ <- pruneTestRandom rdb $ \t wbhdb -> do
+        replicateM_ 20 $ do
+            progressArbitraryFork t wbhdb 1
+    return ()
+
+createForks
+    :: HasVersion
+    => BlockHeaderDb
+    -> BlockHeader
+    -> IO ([BlockHeader], [BlockHeader])
+createForks bdb h = (,)
+    <$> insert bdb h (Nonce 1) 10
+    <*> insert bdb h (Nonce 2) 5
+
+insert
+    :: HasVersion
+    => BlockHeaderDb
+    -> BlockHeader
+    -> Nonce
+    -> Natural
+    -> IO [BlockHeader]
+insert bdb h n l = do
+    hdrs <- insertN_ n l h bdb
+    return hdrs
+
+cid :: ChainId
+cid = unsafeChainId 0
+
+delHdr :: BlockHeaderDb -> BlockHeader -> IO ()
+delHdr cdb k = do
+    tableDelete (_chainDbCas cdb) (casKey $ RankedBlockHeader k)
+    tableDelete (_chainDbRankTable cdb) (view blockHash k)
+
+-- -------------------------------------------------------------------------- --
+-- Test cases
+
+tests :: RocksDb -> TestTree
+tests rdb =
+    testGroup "Chainweb.BlockHeaderDb.PruneForks"
+        [ testCaseSteps "simple 1"
+            $ withVersion (barebonesTestVersion singletonChainGraph)
+            $ singleForkTest rdb 1 5
+        , testCaseSteps "simple 2"
+            $ withVersion (barebonesTestVersion singletonChainGraph)
+            $ singleForkTest rdb 2 5
+        , testCaseSteps "simple 3"
+            $ withVersion (barebonesTestVersion singletonChainGraph)
+            $ singleForkTest rdb 4 5
+        , testCaseSteps "simple 4"
+            $ withVersion (barebonesTestVersion singletonChainGraph)
+            $ singleForkTest rdb 5 0
+        , testCaseSteps "skipping: max bound 1"
+            $ withVersion (barebonesTestVersion singletonChainGraph)
+            $ singleForkTest rdb 9 0
+        , testCaseSteps "skipping: depth == max block height"
+            $ withVersion (barebonesTestVersion singletonChainGraph)
+            $ singleForkTest rdb 10 0
+        , testCaseSteps "fail on missing header 5" $ failTest rdb 5
+        , testCaseSteps "fail on missing header 6" $ failTest rdb 6
+            -- failTest <= 4: succeeds because of second branch
+            -- failTest 7: empty upper bound warning
+            -- failTest 8: succeeds because deleted block at height 8 is above upper pruning bound
+
+        -- , pruneWithChecksTests rdb
+        -- , failPruningChecksTests rdb
+        , testCaseSteps "full gc" $ testFullGc rdb
+
+        , testCase "small" $ pruneTestSmall rdb
+
+        , testCase "one pivot" $ pruneTestWithOnePivot rdb
+
+        , testCase "lots of pivots" $ pruneTestWithLotsOfPivots rdb
+
+        , testCase "many forks" $ pruneTestWithManyForks rdb
+
+        , testCase "many chains" $ pruneTestWithManyChains rdb
+        , testCase "many many chains" $ pruneTestWithManyManyChains rdb
+
+        ]
+
+-- pruneWithChecksTests :: IO RocksDb -> TestTree
+-- pruneWithChecksTests rio = testGroup "prune with checks" $ go <$>
+--     [ [CheckPayloads]
+--     , [CheckPayloadsExist]
+--     , [CheckIntrinsic]
+--     , [CheckInductive]
+--     , [CheckFull]
+--     , [minBound .. maxBound]
+--     ]
+--   where
+--     go checks = testCaseSteps (sshow checks) $ testPruneWithChecks rio checks
+
+-- failPruningChecksTests :: IO RocksDb -> TestTree
+-- failPruningChecksTests rio = testGroup "fail pruning checks"
+--     [ testCaseSteps "CheckIntrinsic" $ failIntrinsicCheck rio [CheckIntrinsic] 7
+--     , testCaseSteps "CheckInductive" $ failIntrinsicCheck rio [CheckInductive] 7
+--     , testCaseSteps "CheckFull" $ failIntrinsicCheck rio [CheckFull] 7
+--     ]
+
+singleForkTest
+    :: HasVersion
+    => RocksDb
+    -> Natural
+    -> Int
+    -> (String -> IO ())
+    -> IO ()
+singleForkTest rdb d expect step = runResourceT $ do
+    cdb <- withDbs rdb
+    liftIO $ do
+        let db = cdb ^?! cutDbBlockHeaderDb cid
+        let h = genesisBlockHeader cid
+        (f0, f1) <- createForks db h
+        let f0Cut = cutToCutHashes Nothing $ unsafeMkCut (HM.singleton cid (last f0))
+        addCutHashes cdb f0Cut
+        atomically $ do
+            curCut <- _cutStm cdb
+            guard (cutToCutHashes Nothing curCut == f0Cut)
+        initialCut <- _cut cdb
+        let wbhdb = view cutDbWebBlockHeaderDb cdb
+        n <- pruneForks logg initialCut wbhdb Prune d
+        assertHeaders db f0
+        when (expect > 0) $ assertPrunedHeaders db f1
+        assertEqual "" expect n
+  where
+    logg = genericLogger testLogLevel (step . T.unpack)
+
+assertHeaders :: HasVersion => BlockHeaderDb -> [BlockHeader] -> IO ()
+assertHeaders db f =
+    unlessM (fmap and $ mapM (tableMember db) $ view blockHash <$> f) $
+        assertFailure "missing block header that should not have been pruned"
+
+assertPrunedHeaders :: HasVersion => BlockHeaderDb -> [BlockHeader] -> IO ()
+assertPrunedHeaders db f =
+    forM_ f $ \bh -> do
+        whenM (tableMember db (casKey bh)) $
+            assertFailure $ "failed to prune some block header: " <> T.unpack (brief bh)
+
+-- -------------------------------------------------------------------------- --
+-- Header Pruning Tests
+
+failTest :: RocksDb -> Natural -> (String -> IO ()) -> IO ()
+failTest rio n step = withVersion (barebonesTestVersion singletonChainGraph) $ runResourceT $ do
+    cdb <- withDbs rio
+    liftIO $ do
+        let db = cdb ^?! cutDbBlockHeaderDb cid
+        let h = genesisBlockHeader cid
+        (f0, _) <- createForks db h
+        delHdr db $ f0 !! (int n)
+        initialCut <- _cut cdb
+        let wbhdb = view cutDbWebBlockHeaderDb cdb
+        try (pruneForks logg initialCut wbhdb Prune 2) >>= \case
+            Left (InternalInvariantViolation{}) -> return ()
+            Right x -> assertFailure
+                $ "missing expected InternalInvariantViolation"
+                <> ". Instead pruning succeeded and deleted "
+                <> sshow x <> " headers"
+        return ()
+  where
+    logg = genericLogger testLogLevel (step . T.unpack)
+
+-- -------------------------------------------------------------------------- --
+-- GC Tests
+
+testFullGc :: RocksDb -> (String -> IO ()) -> IO ()
+testFullGc rdb step = withVersion (barebonesTestVersion singletonChainGraph) $ runResourceT $ do
+    cdb <- withDbs rdb
+    let db = cdb ^?! cutDbBlockHeaderDb cid
+    let h = genesisBlockHeader cid
+    liftIO $ do
+        (f0, f1) <- createForks db h
+        -- fullGc logger rdb (barebonesTestVersion singletonChainGraph)
+        assertHeaders db f0
+        assertPrunedHeaders db f1
+  where
+    logger = genericLogger testLogLevel (step . T.unpack)
+
+testPruneWithChecks :: RocksDb -> (String -> IO ()) -> IO ()
+testPruneWithChecks rdb step = withVersion (barebonesTestVersion singletonChainGraph) $ runResourceT $ do
+    cdb <- withDbs rdb
+    let db = cdb ^?! cutDbBlockHeaderDb cid
+    let h = genesisBlockHeader cid
+    liftIO $ do
+        (f0, f1) <- createForks db h
+        -- pruneAllChains logger rdb (barebonesTestVersion singletonChainGraph)
+        assertHeaders db f0
+        assertPrunedHeaders db f1
+  where
+    logger = genericLogger testLogLevel (step . T.unpack)

--- a/test/unit/Chainweb/Test/CutDB.hs
+++ b/test/unit/Chainweb/Test/CutDB.hs
@@ -402,7 +402,7 @@ randomBlockHeader
     -> IO BlockHeader
 randomBlockHeader cutDb = do
     curCut <- _cut cutDb
-    allBlockHeaders <- webEntries (view cutDbWebBlockHeaderDb cutDb) $ \s -> s
+    allBlockHeaders <- webEntries (view cutDbWebBlockHeaderDb cutDb) Nothing Nothing $ \s -> s
         & S.filter (checkHeight curCut)
         & S.toList_
     generate $ elements allBlockHeaders

--- a/test/unit/Chainweb/Test/TreeDB.hs
+++ b/test/unit/Chainweb/Test/TreeDB.hs
@@ -321,7 +321,7 @@ prop_forkEntry f i j = do
         e <- forkEntry db (head $ reverse (g : a)) (head $ reverse $ (g : b))
         return $ e === g
   where
-    g = view (from isoBH) $ toyGenesis toyChainId
+    g = view (from isoBH) $ genesisBlockHeader toyChainId
     t = Node g []
     a = take (int i) $ branch (Nonce 0) g
     b = take (int j) $ branch (Nonce 1) g

--- a/test/unit/ChainwebTests.hs
+++ b/test/unit/ChainwebTests.hs
@@ -24,6 +24,7 @@ import Chainweb.Storage.Table.RocksDB
 import Chainweb.Test.BlockHeader.Genesis qualified (tests)
 import Chainweb.Test.BlockHeader.Validation qualified (tests)
 import Chainweb.Test.BlockHeaderDB qualified (tests)
+import Chainweb.Test.BlockHeaderDB.PruneForks qualified (tests)
 import Chainweb.Test.Chainweb.Utils.Paging qualified (properties)
 import Chainweb.Test.Cut qualified (properties)
 import Chainweb.Test.CutDB qualified (tests)
@@ -96,7 +97,7 @@ suite rdb =
         , testGroup "BlockHeaderDb"
             [ Chainweb.Test.BlockHeaderDB.tests rdb
             , Chainweb.Test.TreeDB.RemoteDB.tests
-            -- , Chainweb.Test.BlockHeaderDB.PruneForks.tests
+            , Chainweb.Test.BlockHeaderDB.PruneForks.tests rdb
             , testProperties "Chainweb.Test.TreeDB" Chainweb.Test.TreeDB.properties
             ]
         , Chainweb.Test.CutDB.tests rdb


### PR DESCRIPTION
Updates the existing pruning algorithm to operate on multiple chains in lockstep to avoid dangling references and to be possible to interrupt and later resume, as well as run periodically and incrementally.