### PR TITLE
Use BlockHistory if ConsensusState table is empty

### DIFF
--- a/src/Chainweb/Pact/Backend/ChainwebPactDb.hs
+++ b/src/Chainweb/Pact/Backend/ChainwebPactDb.hs
@@ -934,7 +934,7 @@ getLatestBlock db = do
             , _syncStateHeight = int hgt
             }
     go r = fail $
-        "Chainweb.Pact.Backend.RelationalCheckpointer.doGetLatest: impossible. This is a bug in chainweb-node. Details: "
+        "Chainweb.Pact.Backend.ChainwebPactDb.getLatestBlock: impossible. This is a bug in chainweb-node. Details: "
         <> sshow r
 
 lookupBlockWithHeight :: HasCallStack => SQ3.Database -> BlockHeight -> ExceptT LocatedSQ3Error IO (Maybe (Ranked BlockHash))


### PR DESCRIPTION
Otherwise, existing pact databases will trigger rewinds to genesis, because they will see no current ConsensusState rows.

